### PR TITLE
fix(obs): register custom metrics on controller-runtime registry

### DIFF
--- a/internal/obs/metrics/metrics.go
+++ b/internal/obs/metrics/metrics.go
@@ -22,12 +22,15 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+// promautoFactory registers metrics on the same registry the manager exposes (/metrics).
+var promautoFactory = promauto.With(ctrlmetrics.Registry)
 
 var (
 	// Build information
-	buildInfo = promauto.NewGaugeVec(
+	buildInfo = promautoFactory.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "virtrigaud_build_info",
 			Help: "Build information for virtrigaud components",
@@ -36,7 +39,7 @@ var (
 	)
 
 	// Manager metrics
-	managerReconcileTotal = promauto.NewCounterVec(
+	managerReconcileTotal = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_manager_reconcile_total",
 			Help: "Total number of reconcile operations by kind and outcome",
@@ -44,7 +47,7 @@ var (
 		[]string{"kind", "outcome"},
 	)
 
-	managerReconcileDuration = promauto.NewHistogramVec(
+	managerReconcileDuration = promautoFactory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "virtrigaud_manager_reconcile_duration_seconds",
 			Help:    "Duration of reconcile operations by kind",
@@ -53,7 +56,7 @@ var (
 		[]string{"kind"},
 	)
 
-	queueDepth = promauto.NewGaugeVec(
+	queueDepth = promautoFactory.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "virtrigaud_queue_depth",
 			Help: "Current depth of work queue by kind",
@@ -62,7 +65,7 @@ var (
 	)
 
 	// VM operation metrics
-	vmOperationsTotal = promauto.NewCounterVec(
+	vmOperationsTotal = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_vm_operations_total",
 			Help: "Total number of VM operations by operation, provider type, provider, and outcome",
@@ -71,7 +74,7 @@ var (
 	)
 
 	// Provider RPC metrics
-	providerRPCRequestsTotal = promauto.NewCounterVec(
+	providerRPCRequestsTotal = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_provider_rpc_requests_total",
 			Help: "Total number of provider RPC requests by provider type, method, and code",
@@ -79,7 +82,7 @@ var (
 		[]string{"provider_type", "method", "code"},
 	)
 
-	providerRPCLatency = promauto.NewHistogramVec(
+	providerRPCLatency = promautoFactory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "virtrigaud_provider_rpc_latency_seconds",
 			Help:    "Latency of provider RPC requests by provider type and method",
@@ -89,7 +92,7 @@ var (
 	)
 
 	// Provider task metrics
-	providerTasksInflight = promauto.NewGaugeVec(
+	providerTasksInflight = promautoFactory.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "virtrigaud_provider_tasks_inflight",
 			Help: "Number of inflight tasks by provider type and provider",
@@ -98,7 +101,7 @@ var (
 	)
 
 	// Error metrics
-	errorsTotal = promauto.NewCounterVec(
+	errorsTotal = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_errors_total",
 			Help: "Total number of errors by reason and component",
@@ -107,7 +110,7 @@ var (
 	)
 
 	// IP discovery metrics
-	ipDiscoveryDuration = promauto.NewHistogramVec(
+	ipDiscoveryDuration = promautoFactory.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "virtrigaud_ip_discovery_duration_seconds",
 			Help:    "Duration of IP discovery operations by provider type",
@@ -117,7 +120,7 @@ var (
 	)
 
 	// Circuit breaker metrics
-	circuitBreakerState = promauto.NewGaugeVec(
+	circuitBreakerState = promautoFactory.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "virtrigaud_circuit_breaker_state",
 			Help: "Circuit breaker state (0=closed, 1=half-open, 2=open)",
@@ -125,7 +128,7 @@ var (
 		[]string{"provider_type", "provider"},
 	)
 
-	circuitBreakerFailures = promauto.NewCounterVec(
+	circuitBreakerFailures = promautoFactory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_circuit_breaker_failures_total",
 			Help: "Total number of circuit breaker failures",
@@ -340,5 +343,5 @@ func Init() {
 
 // GetRegistry returns the Prometheus registry used by controller-runtime
 func GetRegistry() prometheus.Gatherer {
-	return metrics.Registry
+	return ctrlmetrics.Registry
 }

--- a/internal/obs/metrics/metrics_test.go
+++ b/internal/obs/metrics/metrics_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// expectedMetricNames lists every virtrigaud_* metric that must be registered
+// on the controller-runtime registry so that the manager's /metrics endpoint
+// exposes them. Keep this in sync with the package-level metric declarations.
+var expectedMetricNames = []string{
+	"virtrigaud_build_info",
+	"virtrigaud_manager_reconcile_total",
+	"virtrigaud_manager_reconcile_duration_seconds",
+	"virtrigaud_queue_depth",
+	"virtrigaud_vm_operations_total",
+	"virtrigaud_provider_rpc_requests_total",
+	"virtrigaud_provider_rpc_latency_seconds",
+	"virtrigaud_provider_tasks_inflight",
+	"virtrigaud_errors_total",
+	"virtrigaud_ip_discovery_duration_seconds",
+	"virtrigaud_circuit_breaker_state",
+	"virtrigaud_circuit_breaker_failures_total",
+}
+
+// TestMetricsRegisteredOnControllerRuntimeRegistry asserts every virtrigaud_*
+// metric ends up on the controller-runtime registry (the one served by the
+// manager at /metrics). Regression guard for metrics being registered on
+// promauto's default global registry, which is invisible to the manager.
+func TestMetricsRegisteredOnControllerRuntimeRegistry(t *testing.T) {
+	// Force vmOperationsTotal-style metrics to materialize at least one series
+	// so prometheus.Registry.Gather() reports them. Counter/Gauge/Histogram
+	// vectors only appear in Gather output after at least one labeled child
+	// has been instantiated.
+	buildInfo.WithLabelValues("test", "test", "test", "test").Set(1)
+	managerReconcileTotal.WithLabelValues("VirtualMachine", "success").Inc()
+	managerReconcileDuration.WithLabelValues("VirtualMachine").Observe(0)
+	queueDepth.WithLabelValues("VirtualMachine").Set(0)
+	vmOperationsTotal.WithLabelValues("Create", "vsphere", "test", "success").Inc()
+	providerRPCRequestsTotal.WithLabelValues("vsphere", "Create", "OK").Inc()
+	providerRPCLatency.WithLabelValues("vsphere", "Create").Observe(0)
+	providerTasksInflight.WithLabelValues("vsphere", "test").Set(0)
+	errorsTotal.WithLabelValues("Transient", "manager").Inc()
+	ipDiscoveryDuration.WithLabelValues("vsphere").Observe(0)
+	circuitBreakerState.WithLabelValues("vsphere", "test").Set(0)
+	circuitBreakerFailures.WithLabelValues("vsphere", "test").Inc()
+
+	mfs, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("ctrlmetrics.Registry.Gather() returned error: %v", err)
+	}
+
+	gathered := make(map[string]struct{}, len(mfs))
+	for _, mf := range mfs {
+		gathered[mf.GetName()] = struct{}{}
+	}
+
+	for _, name := range expectedMetricNames {
+		if _, ok := gathered[name]; !ok {
+			t.Errorf("metric %q was not gathered from controller-runtime registry; "+
+				"manager /metrics will not expose it", name)
+		}
+	}
+}
+
+// TestGetRegistryReturnsControllerRuntimeRegistry confirms GetRegistry() and
+// the package-level promautoFactory both point at sigs.k8s.io/controller-runtime
+// metrics.Registry rather than prometheus' default global registry.
+func TestGetRegistryReturnsControllerRuntimeRegistry(t *testing.T) {
+	if GetRegistry() != ctrlmetrics.Registry {
+		t.Fatalf("GetRegistry() = %p, want controller-runtime metrics.Registry %p",
+			GetRegistry(), ctrlmetrics.Registry)
+	}
+}


### PR DESCRIPTION
## Summary

- All `virtrigaud_*` metrics were registered with `promauto`'s default global registry, but the controller-runtime manager serves `/metrics` from `sigs.k8s.io/controller-runtime/pkg/metrics.Registry`. As a result, **none of the `virtrigaud_*` metrics actually appeared on the manager's `/metrics` endpoint**, breaking observability dashboards and alerts.
- Introduce a package-level `promautoFactory = promauto.With(ctrlmetrics.Registry)` and route every metric declaration through it.
- Add `internal/obs/metrics/metrics_test.go` asserting every declared `virtrigaud_*` metric is gathered from `ctrlmetrics.Registry`, plus that `GetRegistry()` returns the same registry.

## Test plan

- [x] `go test ./internal/obs/metrics/`
- [x] `go build ./... && go vet ./...`
- [ ] In-cluster smoke: `kubectl port-forward` the manager metrics service and confirm `virtrigaud_build_info`, `virtrigaud_manager_reconcile_total`, etc. appear in `/metrics`.


Made with [Cursor](https://cursor.com)