### PR TITLE
fix(manager): emit virtrigaud_build_info on startup so /metrics is non-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-22 15:29] - Emit virtrigaud_build_info on manager startup
+**Author:** @williamrizzo (William Rizzo)
+
+### Fixed
+- `cmd/manager/main.go`: Call `metrics.SetupMetrics(version.Version, version.GitSHA, metrics.ComponentManager)` immediately after logger setup. Without this call the build_info `GaugeVec` from `internal/obs/metrics` stays empty after package init, and the `virtrigaud_build_info` family does NOT appear in the manager's `/metrics` output even with the PR #83 registry-binding fix correctly applied.
+
+### Why
+v0.3.3-rc2 deploy + smoke test on `vr1.lab.k8` exposed that PR #83 was a necessary-but-not-sufficient fix. The registry binding is structurally correct (verified by `internal/obs/metrics/metrics_test.go`) but Prometheus Vec metrics with zero observations do not appear in `/metrics` output. The only metric that wouldn't depend on reconcile activity is `virtrigaud_build_info`, which is populated by `SetupMetrics`. Nothing in production called `SetupMetrics`, so the family stayed empty and the smoke test continued to report `0 virtrigaud_* metric families` after upgrading to rc2 — same as rc1.
+
+This change makes the manager emit a `virtrigaud_build_info{version,git_sha,go_version,component}` sample on startup, providing the canary metric that release smoke tests can rely on, and serving as proof end-to-end that the registry binding works in production. Per-reconciler instrumentation (VirtualMachineReconciler, ProviderReconciler) for full operational visibility is deferred to v0.3.4.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager pod restart picks up the new SetupMetrics call)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Verification
+After deploying the fix:
+```bash
+curl -s http://<manager>:8080/metrics | grep '^virtrigaud_build_info'
+# expect: virtrigaud_build_info{component="manager",git_sha="<sha>",go_version="go1.25.x",version="v0.3.3-rc3"} 1
+```
+
+---
+
 ## [2026-05-22 06:38] - Fix virtrigaud_* metrics not exposed on /metrics endpoint
 **Author:** @williamrizzo (William Rizzo)
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -36,7 +36,9 @@ import (
 
 	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
 	"github.com/projectbeskar/virtrigaud/internal/controller"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 	"github.com/projectbeskar/virtrigaud/internal/runtime/remote"
+	"github.com/projectbeskar/virtrigaud/internal/version"
 )
 
 var (
@@ -77,6 +79,16 @@ func main() {
 
 	// Override the logger with flag-based options if provided
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Emit a virtrigaud_build_info{version,git_sha,go_version,component} sample
+	// so the manager's /metrics endpoint exposes a virtrigaud_* family at startup.
+	// Without this call the build_info GaugeVec stays empty and the family does
+	// not appear in /metrics output, defeating Prometheus-based release verification.
+	metrics.SetupMetrics(version.Version, version.GitSHA, metrics.ComponentManager)
+	setupLog.Info("virtrigaud metrics registered",
+		"version", version.Version,
+		"gitSHA", version.GitSHA,
+		"component", metrics.ComponentManager)
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will


### PR DESCRIPTION
## Summary

Calls `metrics.SetupMetrics(version.Version, version.GitSHA, metrics.ComponentManager)` in `cmd/manager/main.go` immediately after logger setup, so the manager's `/metrics` endpoint actually exposes the `virtrigaud_build_info` family at startup. This is the operational counterpart to PR #83.

## Why this is needed (and why PR #83 alone wasn't enough)

PR #83 correctly fixed the registry binding — all 12 metric Vec families now register with controller-runtime's `metrics.Registry` (the one served on `/metrics`) instead of promauto's default global registry. That fix is structurally correct, verified by `internal/obs/metrics/metrics_test.go::TestMetricsRegisteredInControllerRuntimeRegistry`.

**But** Prometheus `*Vec` metrics with zero observations do not appear in `/metrics` output. They only emit family lines and samples once `WithLabelValues(...).Inc()/Set()/Observe()` has been called at least once. In production:

- The active reconciler (`VirtualMachineReconciler`) does not use the metrics package.
- `vmsnapshot` and `vmmigration` reconcilers do use it, but there were no `VMSnapshot`/`VMMigration` CRs on the test cluster — no reconcile → no recording → no family on `/metrics`.
- The one metric that doesn't depend on reconcile activity is `virtrigaud_build_info`, populated by `SetupMetrics(...)`. Nothing called it.

Confirmed in the **v0.3.3-rc2 deploy + smoke test on `vr1.lab.k8`**: `/metrics` reported `57` metric families, `0` of them `virtrigaud_*` — identical to rc1. The PR #83 fix was in the binary (verified by `strings` on the extracted binary: `registerer` symbol present, dead `Init` symbol gone), but the operational gap kept the regression visible.

This change adds the one missing call. Per-reconciler instrumentation (`VirtualMachineReconciler`, `ProviderReconciler`, etc.) for full operational visibility is **deferred to v0.3.4** — out of scope for the v0.3.3 hotfix sequence.

## Test plan
- [x] `go fmt`, `go vet`, `go build ./cmd/manager/...` clean
- [x] `golangci-lint run ./cmd/manager/...` — 0 issues
- [x] `go test ./internal/obs/metrics/...` PASS (registry binding canary still green)
- [x] Manual binary build sanity check — `/tmp/manager-localtest` produced, 65MB, no errors
- [ ] **Reviewer**: cut `v0.3.3-rc3` from this commit, deploy to `vr1.lab.k8`, expect `curl /metrics | grep '^virtrigaud_build_info'` to return one line with the rc3 version label

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (manager pod restart picks up the new SetupMetrics call)
- [ ] Config change only
- [ ] Documentation only

## Follow-ups (NOT in this PR)
1. Instrument `VirtualMachineReconciler.Reconcile()` with `metrics.NewReconcileTimer("VirtualMachine")` to expose `virtrigaud_manager_reconcile_total{kind="VirtualMachine"}` etc. Same for `ProviderReconciler`, `VMClassReconciler`, others. → v0.3.4
2. Remove orphan `cmd/main.go` and root `Dockerfile` — both unused; the real build is `cmd/manager/main.go` + `build/Dockerfile.manager`. Caused 30 minutes of debugging confusion. → v0.3.4
3. Wire `test/integration/observability_test.go` into CI (or move its assertions into a unit test) — root cause of why both the registry bug AND this operational gap were invisible to CI for v0.3.0–v0.3.2. → v0.3.4