### PR TITLE
fix(docker): upgrade packages in provider-vsphere runtime image

### DIFF
--- a/cmd/provider-vsphere/Dockerfile
+++ b/cmd/provider-vsphere/Dockerfile
@@ -47,10 +47,13 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
 # Runtime stage - use Debian slim for qemu-img support
 FROM ${BASE_IMAGE} as runtime
 
-# Install qemu-img and CA certificates
+# Install qemu-img and CA certificates, then upgrade any installed packages
+# to pick up security fixes that may not yet be baked into the base image
+# layer (matches the pattern used in cmd/provider-libvirt/Dockerfile).
 RUN apt-get update && apt-get install -y \
     qemu-utils \
     ca-certificates \
+    && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/* \
     && echo "DEBIAN BUILD SUCCESS - QEMU-IMG AVAILABLE" \
     && which qemu-img \


### PR DESCRIPTION
## Summary

The Release workflow [run #220](https://github.com/projectbeskar/virtrigaud/actions/runs/26215630955/job/77137455577) (`v0.3.1-rc10`) failed the `Security Scan Images (provider-vsphere)` Trivy job with **6 vulnerabilities** (2 CRITICAL, 4 HIGH) in `libgnutls30 3.7.9-2+deb12u6`, all with the same available fix in `3.7.9-2+deb12u7`:

| CVE | Severity | Title |
|---|---|---|
| CVE-2026-33845 | CRITICAL | GnuTLS DoS via DTLS zero-length record |
| CVE-2026-42010 | CRITICAL | GnuTLS auth bypass via NUL in name constraints |
| CVE-2026-33846 | HIGH | GnuTLS DoS via heap buffer overflow |
| CVE-2026-3833  | HIGH | GnuTLS policy bypass (case-sensitive matching) |
| CVE-2026-42009 | HIGH | GnuTLS DoS via DTLS packet reordering |
| CVE-2026-42011 | HIGH | GnuTLS bypass via incorrect name handling |

`libgnutls30` is pulled in transitively when `qemu-utils` is installed on top of `debian:bookworm-slim`. The vsphere runtime stage ran `apt-get install` and immediately purged the apt lists **without upgrading the resulting package set**, leaving `libgnutls30` at the older version baked into the base layer.

This PR adds `apt-get upgrade -y` to the same `RUN`, matching the existing pattern in `cmd/provider-libvirt/Dockerfile` — which is why `provider-libvirt` doesn't exhibit this class of failure.

```diff
-# Install qemu-img and CA certificates
+# Install qemu-img and CA certificates, then upgrade any installed packages
+# to pick up security fixes that may not yet be baked into the base image
+# layer (matches the pattern used in cmd/provider-libvirt/Dockerfile).
 RUN apt-get update && apt-get install -y \
     qemu-utils \
     ca-certificates \
+    && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/* \
     ...
```

## Audit of other release-matrix Dockerfiles

| Component | Image | Status |
|---|---|---|
| `manager` (`build/Dockerfile.manager`) | distroless/static | safe (no apt) |
| `provider-libvirt` (`cmd/provider-libvirt/Dockerfile`) | debian:bookworm-slim **+ apt-get upgrade -y** | safe |
| `provider-vsphere` (`cmd/provider-vsphere/Dockerfile`) | debian:bookworm-slim, no upgrade | **fixed here** |
| `provider-proxmox` (`cmd/provider-proxmox/Dockerfile`) | distroless/static | safe |
| `kubectl` (`build/Dockerfile.kubectl`) | alpine:3.20, no `apk upgrade` | currently passes Trivy; defensive hardening intentionally out of scope here |

The unused legacy Dockerfiles (`build/Dockerfile.provider-vsphere` distroless, `build/Dockerfile.provider-libvirt` alpine:3.18) are not exercised by the release workflow and are not touched in this PR — they're candidates for a separate cleanup discussion.

## Test plan

- [ ] Re-cut `v0.3.1-rcNN` after merging and verify `Security Scan Images (provider-vsphere)` is green
- [ ] Local: `docker buildx build -f cmd/provider-vsphere/Dockerfile -t test-vsphere .` then `trivy image --severity HIGH,CRITICAL --ignore-unfixed test-vsphere` returns no findings

## Notes

- Image-only fix, no Go code changes.
- The CVEs are recent (dated 2026) — the Trivy DB was updated with them in the last few days, which is why this is suddenly failing now rather than on previous RCs.
- Once the upstream `debian:bookworm-slim` layer is rebuilt to include `+deb12u7`, this image's `apt-get upgrade -y` will be a no-op; until then it's what keeps the image clean.

Made with [Cursor](https://cursor.com)