### PR TITLE
feat: expand environment enum with qa and uat values

### DIFF
--- a/api/infra.virtrigaud.io/v1beta1/vmclone_types.go
+++ b/api/infra.virtrigaud.io/v1beta1/vmclone_types.go
@@ -469,7 +469,7 @@ type CloneMetadata struct {
 
 	// Environment specifies the environment
 	// +optional
-	// +kubebuilder:validation:Enum=dev;staging;prod;test
+	// +kubebuilder:validation:Enum=dev;staging;prod;test;qa;uat
 	Environment string `json:"environment,omitempty"`
 
 	// Tags are key-value pairs for categorizing the clone

--- a/api/infra.virtrigaud.io/v1beta1/vmmigration_types.go
+++ b/api/infra.virtrigaud.io/v1beta1/vmmigration_types.go
@@ -268,7 +268,7 @@ type MigrationMetadata struct {
 
 	// Environment specifies the environment
 	// +optional
-	// +kubebuilder:validation:Enum=dev;staging;prod;test
+	// +kubebuilder:validation:Enum=dev;staging;prod;test;qa;uat
 	Environment string `json:"environment,omitempty"`
 
 	// Tags are key-value pairs for categorizing the migration

--- a/api/infra.virtrigaud.io/v1beta1/vmsnapshot_types.go
+++ b/api/infra.virtrigaud.io/v1beta1/vmsnapshot_types.go
@@ -211,7 +211,7 @@ type SnapshotMetadata struct {
 
 	// Environment specifies the environment
 	// +optional
-	// +kubebuilder:validation:Enum=dev;staging;prod;test
+	// +kubebuilder:validation:Enum=dev;staging;prod;test;qa;uat
 	Environment string `json:"environment,omitempty"`
 }
 

--- a/config/crd/bases/infra.virtrigaud.io_vmclones.yaml
+++ b/config/crd/bases/infra.virtrigaud.io_vmclones.yaml
@@ -363,6 +363,8 @@ spec:
                     - staging
                     - prod
                     - test
+                    - qa
+                    - uat
                     type: string
                   project:
                     description: Project identifies the project this clone belongs

--- a/config/crd/bases/infra.virtrigaud.io_vmmigrations.yaml
+++ b/config/crd/bases/infra.virtrigaud.io_vmmigrations.yaml
@@ -71,6 +71,8 @@ spec:
                     - staging
                     - prod
                     - test
+                    - qa
+                    - uat
                     type: string
                   project:
                     description: Project identifies the project this migration belongs

--- a/config/crd/bases/infra.virtrigaud.io_vmsnapshots.yaml
+++ b/config/crd/bases/infra.virtrigaud.io_vmsnapshots.yaml
@@ -75,6 +75,8 @@ spec:
                     - staging
                     - prod
                     - test
+                    - qa
+                    - uat
                     type: string
                   pinned:
                     default: false


### PR DESCRIPTION
Adds 'qa' and 'uat' to the Environment enum across all resource types that include NetworkMetadata: VMClone, VMMigration, VMSnapshot. Updates the corresponding CRD validation schema.

Closes #56