### PR TITLE
fix(build): inject VERSION + GIT_SHA into manager binary via ldflags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,13 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Inject VERSION and GIT_SHA into the binary via ldflags so that
+          # internal/version reports accurate values (consumed by
+          # virtrigaud_build_info on /metrics). Dockerfiles that do not
+          # declare these ARGs ignore them silently.
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.tag }}
+            GIT_SHA=${{ github.sha }}
           # Disable GitHub Actions cache due to reliability issues
           # cache-from: type=gha
           # cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-22 18:27] - Inject VERSION and GIT_SHA into manager binary via ldflags
+**Author:** @williamrizzo (William Rizzo)
+
+### Fixed
+- `build/Dockerfile.manager`: Added `ARG VERSION=dev` and `ARG GIT_SHA=unknown` plus `-ldflags="-s -w -X 'github.com/projectbeskar/virtrigaud/internal/version.Version=${VERSION}' -X 'github.com/projectbeskar/virtrigaud/internal/version.GitSHA=${GIT_SHA}'"` on the `go build` step. The container image now reports accurate version metadata at runtime.
+- `.github/workflows/release.yml`: Added `build-args: VERSION / GIT_SHA` to the `docker/build-push-action` step so the release tag and commit SHA are passed into the container build. Dockerfiles that don't declare these ARGs (kubectl image, current provider images) silently ignore them — no impact.
+
+### Why
+v0.3.3-rc3 smoke test on `vr1.lab.k8` showed `virtrigaud_build_info{component="manager",git_sha="unknown",go_version="go1.25.10",version="dev"} 1` on `/metrics` instead of `version="v0.3.3-rc3"` and the real SHA. The metrics pipeline (registry binding from PR #83 + SetupMetrics call from PR #84) was working — the binary itself had never been built with ldflags to populate `internal/version`. Latent bug since the project's inception, but only became visible once `virtrigaud_build_info` was actually exposed. `virtrigaud_build_info` is the canonical way for operators to know which manager version is running; reporting `version="dev"` to Prometheus dashboards is actively misleading during incident response, which matters for the project's banking-grade operational posture.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (new manager image needed for labels to update)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Verification
+After deploying the new image:
+```bash
+kubectl -n virtrigaud-system port-forward deploy/virtrigaud-manager 8080:8080 &
+curl -s http://localhost:8080/metrics | grep '^virtrigaud_build_info'
+# expect:
+# virtrigaud_build_info{component="manager",git_sha="<rc4-commit-sha>",go_version="...",version="v0.3.3-rc4"} 1
+```
+
+Local sanity check:
+```bash
+go build -ldflags="-s -w \
+  -X 'github.com/projectbeskar/virtrigaud/internal/version.Version=v0.3.3-rc4-sanity' \
+  -X 'github.com/projectbeskar/virtrigaud/internal/version.GitSHA=abc1234'" \
+  -o /tmp/manager ./cmd/manager/
+strings /tmp/manager | grep -E 'v0\.3\.3-rc4-sanity|abc1234'
+# both literals present in the resulting binary
+```
+
+---
+
 ## [2026-05-22 15:29] - Emit virtrigaud_build_info on manager startup
 **Author:** @williamrizzo (William Rizzo)
 

--- a/build/Dockerfile.manager
+++ b/build/Dockerfile.manager
@@ -2,6 +2,12 @@
 FROM golang:1.25 as builder
 ARG TARGETOS
 ARG TARGETARCH
+# VERSION and GIT_SHA are injected into internal/version via ldflags so that
+# virtrigaud_build_info on /metrics reports accurate labels. Defaults match
+# the zero values in internal/version/version.go so a developer build without
+# build-args still works.
+ARG VERSION=dev
+ARG GIT_SHA=unknown
 
 WORKDIR /workspace
 # Copy the Go Modules manifests and local modules (needed for replace directives)
@@ -23,7 +29,11 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/manager/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
+    -ldflags="-s -w \
+      -X 'github.com/projectbeskar/virtrigaud/internal/version.Version=${VERSION}' \
+      -X 'github.com/projectbeskar/virtrigaud/internal/version.GitSHA=${GIT_SHA}'" \
+    -o manager cmd/manager/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
## Summary
- Manager Dockerfile now accepts `VERSION` and `GIT_SHA` ARGs and passes them into `go build -ldflags="-X .../version.Version=..."` so `internal/version` is populated at container build time.
- Release workflow passes the release tag and commit SHA into the `docker/build-push-action` step via `build-args`.
- `virtrigaud_build_info{version=...,git_sha=...}` on `/metrics` will report accurate values from v0.3.3-rc4 onwards.

## Why this is the third release blocker for v0.3.3

The metrics pipeline took three PRs to be production-ready:

| PR | Fix | Verified by |
|----|-----|-------------|
| #83 | Bind metric vectors to controller-runtime's `Registry` instead of promauto's default | rc2 smoke: 57 → 57 families (registry binding correct but no samples emitted) |
| #84 | Call `SetupMetrics` in `cmd/manager/main.go` so `virtrigaud_build_info` emits one sample on startup | rc3 smoke: 57 → 58 families, `virtrigaud_build_info` present |
| **this PR** | Pass `VERSION` + `GIT_SHA` into the manager binary at container build time so `internal/version` is populated | **rc4 expected**: `virtrigaud_build_info{version="v0.3.3-rc4",git_sha="<sha>",...}` instead of `version="dev"`, `git_sha="unknown"` |

rc3 ships with the canary lit but with misleading labels (`version=\"dev\"`, `git_sha=\"unknown\"`). For a project documented as deployable in regulated banking environments, accurate version info on `/metrics` is the canonical way for operators to know which manager version is running during incident response. Blocking on rc4 to ship this correctly.

## Root cause
`internal/version/version.go` declares `Version="dev"` and `GitSHA="unknown"` as defaults, intended to be overridden via `go build -ldflags "-X .../version.Version=..."`. The manager Dockerfile ran a plain `go build` with no ldflags, so the defaults shipped unchanged in every container image since project inception. The bug was invisible until PR #84 made `virtrigaud_build_info` appear on `/metrics`.

## Files changed
- `build/Dockerfile.manager`: `ARG VERSION=dev`, `ARG GIT_SHA=unknown`, ldflags on `go build` step. Defaults match `internal/version` zero values so a developer build without `--build-arg` still works.
- `.github/workflows/release.yml`: `build-args: VERSION=${{ needs.prepare.outputs.tag }}` and `GIT_SHA=${{ github.sha }}` added to the `docker/build-push-action` step. Other component Dockerfiles (kubectl, provider-*) don't declare these ARGs and silently ignore them.
- `CHANGELOG.md`: entry with William Rizzo attribution + verification commands.

## Verification

### Local sanity (pre-CI)
\`\`\`
$ go build -ldflags=\"-s -w \\
    -X 'github.com/projectbeskar/virtrigaud/internal/version.Version=v0.3.3-rc4-sanity' \\
    -X 'github.com/projectbeskar/virtrigaud/internal/version.GitSHA=abc1234'\" \\
    -o /tmp/m ./cmd/manager/
$ strings /tmp/m | grep -E 'v0\\.3\\.3-rc4-sanity|abc1234'
abc1234
v0.3.3-rc4-sanity
\`\`\`
Both literals land in the binary — ldflags syntax is correct.

### CI gates (this PR)
- [x] `go fmt` clean
- [x] `go vet` clean
- [x] `golangci-lint run ./internal/version/... ./cmd/manager/...` → 0 issues
- [x] `go build ./...` clean (no Go source change; Dockerfile + workflow only)
- [ ] **CI on this PR**: expect all jobs green; no Go source change

### End-to-end (post-merge + rc4 release + helm upgrade on `vr1.lab.k8`)
\`\`\`
$ kubectl -n virtrigaud-system port-forward deploy/virtrigaud-manager 8080:8080 &
$ curl -s http://localhost:8080/metrics | grep '^virtrigaud_build_info'
virtrigaud_build_info{component=\"manager\",git_sha=\"<rc4-sha>\",go_version=\"...\",version=\"v0.3.3-rc4\"} 1
\`\`\`

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (new manager image needed for labels to update)
- [ ] Config change only
- [ ] Documentation only

## Provider images deferred
Provider Dockerfiles (libvirt, vsphere, proxmox) don't currently emit metrics on a `/metrics` endpoint — their gRPC servers don't yet wire `virtrigaud_build_info`. Once they do (tracked as G2 in `PROJECT_CONTEXT.md`, planned for v0.3.4), the same ARG block can be added to their Dockerfiles. The build-args from `release.yml` already flow to those images; they just silently ignore the unknown ARGs today.