### PR TITLE
chore(test): gate e2e suite behind //go:build e2e

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2025.
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2025.
 


### PR DESCRIPTION
## Summary

- Add `//go:build e2e` build tags to the e2e test files so they are excluded from default `go test ./...` and `go vet ./...` runs.
- The e2e suite needs a running cluster and provider credentials, which makes it unsuitable for fast local feedback loops and standard CI lint/test jobs.

Run the suite explicitly with:

```bash
go test -tags=e2e ./test/e2e/...
```

## Test plan

- [x] `go vet ./test/e2e/...` reports "no packages to vet" (suite correctly excluded)
- [x] `go vet -tags=e2e ./test/e2e/...` vets cleanly
- [x] `go build ./...` still works


Made with [Cursor](https://cursor.com)