### PR TITLE
fix(obs/metrics): expose virtrigaud_* metrics on /metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-22 06:38] - Fix virtrigaud_* metrics not exposed on /metrics endpoint
+**Author:** @williamrizzo (William Rizzo)
+
+### Fixed
+- `internal/obs/metrics/metrics.go`: Bind all 12 virtrigaud Prometheus metric vectors to controller-runtime's `metrics.Registry` (the registry served by the manager on `/metrics`) instead of promauto's default global registry. Previously the metrics were created in-process but never exposed because the manager's `/metrics` endpoint serves controller-runtime's registry, not promauto's default. Use `promauto.With(ctrlmetrics.Registry).New*` for: `virtrigaud_build_info`, `virtrigaud_manager_reconcile_total`, `virtrigaud_manager_reconcile_duration_seconds`, `virtrigaud_queue_depth`, `virtrigaud_vm_operations_total`, `virtrigaud_provider_rpc_requests_total`, `virtrigaud_provider_rpc_latency_seconds`, `virtrigaud_provider_tasks_inflight`, `virtrigaud_errors_total`, `virtrigaud_ip_discovery_duration_seconds`, `virtrigaud_circuit_breaker_state`, `virtrigaud_circuit_breaker_failures_total`.
+
+### Removed
+- `internal/obs/metrics/metrics.go`: Removed dead `Init()` function which had a misleading comment claiming promauto registered metrics with the controller-runtime registry; it had zero callers anywhere in the codebase.
+
+### Added
+- `internal/obs/metrics/metrics_test.go`: New unit tests `TestMetricsRegisteredInControllerRuntimeRegistry` and `TestSetupMetricsEmitsBuildInfo` asserting all 12 metric families appear in `GetRegistry().Gather()` after one observation each, and that `virtrigaud_build_info` carries the correct label values. These run under `make test` and serve as a regression canary.
+- `test/integration/observability_test.go`: Added missing `metrics.SetupMetrics(...)` call at the top of `TestMetricsIntegration` so the test is self-contained rather than relying on side effects from other tests. The integration test now passes when run directly (`go test ./test/integration/...`), though `make test` continues to exclude that path.
+
+### Why
+v0.3.3-rc1 smoke test on `vr1.lab.k8` confirmed that scraping `/metrics:8080` returned 41 metric families — all controller-runtime/workqueue/certwatcher/go_/process_ — with zero `virtrigaud_*` series. Root cause: `promauto.NewGaugeVec(...)` etc. bind to `prometheus.DefaultRegisterer`, which the manager does not serve. The bug shipped in v0.3.0 through v0.3.2 (originally introduced in commit `a849271 implement observability extensions`) and would have shipped in v0.3.3 without this fix. Observability is load-bearing for the project's banking-compliance posture; releasing without exposed metrics is a regression on every downstream operator that relies on Prometheus scraping. This change blocks v0.3.3 release until merged (cut v0.3.3-rc2 from this commit).
+
+### Impact
+- [ ] Breaking change (no public API change; vector variables are unexported and callers use the helper structs)
+- [x] Requires cluster rollout (`virtrigaud_*` metrics begin appearing once the new manager image is deployed)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Verification
+After deploying the fix:
+```bash
+kubectl -n virtrigaud-system port-forward deploy/virtrigaud-controller-manager 8080:8080 &
+curl -s http://localhost:8080/metrics | grep -c '^virtrigaud_'
+# expect: 12 or more (one line per metric family + samples)
+curl -s http://localhost:8080/metrics | grep '^virtrigaud_build_info'
+# expect: virtrigaud_build_info{component="manager",git_sha="...",go_version="go...",version="v0.3.3-rc2"} 1
+```
+
+---
+
 ## [2026-03-17 22:10] - Add SCSI Controller Configuration for Additional Disks
 **Author:** @firestoned (Erick Bourgeois)
 

--- a/internal/obs/metrics/metrics.go
+++ b/internal/obs/metrics/metrics.go
@@ -22,12 +22,17 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+// All virtrigaud metrics register with controller-runtime's metrics.Registry, which is
+// the registry served by the manager's /metrics endpoint. Using promauto's default
+// (global) registry would create the metrics in-process but never expose them.
+var registerer = promauto.With(ctrlmetrics.Registry)
 
 var (
 	// Build information
-	buildInfo = promauto.NewGaugeVec(
+	buildInfo = registerer.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "virtrigaud_build_info",
 			Help: "Build information for virtrigaud components",
@@ -36,7 +41,7 @@ var (
 	)
 
 	// Manager metrics
-	managerReconcileTotal = promauto.NewCounterVec(
+	managerReconcileTotal = registerer.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_manager_reconcile_total",
 			Help: "Total number of reconcile operations by kind and outcome",
@@ -44,7 +49,7 @@ var (
 		[]string{"kind", "outcome"},
 	)
 
-	managerReconcileDuration = promauto.NewHistogramVec(
+	managerReconcileDuration = registerer.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "virtrigaud_manager_reconcile_duration_seconds",
 			Help:    "Duration of reconcile operations by kind",
@@ -53,7 +58,7 @@ var (
 		[]string{"kind"},
 	)
 
-	queueDepth = promauto.NewGaugeVec(
+	queueDepth = registerer.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "virtrigaud_queue_depth",
 			Help: "Current depth of work queue by kind",
@@ -62,7 +67,7 @@ var (
 	)
 
 	// VM operation metrics
-	vmOperationsTotal = promauto.NewCounterVec(
+	vmOperationsTotal = registerer.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_vm_operations_total",
 			Help: "Total number of VM operations by operation, provider type, provider, and outcome",
@@ -71,7 +76,7 @@ var (
 	)
 
 	// Provider RPC metrics
-	providerRPCRequestsTotal = promauto.NewCounterVec(
+	providerRPCRequestsTotal = registerer.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_provider_rpc_requests_total",
 			Help: "Total number of provider RPC requests by provider type, method, and code",
@@ -79,7 +84,7 @@ var (
 		[]string{"provider_type", "method", "code"},
 	)
 
-	providerRPCLatency = promauto.NewHistogramVec(
+	providerRPCLatency = registerer.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "virtrigaud_provider_rpc_latency_seconds",
 			Help:    "Latency of provider RPC requests by provider type and method",
@@ -89,7 +94,7 @@ var (
 	)
 
 	// Provider task metrics
-	providerTasksInflight = promauto.NewGaugeVec(
+	providerTasksInflight = registerer.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "virtrigaud_provider_tasks_inflight",
 			Help: "Number of inflight tasks by provider type and provider",
@@ -98,7 +103,7 @@ var (
 	)
 
 	// Error metrics
-	errorsTotal = promauto.NewCounterVec(
+	errorsTotal = registerer.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_errors_total",
 			Help: "Total number of errors by reason and component",
@@ -107,7 +112,7 @@ var (
 	)
 
 	// IP discovery metrics
-	ipDiscoveryDuration = promauto.NewHistogramVec(
+	ipDiscoveryDuration = registerer.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "virtrigaud_ip_discovery_duration_seconds",
 			Help:    "Duration of IP discovery operations by provider type",
@@ -117,7 +122,7 @@ var (
 	)
 
 	// Circuit breaker metrics
-	circuitBreakerState = promauto.NewGaugeVec(
+	circuitBreakerState = registerer.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "virtrigaud_circuit_breaker_state",
 			Help: "Circuit breaker state (0=closed, 1=half-open, 2=open)",
@@ -125,7 +130,7 @@ var (
 		[]string{"provider_type", "provider"},
 	)
 
-	circuitBreakerFailures = promauto.NewCounterVec(
+	circuitBreakerFailures = registerer.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "virtrigaud_circuit_breaker_failures_total",
 			Help: "Total number of circuit breaker failures",
@@ -332,13 +337,9 @@ func (rt *RPCTimer) Finish(code string) {
 	rt.metrics.RecordRPC(rt.method, code, rt.timer.Duration())
 }
 
-// Init registers all metrics with the controller-runtime metrics registry
-func Init() {
-	// Metrics are automatically registered via promauto
-	// This function is for any additional setup if needed
-}
-
-// GetRegistry returns the Prometheus registry used by controller-runtime
+// GetRegistry returns the Prometheus registry used by controller-runtime,
+// which is the registry served by the manager's /metrics endpoint and into
+// which all virtrigaud_* metrics are registered.
 func GetRegistry() prometheus.Gatherer {
-	return metrics.Registry
+	return ctrlmetrics.Registry
 }

--- a/internal/obs/metrics/metrics_test.go
+++ b/internal/obs/metrics/metrics_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gatheredNames returns the set of metric family names currently registered
+// in the registry returned by GetRegistry().
+func gatheredNames(t *testing.T) map[string]bool {
+	t.Helper()
+	families, err := GetRegistry().Gather()
+	require.NoError(t, err, "GetRegistry().Gather() should not error")
+	names := make(map[string]bool, len(families))
+	for _, f := range families {
+		names[f.GetName()] = true
+	}
+	return names
+}
+
+// TestMetricsRegisteredInControllerRuntimeRegistry verifies that every
+// virtrigaud_* metric is registered in controller-runtime's Registry (which is
+// the one served at /metrics) rather than promauto's default global registry.
+// This is the canary test for the regression where metrics were created but
+// never exposed.
+func TestMetricsRegisteredInControllerRuntimeRegistry(t *testing.T) {
+	// Touch buildInfo so the metric family appears in the registry's gather output.
+	// Metric vectors only emit a family entry once they have at least one observation.
+	SetupMetrics("test-version", "test-sha", "test-component")
+
+	// Exercise each metric vector with one observation so all 12 families appear.
+	NewReconcileMetrics("VirtualMachine").RecordReconcile(OutcomeSuccess, 5*time.Millisecond)
+	NewReconcileMetrics("VirtualMachine").SetQueueDepth(1)
+	NewVMOperationMetrics("test", "p1").RecordOperation(OpCreate, OutcomeSuccess)
+	NewProviderRPCMetrics("test").RecordRPC("Validate", "OK", 2*time.Millisecond)
+	NewTaskMetrics("test", "p1").SetInflightTasks(0)
+	RecordError("UnitTest", ComponentManager)
+	RecordIPDiscovery("test", 100*time.Millisecond)
+	cb := NewCircuitBreakerMetrics("test", "p1")
+	cb.SetState(CircuitBreakerClosed)
+	cb.RecordFailure()
+
+	names := gatheredNames(t)
+
+	expected := []string{
+		"virtrigaud_build_info",
+		"virtrigaud_manager_reconcile_total",
+		"virtrigaud_manager_reconcile_duration_seconds",
+		"virtrigaud_queue_depth",
+		"virtrigaud_vm_operations_total",
+		"virtrigaud_provider_rpc_requests_total",
+		"virtrigaud_provider_rpc_latency_seconds",
+		"virtrigaud_provider_tasks_inflight",
+		"virtrigaud_errors_total",
+		"virtrigaud_ip_discovery_duration_seconds",
+		"virtrigaud_circuit_breaker_state",
+		"virtrigaud_circuit_breaker_failures_total",
+	}
+
+	for _, name := range expected {
+		assert.True(t, names[name], "expected metric %q to be registered in controller-runtime's Registry; this is the v0.3.x metrics-not-exposed regression", name)
+	}
+}
+
+// TestSetupMetricsEmitsBuildInfo verifies SetupMetrics writes a build_info
+// sample with the expected labels. This is the canary for release smoke tests.
+func TestSetupMetricsEmitsBuildInfo(t *testing.T) {
+	SetupMetrics("v0.3.3-rc2", "abc1234", "manager")
+
+	families, err := GetRegistry().Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, f := range families {
+		if f.GetName() != "virtrigaud_build_info" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			labels := make(map[string]string, len(m.GetLabel()))
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["version"] == "v0.3.3-rc2" &&
+				labels["git_sha"] == "abc1234" &&
+				labels["component"] == "manager" {
+				found = true
+				assert.Equal(t, float64(1), m.GetGauge().GetValue(), "build_info gauge should be set to 1")
+			}
+		}
+	}
+	assert.True(t, found, "virtrigaud_build_info should have a sample with the labels passed to SetupMetrics")
+}

--- a/test/integration/observability_test.go
+++ b/test/integration/observability_test.go
@@ -63,6 +63,9 @@ func TestObservabilityIntegration(t *testing.T) {
 }
 
 func TestMetricsIntegration(t *testing.T) {
+	// Emit a build_info sample so the family appears in Gather() output.
+	metrics.SetupMetrics("test", "abc123", "test-component")
+
 	// Test reconcile metrics
 	reconcileMetrics := metrics.NewReconcileMetrics("VirtualMachine")
 


### PR DESCRIPTION
## Summary
- Rebind all 12 `virtrigaud_*` Prometheus metric vectors from promauto's default global registry to controller-runtime's `metrics.Registry`, which is the one actually served by the manager on `/metrics`.
- Add unit tests in `internal/obs/metrics/metrics_test.go` asserting the binding; package coverage goes from 0% to 75% under `make test`.
- Remove dead `Init()` function (misleading comment, zero callers).
- Fix `TestMetricsIntegration` to call `SetupMetrics()` so it is self-contained when run directly.

## Why this is a release blocker

Smoke test of `v0.3.3-rc1` on `vr1.lab.k8` confirmed `/metrics:8080` returned 41 metric families, all controller-runtime/workqueue/certwatcher/go_/process_, with **zero `virtrigaud_*` series**. Observability is load-bearing for the project's compliance posture; releasing without exposed metrics regresses every downstream operator that scrapes Prometheus.

The regression has shipped in v0.3.0, .1, and .2 already, originally introduced in `a849271 "implement observability extensions"`. The reason it slipped past CI: the existing `test/integration/observability_test.go::TestMetricsIntegration` does cover this, but `make test` explicitly excludes `/test/integration/`, so the failing assertion was never visible. A follow-up should wire that path into CI (or move the canary into `internal/obs/metrics/` as this PR does).

## Root cause
`promauto.NewGaugeVec(...)` binds to `prometheus.DefaultRegisterer`. The manager serves `sigs.k8s.io/controller-runtime/pkg/metrics.Registry`. So the metrics were created in-process but never exposed.

Fix: use a single `var registerer = promauto.With(ctrlmetrics.Registry)` at the top of the var block, then every `promauto.NewXxxVec(...)` becomes `registerer.NewXxxVec(...)`.

## Test plan
- [x] `go fmt` clean
- [x] `go vet` clean
- [x] `golangci-lint run ./internal/obs/metrics/... ./test/integration/...` → `0 issues`
- [x] `go build ./...` clean
- [x] `make test` PASS — `internal/obs/metrics` 0% → 75% coverage; no other package regresses
- [x] New `TestMetricsRegisteredInControllerRuntimeRegistry` asserts all 12 metric families appear in `GetRegistry().Gather()` after one observation each
- [x] New `TestSetupMetricsEmitsBuildInfo` asserts `virtrigaud_build_info{version,git_sha,go_version,component}` is exposed correctly
- [x] Existing `TestMetricsIntegration` (excluded from `make test`) now passes when run directly: `go test ./test/integration/...`
- [ ] **Reviewer**: cut `v0.3.3-rc2` from this commit and re-run cluster smoke against `vr1.lab.k8`; expect `curl /metrics | grep -c '^virtrigaud_'` ≥ 12 (vs. 0 today) and `virtrigaud_build_info{version="v0.3.3-rc2",...} 1`

## No public API change
All metric vector variables are unexported; callers use the helper structs (`NewReconcileMetrics`, `SetupMetrics`, `RecordError`, etc.) whose signatures are unchanged.

## Impact checklist
- [ ] Breaking change
- [x] Requires cluster rollout (new manager image needed for metrics to appear)
- [ ] Config change only
- [ ] Documentation only