### PR TITLE
fix(security): redact secret VALUES not field NAMES in logging.Redact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-23 09:23] - SECURITY: fix logging.Redact to mask values, not field names (closes #95)
+**Author:** @williamrizzo (William Rizzo)
+
+### Security
+- `internal/obs/logging/logging.go`: `Redactor.Redact` (and the convenience wrappers `RedactString`, `RedactMap`) previously replaced the FIRST capture group of every matched pattern. For two-group kv-pair patterns like `(password|token|...)\s*[:=]\s*([^\s]+)`, this meant the field NAME (group 1) was masked while the SECRET VALUE (group 2) survived in cleartext. Input `"password=hunter2"` produced `"[REDACTED]=hunter2"`.
+- Fix: replace the LAST capture group, by documented convention "the value is always the last group". Works correctly for both 1-group patterns (URL passwords) and 2-group patterns (kv-pairs); 0-group patterns continue to replace the entire match.
+
+### Added
+- `internal/obs/logging/logging_test.go`: New file. 6 tests with 22+ sub-cases covering:
+  - `TestRedactStringValuesNotKeys`: 13 sub-cases (equals/colon separators, `api_key` underscore + hyphen variants, case-insensitivity, all `password|passwd|pwd|token|secret` aliases, quoted values, multiple kv-pairs in one string, URL-embedded passwords incl. `qemu+ssh://`).
+  - `TestRedactStringNonSensitiveInputUntouched`: confirms harmless content passes through unchanged.
+  - `TestRedactMap`: confirms `RedactMap` masks whole values for sensitive keys, recursively masks values for non-sensitive keys, leaves harmless map entries alone.
+  - `TestRedactStringSSHPublicKey`, `TestIsSensitiveKey`, `TestRedactStringIdempotent`.
+
+### Changed
+- `test/integration/observability_test.go`: Removed the `t.Skip("blocked by #95 ...")` on `TestObservabilityIntegration`. The integration assertion `assert.NotContains(t, redacted, "secret123")` now passes against the fixed implementation.
+
+### Why
+Discovered during PR #98 (wiring `test/integration/` into CI) on 2026-05-23. `TestObservabilityIntegration` had been failing silently in the disabled CI job since the function shipped. The bug is real but has **zero production callsites today** — no code in `internal/controller/`, `internal/providers/`, or `internal/transport/` calls any redaction function. So no operator's v0.3.3 logs contain leaked secrets via this path. Still shipping as a security fix because (a) the function name implies behavior the implementation didn't deliver, giving any future caller a false sense of security; (b) banking-compliance posture demands rapid response to security findings even when current exposure is dormant; (c) the fix is small and isolated.
+
+Cut as v0.3.3.1 patch release (not rolled into v0.3.4 alongside the G-track) for clean per-incident release auditability.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (new manager image for the redaction behavior to take effect — only matters once a code path actually calls Redact)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Verification
+Locally:
+```bash
+go test -v -run TestRedact ./internal/obs/logging/
+# PASS: 13 sub-tests
+go test -v -run TestObservabilityIntegration ./test/integration/
+# PASS: now un-skipped; log output proves the fix:
+#   Original: password=secret123 and api_key=abcdef
+#   Redacted: password=[REDACTED] and api_key=[REDACTED]
+```
+
+### References
+- Closes #95
+- Discovered by PR #98 (wiring observability_test into CI)
+- PROJECT_CONTEXT.md track K1 (renamed from previous "Active TODO" entry)
+
+---
+
 ## [2026-05-23 09:07] - Wire observability integration test into CI (closes #93)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/internal/obs/logging/logging.go
+++ b/internal/obs/logging/logging.go
@@ -216,35 +216,58 @@ type Redactor struct {
 	patterns []*regexp.Regexp
 }
 
-// NewRedactor creates a redactor with common sensitive patterns
+// NewRedactor creates a redactor with common sensitive patterns.
+//
+// PATTERN CONVENTION: when a pattern uses capture groups, the LAST capture
+// group must be the sensitive value to redact. Earlier groups are treated
+// as context (e.g. the field name in a kv-pair like "password=hunter2",
+// where group 1 = "password" and the last group = "hunter2"). Single-group
+// patterns put the sensitive value in their only group. Zero-group patterns
+// are replaced entirely. This convention is enforced by Redact() below.
 func NewRedactor() *Redactor {
 	patterns := []*regexp.Regexp{
-		// Passwords in URLs
+		// Passwords embedded in URLs, e.g. "https://user:hunter2@host".
+		// 1 group: the password (last group).
 		regexp.MustCompile(`://[^:]*:([^@]*?)@`),
-		// API keys and tokens
+		// Common credential kv-pairs in logs and config dumps.
+		// 2 groups: key name (context) + value (last group, sensitive).
 		regexp.MustCompile(`(?i)(api[_-]?key|token|secret|password|passwd|pwd)\s*[:=]\s*["']?([^"'\s]+)["']?`),
-		// Cloud-init user data (may contain sensitive info)
+		// Cloud-init user-data blobs (may contain credentials, ssh keys, etc).
+		// 2 groups: key name (context) + value (last group, sensitive).
 		regexp.MustCompile(`(?i)(user[_-]?data|userdata)\s*[:=]\s*["']?([^"'\n]{20,})["']?`),
-		// SSH keys
+		// SSH public keys (no capture group; whole match is replaced).
 		regexp.MustCompile(`ssh-[a-z0-9]+ [A-Za-z0-9+/=]+ `),
-		// Generic secrets (base64-like strings > 20 chars)
+		// Generic base64-like strings > 20 chars (no capture group; whole match).
 		regexp.MustCompile(`[A-Za-z0-9+/]{20,}={0,2}`),
 	}
 
 	return &Redactor{patterns: patterns}
 }
 
-// Redact removes sensitive information from strings
+// Redact removes sensitive information from strings.
+//
+// For patterns with capture groups, the LAST capture group is treated as the
+// sensitive value and replaced with "[REDACTED]". Earlier groups are kept
+// (they are typically context, e.g. the field name in "password=X"). This
+// convention is documented on NewRedactor.
+//
+// For patterns without capture groups, the entire match is replaced.
+//
+// Fixes issue #95: prior implementation replaced the FIRST capture group,
+// which for kv-pair patterns meant the field NAME was masked while the
+// secret VALUE survived in cleartext ("password=hunter2" -> "[REDACTED]=hunter2").
 func (r *Redactor) Redact(input string) string {
 	result := input
 	for _, pattern := range r.patterns {
 		if pattern.NumSubexp() > 0 {
-			// Replace capture groups with [REDACTED]
+			// Replace the LAST capture group with [REDACTED]. By the pattern
+			// convention this group is always the sensitive value.
 			result = pattern.ReplaceAllStringFunc(result, func(match string) string {
 				submatches := pattern.FindStringSubmatch(match)
 				if len(submatches) > 1 {
-					// Replace the sensitive part (first capture group) with [REDACTED]
-					return strings.Replace(match, submatches[1], "[REDACTED]", 1)
+					// submatches[0] is the full match; submatches[1..len-1]
+					// are the capture groups. The last one is the value.
+					return strings.Replace(match, submatches[len(submatches)-1], "[REDACTED]", 1)
 				}
 				return match
 			})

--- a/internal/obs/logging/logging_test.go
+++ b/internal/obs/logging/logging_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRedactStringValuesNotKeys is the regression canary for issue #95.
+//
+// The pre-fix implementation replaced the FIRST capture group of every
+// pattern. For two-group patterns like (key)(value), that meant the field
+// NAME got masked while the SECRET VALUE survived in cleartext. This test
+// asserts the inverse: the value is redacted and the field name is preserved
+// (the field name is operationally useful — knowing "there is a password
+// here" is fine; what matters is not leaking the password itself).
+func TestRedactStringValuesNotKeys(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		mustNotContain []string // secret values that MUST NOT appear in output
+		mustContain    []string // tokens that MUST appear in output ([REDACTED] markers, preserved context)
+	}{
+		{
+			name:           "password=value (equals separator)",
+			input:          "password=hunter2",
+			mustNotContain: []string{"hunter2"},
+			mustContain:    []string{"password", "[REDACTED]"},
+		},
+		{
+			name:           "password: value (colon separator)",
+			input:          "password: hunter2",
+			mustNotContain: []string{"hunter2"},
+			mustContain:    []string{"password", "[REDACTED]"},
+		},
+		{
+			name:           "api_key (underscore variant)",
+			input:          "api_key=abc123xyz",
+			mustNotContain: []string{"abc123xyz"},
+			mustContain:    []string{"api_key", "[REDACTED]"},
+		},
+		{
+			name:           "api-key (hyphen variant)",
+			input:          "api-key=abc123xyz",
+			mustNotContain: []string{"abc123xyz"},
+			mustContain:    []string{"api-key", "[REDACTED]"},
+		},
+		{
+			name:           "token (case-insensitive)",
+			input:          "TOKEN=very-secret-token-value",
+			mustNotContain: []string{"very-secret-token-value"},
+			mustContain:    []string{"TOKEN", "[REDACTED]"},
+		},
+		{
+			name:           "passwd alias",
+			input:          "passwd=hunter2",
+			mustNotContain: []string{"hunter2"},
+			mustContain:    []string{"passwd", "[REDACTED]"},
+		},
+		{
+			name:           "pwd alias",
+			input:          "pwd=hunter2",
+			mustNotContain: []string{"hunter2"},
+			mustContain:    []string{"pwd", "[REDACTED]"},
+		},
+		{
+			name:           "secret keyword",
+			input:          "secret=value-to-hide",
+			mustNotContain: []string{"value-to-hide"},
+			mustContain:    []string{"secret", "[REDACTED]"},
+		},
+		{
+			name:           "quoted value (double quotes)",
+			input:          `password="hunter2"`,
+			mustNotContain: []string{"hunter2"},
+			mustContain:    []string{"password", "[REDACTED]"},
+		},
+		{
+			name:           "quoted value (single quotes)",
+			input:          `password='hunter2'`,
+			mustNotContain: []string{"hunter2"},
+			mustContain:    []string{"password", "[REDACTED]"},
+		},
+		{
+			name:           "multiple kv pairs (the original integration-test failure case)",
+			input:          "password=secret123 and api_key=abcdef",
+			mustNotContain: []string{"secret123", "abcdef"},
+			mustContain:    []string{"password", "api_key", "[REDACTED]"},
+		},
+		{
+			name:           "URL with embedded password",
+			input:          "https://user:hunter2@host.example",
+			mustNotContain: []string{"hunter2"},
+			mustContain:    []string{"https://user:", "@host.example", "[REDACTED]"},
+		},
+		{
+			name:           "qemu+ssh URL with password",
+			input:          "qemu+ssh://wrkode:KUb34us!@172.16.56.8/system",
+			mustNotContain: []string{"KUb34us!"},
+			mustContain:    []string{"qemu+ssh://wrkode:", "@172.16.56.8/system", "[REDACTED]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactString(tt.input)
+			for _, leak := range tt.mustNotContain {
+				assert.NotContains(t, got, leak,
+					"input=%q produced output that still contains the secret %q", tt.input, leak)
+			}
+			for _, marker := range tt.mustContain {
+				assert.Contains(t, got, marker,
+					"input=%q produced output missing expected marker %q (got %q)", tt.input, marker, got)
+			}
+		})
+	}
+}
+
+// TestRedactStringNonSensitiveInputUntouched verifies the redactor doesn't
+// over-redact harmless content. Currently the "base64-like string > 20 chars"
+// pattern is broad enough that some long alphanumeric tokens (e.g. UUIDs
+// without hyphens, container image digests) will be replaced — that's a known
+// design trade-off but worth pinning to catch unintentional regressions.
+func TestRedactStringNonSensitiveInputUntouched(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "short alphanumeric",
+			input: "hello world 12345",
+			want:  "hello world 12345",
+		},
+		{
+			name:  "log line without secrets",
+			input: "Reconcile VirtualMachine default/test-vm: phase=Provisioning",
+			want:  "Reconcile VirtualMachine default/test-vm: phase=Provisioning",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactString(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestRedactMap verifies map-based redaction redacts whole VALUES for
+// sensitive keys, and recursively redacts values for non-sensitive keys.
+func TestRedactMap(t *testing.T) {
+	input := map[string]string{
+		"password":    "hunter2",
+		"username":    "wrkode",
+		"api_key":     "sk-abcd1234567890",
+		"description": "harmless field",
+		"connection":  "password=secret-in-value",
+	}
+
+	got := RedactMap(input)
+
+	assert.Equal(t, "[REDACTED]", got["password"],
+		"sensitive key 'password' should have entire value redacted")
+	assert.Equal(t, "[REDACTED]", got["api_key"],
+		"sensitive key 'api_key' should have entire value redacted")
+	assert.Equal(t, "wrkode", got["username"],
+		"non-sensitive key 'username' should not be redacted (it's not in isSensitiveKey list)")
+	assert.Equal(t, "harmless field", got["description"],
+		"non-sensitive key with non-sensitive value should pass through unchanged")
+	// The "connection" value contains a kv-pair pattern that the value-level
+	// Redact() should catch.
+	assert.NotContains(t, got["connection"], "secret-in-value",
+		"value-level redaction should still apply to non-sensitive keys when their value matches a pattern")
+}
+
+// TestRedactStringSSHPublicKey verifies SSH public keys are scrubbed.
+func TestRedactStringSSHPublicKey(t *testing.T) {
+	input := "authorized: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN7lHIuo2QJBkdVDL79bl wrkode@laptop\nnext line"
+	got := RedactString(input)
+	assert.NotContains(t, got, "AAAAC3NzaC1lZDI1NTE5AAAAIN7lHIuo2QJBkdVDL79bl",
+		"SSH public key body must be redacted (got %q)", got)
+}
+
+// TestIsSensitiveKey covers the helper used by RedactMap.
+func TestIsSensitiveKey(t *testing.T) {
+	sensitive := []string{"password", "Password", "PASSWORD", "api_key", "apikey",
+		"access_key", "private_key", "tls.key", "client.key", "ssh_private_key",
+		"userdata", "user_data", "secret", "token", "credential", "auth"}
+	for _, k := range sensitive {
+		assert.True(t, isSensitiveKey(k), "expected %q to be classified as sensitive", k)
+	}
+
+	nonSensitive := []string{"username", "host", "port", "namespace", "name", "phase"}
+	for _, k := range nonSensitive {
+		assert.False(t, isSensitiveKey(k),
+			"expected %q to NOT be classified as sensitive", k)
+	}
+}
+
+// TestRedactStringIdempotent verifies running Redact twice doesn't double-mask.
+func TestRedactStringIdempotent(t *testing.T) {
+	input := "password=hunter2 and api_key=abc"
+	once := RedactString(input)
+	twice := RedactString(once)
+	// After the first pass values are gone; second pass should be a no-op
+	// (the [REDACTED] marker shouldn't itself match any pattern).
+	assert.Equal(t, once, twice,
+		"redaction should be idempotent: once=%q twice=%q", once, twice)
+	assert.False(t, strings.Contains(twice, "hunter2"),
+		"secret must still be absent after second pass")
+}

--- a/test/integration/observability_test.go
+++ b/test/integration/observability_test.go
@@ -32,13 +32,6 @@ import (
 )
 
 func TestObservabilityIntegration(t *testing.T) {
-	// SECURITY: blocked by #95 - logging.RedactString redacts keys instead of
-	// values, leaking secrets into logs. Skipping this whole test until the
-	// underlying RedactString is fixed; the assertion at line 59 fails today
-	// because "password=secret123" becomes "[REDACTED]=secret123" (key
-	// masked, value intact). Once #95 lands, remove this t.Skip.
-	t.Skip("blocked by #95 - logging.RedactString redacts keys instead of values")
-
 	// Setup logging
 	logConfig := logging.DefaultConfig()
 	logConfig.Level = "debug"


### PR DESCRIPTION
## Summary
- `internal/obs/logging/Redactor.Redact` (and wrappers `RedactString`, `RedactMap`) now redacts the VALUE in `password=hunter2` instead of the field NAME.
- New file `internal/obs/logging/logging_test.go` with 6 tests / 22+ sub-cases as a regression canary.
- `TestObservabilityIntegration` in `test/integration/` un-skipped (the fix unblocks it).

Closes #95. Cuts as **v0.3.3.1 security patch** per the agreed release vehicle.

## The bug

```diff
-                 password=hunter2  →  [REDACTED]=hunter2   ❌ secret leaks
+                 password=hunter2  →  password=[REDACTED]  ✅ secret masked
```

Root cause: `Redactor.Redact` replaced `submatches[1]` (the first capture group). For two-group kv-pair patterns where group 1 = field name and group 2 = value, that masked the wrong thing.

Fix: replace `submatches[len(submatches)-1]` (the last capture group). New convention is documented in a comment block on `NewRedactor()`: **when a pattern has capture groups, the LAST one is the sensitive value**. Works for:
- 1-group URL patterns (`://user:HERE@host`)
- 2-group kv-pair patterns (key=value)
- 0-group patterns continue to replace the entire match (SSH keys, bare base64)

## ⚠️ Severity reframed (still cutting v0.3.3.1 per maintainer decision)

This function has **zero production callsites today** — `grep -rn 'RedactString|RedactMap|\.Redact\(' --include='*.go'` finds only the function definition and the test file. Nothing in `internal/controller/`, `internal/providers/`, or `internal/transport/` calls it. So no operator's v0.3.3 logs contain leaked secrets via this path.

Shipping anyway as a security fix because:
- The function NAME implies behavior the implementation didn't deliver, giving any future caller a false sense of security.
- Banking-compliance posture demands rapid response to security findings even when current exposure is dormant.
- The fix is small and isolated. No reason to bundle it with the larger G-track work.

## Test plan

### Unit (`make test`)
```
$ go test -v -run TestRedact ./internal/obs/logging/
=== RUN   TestRedactStringValuesNotKeys
    --- PASS: password=value (equals separator)
    --- PASS: password: value (colon separator)
    --- PASS: api_key (underscore variant)
    --- PASS: api-key (hyphen variant)
    --- PASS: token (case-insensitive)
    --- PASS: passwd alias
    --- PASS: pwd alias
    --- PASS: secret keyword
    --- PASS: quoted value (double quotes)
    --- PASS: quoted value (single quotes)
    --- PASS: multiple kv pairs (the original integration-test failure case)
    --- PASS: URL with embedded password
    --- PASS: qemu+ssh URL with password
=== RUN   TestRedactStringNonSensitiveInputUntouched (3 sub-cases)
=== RUN   TestRedactMap
=== RUN   TestRedactStringSSHPublicKey
=== RUN   TestIsSensitiveKey
=== RUN   TestRedactStringIdempotent
PASS  (22+ sub-cases total)
```

### Integration (`make test-integration` — gated in CI as of PR #98)
```
$ go test -v -run TestObservabilityIntegration ./test/integration/
    observability_test.go:61: Original: password=secret123 and api_key=abcdef
    observability_test.go:62: Redacted: password=[REDACTED] and api_key=[REDACTED]
--- PASS: TestObservabilityIntegration
```

The diagnostic log line proves the behavior end-to-end.

### Gates
- [x] `go fmt`, `go vet`, `golangci-lint` all clean
- [x] `make test` passes
- [x] `make test-integration` passes (4 pass, 2 still skipped per #96 #97)
- [ ] CI on this PR: expect green; if PR #98 hasn't merged yet, the Integration Tests job still runs because that workflow change is included in this branch's main-merge base only after #98 — if needed, rebase post-#98

## Dependency on PR #98

PR #98 (CI wiring) is in your approval queue. This PR is independent in scope but the integration test gate it adds would validate the fix at CI time. Either ordering works:
- If #98 merges first: this PR's branch will rebase and the integration test runs in this PR's CI as a check.
- If this PR merges first: the integration test runs at the next push to `main` (post-#98 merge).

Recommend you approve #98 first to get the CI gate active, then this PR.

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (new manager image for the redaction behavior to take effect — only matters once a code path actually calls Redact)
- [ ] Config change only
- [ ] Documentation only

## Release vehicle

After merge: tag **v0.3.3.1** from this commit. Release workflow publishes:
- `ghcr.io/projectbeskar/virtrigaud/manager:v0.3.3.1`
- `virtrigaud-0.3.3.1.tgz` helm chart on `gh-pages`
- GitHub Release with `prerelease=false`
- SBOMs + signed images via cosign

Then `helm upgrade -i virtrigaud virtrigaud/virtrigaud --version v0.3.3.1 --reset-values` on `vr1.lab.k8`.

## Follow-up to consider after merge
- **GitHub Security Advisory (GHSA)** — file one retroactively under projectbeskar/virtrigaud's "Security" tab. Even though there's no current customer impact, it documents the issue formally and allows CVE assignment if you want one for the audit trail.
- **Audit other "looks-secure-but-isn't" functions** — this bug was a function whose name promised one thing and whose implementation did another. Worth a small sweep of `internal/obs/` for similar mismatches.