### PR TITLE
fix(resilience): non-retryable CircuitOpen error + correct half-open accounting

### DIFF
--- a/internal/providers/contracts/errors.go
+++ b/internal/providers/contracts/errors.go
@@ -44,6 +44,8 @@ const (
 	ErrorTypeQuotaExceeded ErrorType = "QuotaExceeded"
 	// ErrorTypeConflict indicates resource conflict
 	ErrorTypeConflict ErrorType = "Conflict"
+	// ErrorTypeCircuitOpen indicates the circuit breaker is open (not retryable)
+	ErrorTypeCircuitOpen ErrorType = "CircuitOpen"
 )
 
 // ProviderError represents a categorized error from a provider
@@ -144,6 +146,15 @@ func NewUnavailableError(message string, cause error) *ProviderError {
 		Message:   message,
 		Cause:     cause,
 		Retryable: true,
+	}
+}
+
+// NewCircuitBreakerOpenError indicates the circuit breaker is open; callers should not retry.
+func NewCircuitBreakerOpenError(message string) *ProviderError {
+	return &ProviderError{
+		Type:      ErrorTypeCircuitOpen,
+		Message:   message,
+		Retryable: false,
 	}
 }
 

--- a/internal/resilience/circuitbreaker.go
+++ b/internal/resilience/circuitbreaker.go
@@ -103,9 +103,8 @@ func NewCircuitBreaker(name, providerType, provider string, config *Config) *Cir
 func (cb *CircuitBreaker) Call(ctx context.Context, fn func(ctx context.Context) error) error {
 	// Check if we should allow the call
 	if !cb.allowCall() {
-		return contracts.NewUnavailableError(
+		return contracts.NewCircuitBreakerOpenError(
 			fmt.Sprintf("circuit breaker %s is open", cb.name),
-			nil,
 		)
 	}
 
@@ -130,7 +129,11 @@ func (cb *CircuitBreaker) allowCall() bool {
 		// Check if we should transition to half-open
 		if time.Since(cb.lastFailureTime) > cb.config.ResetTimeout {
 			cb.transitionToHalfOpen()
-			return true
+			// Count the first half-open probe (same as StateHalfOpen branch below)
+			if cb.halfOpenCalls < cb.config.HalfOpenMaxCalls {
+				cb.halfOpenCalls++
+				return true
+			}
 		}
 		return false
 	case StateHalfOpen:

--- a/internal/resilience/circuitbreaker_test.go
+++ b/internal/resilience/circuitbreaker_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resilience
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+)
+
+func newTestBreaker(failureThreshold, halfOpenMaxCalls int, resetTimeout time.Duration) *CircuitBreaker {
+	return NewCircuitBreaker("t", "test", "test", &Config{
+		FailureThreshold: failureThreshold,
+		ResetTimeout:     resetTimeout,
+		HalfOpenMaxCalls: halfOpenMaxCalls,
+	})
+}
+
+func failingFn(context.Context) error { return errors.New("boom") }
+func successFn(context.Context) error { return nil }
+
+// TestOpensAfterFailureThreshold confirms the basic happy-path transition
+// Closed -> Open after FailureThreshold consecutive failures.
+func TestOpensAfterFailureThreshold(t *testing.T) {
+	cb := newTestBreaker(2, 2, time.Hour)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		_ = cb.Call(ctx, failingFn)
+	}
+
+	if got := cb.GetState(); got != StateOpen {
+		t.Fatalf("after %d failures: state = %s, want %s", 2, got, StateOpen)
+	}
+}
+
+// TestOpenCallReturnsCircuitOpenError is the regression test for the contract
+// of the error returned when the circuit is open:
+//   - Type must be contracts.ErrorTypeCircuitOpen (not Unavailable)
+//   - Retryable must be false
+//   - IsRetryable() must return false
+//
+// Previously the breaker returned NewUnavailableError, which marks the error
+// Retryable=true and is also classified retryable by ProviderError.IsRetryable
+// via the Type==Unavailable branch — i.e. callers would retry on an open
+// circuit, defeating the purpose of the breaker.
+func TestOpenCallReturnsCircuitOpenError(t *testing.T) {
+	cb := newTestBreaker(1, 2, time.Hour)
+	ctx := context.Background()
+
+	_ = cb.Call(ctx, failingFn)
+	if got := cb.GetState(); got != StateOpen {
+		t.Fatalf("setup: state = %s, want %s", got, StateOpen)
+	}
+
+	err := cb.Call(ctx, successFn)
+	if err == nil {
+		t.Fatal("Call on open breaker returned nil error")
+	}
+
+	var pe *contracts.ProviderError
+	if !errors.As(err, &pe) {
+		t.Fatalf("error %v (%T) is not a *contracts.ProviderError", err, err)
+	}
+	if pe.Type != contracts.ErrorTypeCircuitOpen {
+		t.Errorf("error Type = %q, want %q", pe.Type, contracts.ErrorTypeCircuitOpen)
+	}
+	if pe.Retryable {
+		t.Errorf("error Retryable = true, want false (open circuit must not be retried)")
+	}
+	if pe.IsRetryable() {
+		t.Errorf("IsRetryable() = true, want false (open circuit must not be retried)")
+	}
+}
+
+// TestHalfOpenFirstProbeCountsAgainstBudget is the regression test for the
+// bug where the first probe after the Open -> HalfOpen transition bypassed
+// the HalfOpenMaxCalls accounting. With HalfOpenMaxCalls=2 and 2 successful
+// probes, the fix transitions back to Closed; the buggy version required a
+// third probe before closing.
+func TestHalfOpenFirstProbeCountsAgainstBudget(t *testing.T) {
+	const resetTimeout = 5 * time.Millisecond
+	cb := newTestBreaker(2, 2, resetTimeout)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		_ = cb.Call(ctx, failingFn)
+	}
+	if got := cb.GetState(); got != StateOpen {
+		t.Fatalf("setup: state = %s, want %s", got, StateOpen)
+	}
+
+	time.Sleep(resetTimeout + 5*time.Millisecond)
+
+	if err := cb.Call(ctx, successFn); err != nil {
+		t.Fatalf("probe 1: unexpected error %v", err)
+	}
+	if got := cb.GetState(); got != StateHalfOpen {
+		t.Errorf("after probe 1: state = %s, want %s", got, StateHalfOpen)
+	}
+
+	if err := cb.Call(ctx, successFn); err != nil {
+		t.Fatalf("probe 2: unexpected error %v", err)
+	}
+
+	if got := cb.GetState(); got != StateClosed {
+		t.Errorf("after probe 2: state = %s, want %s (fix should have closed the "+
+			"breaker; the buggy version stays HalfOpen because the first probe "+
+			"did not count against HalfOpenMaxCalls)", got, StateClosed)
+	}
+}
+
+// TestHalfOpenFailureReopens ensures any failure observed during half-open
+// probing puts the breaker back into Open state immediately.
+func TestHalfOpenFailureReopens(t *testing.T) {
+	const resetTimeout = 5 * time.Millisecond
+	cb := newTestBreaker(1, 3, resetTimeout)
+	ctx := context.Background()
+
+	_ = cb.Call(ctx, failingFn)
+	time.Sleep(resetTimeout + 5*time.Millisecond)
+
+	if err := cb.Call(ctx, failingFn); err == nil {
+		t.Fatal("probe expected to surface inner error, got nil")
+	}
+
+	if got := cb.GetState(); got != StateOpen {
+		t.Errorf("after failing probe: state = %s, want %s", got, StateOpen)
+	}
+}
+
+// TestReset returns the breaker to Closed regardless of the prior state.
+func TestReset(t *testing.T) {
+	cb := newTestBreaker(1, 2, time.Hour)
+	_ = cb.Call(context.Background(), failingFn)
+
+	if got := cb.GetState(); got != StateOpen {
+		t.Fatalf("setup: state = %s, want %s", got, StateOpen)
+	}
+
+	cb.Reset()
+	if got := cb.GetState(); got != StateClosed {
+		t.Errorf("after Reset: state = %s, want %s", got, StateClosed)
+	}
+	if f := cb.GetFailures(); f != 0 {
+		t.Errorf("after Reset: failures = %d, want 0", f)
+	}
+}


### PR DESCRIPTION
## Summary

Two coupled circuit-breaker correctness fixes.

### 1. Distinct, non-retryable open-circuit error

The breaker previously returned `NewUnavailableError` when refusing a call, which is classified retryable by `ProviderError.IsRetryable` (both via `Retryable=true` and the `Type == Unavailable` branch). Callers that honored `IsRetryable()` would therefore **retry on an open circuit, defeating the purpose of the breaker**.

Introduce `ErrorTypeCircuitOpen` and `NewCircuitBreakerOpenError(...)` with `Retryable=false`, and have `CircuitBreaker.Call` return it.

### 2. Count the first half-open probe against `HalfOpenMaxCalls`

The `Open -> HalfOpen` transition in `allowCall()` returned `true` without incrementing `halfOpenCalls`, so the first probe after `ResetTimeout` slipped through the budget. With `HalfOpenMaxCalls=N` the breaker effectively allowed `N+1` probes and would not transition back to Closed until the `(N+1)`th success, since `recordSuccess(HalfOpen)` only closes when `halfOpenCalls >= HalfOpenMaxCalls`.

Mirror the `StateHalfOpen` branch: increment `halfOpenCalls` when admitting the first probe.

### Tests

Add `internal/resilience/circuitbreaker_test.go` covering:
- Closed → Open after `FailureThreshold` consecutive failures.
- Open call returns `ErrorTypeCircuitOpen`, `Retryable=false`, `IsRetryable()=false` (regression for #1).
- HalfOpen first-probe budget regression — with `HalfOpenMaxCalls=2` and 2 successful probes the breaker transitions back to Closed; the buggy code stayed HalfOpen (regression for #2).
- Any failure during HalfOpen probing reopens the breaker.
- `Reset()` returns the breaker to Closed.

## Test plan

- [x] `go test ./internal/resilience/ ./internal/providers/contracts/`
- [x] `go vet ./...`


Made with [Cursor](https://cursor.com)