### PR TITLE
feat(obs): instrument ProviderReconciler with reconcile timer + error counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-23 11:58] - feat(obs): instrument ProviderReconciler with reconcile timer + error counter (closes #88)
+**Author:** @williamrizzo (William Rizzo)
+
+### Added
+- `internal/controller/provider_controller.go`: `Reconcile` now records `virtrigaud_manager_reconcile_total{kind="Provider",outcome=...}` and `virtrigaud_manager_reconcile_duration_seconds{kind="Provider"}` via a single deferred block that infers outcome from named return values. Mirrors the G1 pattern shipped for `VirtualMachineReconciler` in PR #101.
+- `internal/controller/provider_controller.go`: 6 `metrics.RecordError(reason, ComponentManager)` calls at the documented error sites in `Reconcile`, `handleDeletion`, and `reconcileRemoteRuntime`. New `errReason*` constants at the top of the file: `get-provider`, `runtime-spec-invalid`, `service-reconcile-failed`, `deployment-reconcile-failed`, `cleanup-failed`. No collisions with the VirtualMachine reconciler's taxonomy.
+- `internal/controller/provider_metrics_test.go`: New file. 3 focused unit tests using `client/fake` (no envtest needed):
+  - `TestProviderReconcile_Metrics_NotFoundIsSuccessOutcome` — IsNotFound is outcome=success
+  - `TestProviderReconcile_Metrics_MissingRuntimeIsErrorOutcome` — missing `spec.runtime` is outcome=error + `errors_total{reason="runtime-spec-invalid"}`
+  - `TestProviderReconcile_Metrics_DurationHistogramFires` — smoke that the histogram observes at least one sample under `kind="Provider"`
+
+### Why
+Second in the G-track sequence (after G1 / PR #101). `ProviderReconciler` reconciles Provider CRs into per-Provider Deployments + Services + Secrets, and its failure modes (missing runtime spec, Service/Deployment reconcile errors) are operationally distinct from VM reconcile failures. Per-Kind reconcile counters and a dedicated reason taxonomy let operators dashboard "Provider lifecycle health" separately from "VM lifecycle health."
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (new manager image needed to emit)
+- [ ] Config change only
+- [ ] Documentation only
+
+Targeted for **v0.3.5** alongside G1 (already merged), G3, G4, G5.
+
+### Verification
+Locally:
+```bash
+go test -v -count=1 -run TestProviderReconcile_Metrics ./internal/controller/
+# PASS: 3 tests
+make test  # controller coverage 21.6% -> 22.4%
+make test-integration  # still green
+```
+
+Post-deploy (after the full G-track lands + v0.3.5-rc1 deploys):
+```bash
+curl /metrics | grep '^virtrigaud_manager_reconcile_total{kind="Provider"'
+# expect non-zero samples for outcome=success|requeue|error
+```
+
+### References
+- Closes #88
+- Umbrella: #86
+- Pattern established by: #101 (G1)
+- PROJECT_CONTEXT.md G-track item G2
+
+---
+
 ## [2026-05-23 11:26] - feat(obs): instrument VirtualMachineReconciler with reconcile timer + structured error counter (closes #87)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -38,7 +38,20 @@ import (
 
 	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
 	"github.com/projectbeskar/virtrigaud/internal/k8s"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 	"github.com/projectbeskar/virtrigaud/internal/util"
+)
+
+// Reason labels used in metrics.RecordError calls for the Provider
+// reconciler. See virtualmachine_controller.go for the naming convention.
+// These constants are package-local; the `errReason*` prefix prevents
+// collisions with the VirtualMachine reconciler's taxonomy.
+const (
+	errReasonGetProvider         = "get-provider"
+	errReasonRuntimeSpecInvalid  = "runtime-spec-invalid"
+	errReasonServiceReconcile    = "service-reconcile-failed"
+	errReasonDeploymentReconcile = "deployment-reconcile-failed"
+	errReasonCleanupFailed       = "cleanup-failed"
 )
 
 // ProviderReconciler reconciles a Provider object
@@ -56,8 +69,31 @@ type ProviderReconciler struct {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
-// Reconcile manages Provider resources and their runtime deployments
-func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// Reconcile manages Provider resources and their runtime deployments.
+//
+// Observability: per-call timer + outcome inference via deferred block
+// emits `virtrigaud_manager_reconcile_total{kind="Provider",outcome=...}`
+// and `virtrigaud_manager_reconcile_duration_seconds{kind="Provider"}`.
+// Specific error sites also record `virtrigaud_errors_total{reason=...,
+// component="manager"}`. Reason taxonomy: see the `errReason*` constants
+// at the top of this file.
+//
+// Named return values (`result`, `retErr`) are required by the deferred
+// outcome-inference block — do not change the signature without updating
+// the defer.
+func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
+	timer := metrics.NewReconcileTimer("Provider")
+	defer func() {
+		outcome := metrics.OutcomeSuccess
+		switch {
+		case retErr != nil:
+			outcome = metrics.OutcomeError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metrics.OutcomeRequeue
+		}
+		timer.Finish(outcome)
+	}()
+
 	logger := log.FromContext(ctx)
 
 	// Fetch the Provider
@@ -68,6 +104,7 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get Provider")
+		metrics.RecordError(errReasonGetProvider, metrics.ComponentManager)
 		return ctrl.Result{}, err
 	}
 
@@ -89,6 +126,7 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if updateErr := r.Status().Update(ctx, &provider); updateErr != nil {
 			logger.Error(updateErr, "Failed to update Provider status")
 		}
+		metrics.RecordError(errReasonRuntimeSpecInvalid, metrics.ComponentManager)
 		return ctrl.Result{}, err
 	}
 
@@ -148,6 +186,7 @@ func (r *ProviderReconciler) handleDeletion(ctx context.Context, provider *infra
 	// Always clean up remote runtime resources (all providers are remote now)
 	if err := r.cleanupRemoteRuntime(ctx, provider); err != nil {
 		logger.Error(err, "Failed to cleanup remote runtime resources")
+		metrics.RecordError(errReasonCleanupFailed, metrics.ComponentManager)
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
@@ -163,6 +202,7 @@ func (r *ProviderReconciler) reconcileRemoteRuntime(ctx context.Context, provide
 		k8s.SetCondition(&provider.Status.Conditions, "ProviderRuntimeReady", metav1.ConditionFalse, "InvalidConfiguration", err.Error())
 		provider.Status.Runtime.Phase = infravirtrigaudiov1beta1.ProviderRuntimePhaseFailed
 		provider.Status.Runtime.Message = err.Error()
+		metrics.RecordError(errReasonRuntimeSpecInvalid, metrics.ComponentManager)
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
@@ -177,6 +217,7 @@ func (r *ProviderReconciler) reconcileRemoteRuntime(ctx context.Context, provide
 		k8s.SetCondition(&provider.Status.Conditions, "ProviderRuntimeReady", metav1.ConditionFalse, "ServiceError", fmt.Sprintf("Failed to create service: %v", err))
 		provider.Status.Runtime.Phase = infravirtrigaudiov1beta1.ProviderRuntimePhaseFailed
 		provider.Status.Runtime.Message = err.Error()
+		metrics.RecordError(errReasonServiceReconcile, metrics.ComponentManager)
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
@@ -187,6 +228,7 @@ func (r *ProviderReconciler) reconcileRemoteRuntime(ctx context.Context, provide
 		k8s.SetCondition(&provider.Status.Conditions, "ProviderRuntimeReady", metav1.ConditionFalse, "DeploymentError", fmt.Sprintf("Failed to create deployment: %v", err))
 		provider.Status.Runtime.Phase = infravirtrigaudiov1beta1.ProviderRuntimePhaseFailed
 		provider.Status.Runtime.Message = err.Error()
+		metrics.RecordError(errReasonDeploymentReconcile, metrics.ComponentManager)
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 

--- a/internal/controller/provider_metrics_test.go
+++ b/internal/controller/provider_metrics_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
+)
+
+// newProviderMetricsScheme registers only the v1beta1 types needed by the
+// Provider reconciler tests. Helper-functions counterSample / labelsMatch
+// live in virtualmachine_metrics_test.go (same package).
+func newProviderMetricsScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	sch := runtime.NewScheme()
+	require.NoError(t, infravirtrigaudiov1beta1.AddToScheme(sch))
+	return sch
+}
+
+// TestProviderReconcile_Metrics_NotFoundIsSuccessOutcome — reconciling a
+// Provider that doesn't exist (IsNotFound) records the reconcile as
+// outcome=success. No error to controller-runtime; no work needed.
+func TestProviderReconcile_Metrics_NotFoundIsSuccessOutcome(t *testing.T) {
+	sch := newProviderMetricsScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(sch).Build()
+	r := &ProviderReconciler{Client: cli, Scheme: sch}
+
+	wantLabels := map[string]string{
+		"kind":    "Provider",
+		"outcome": metrics.OutcomeSuccess,
+	}
+	before := counterSample(t, "virtrigaud_manager_reconcile_total", wantLabels)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "ghost-provider", Namespace: "default"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result, "should return empty result for IsNotFound")
+
+	after := counterSample(t, "virtrigaud_manager_reconcile_total", wantLabels)
+	assert.Equal(t, before+1, after,
+		"reconcile of non-existent Provider should increment outcome=success counter by 1")
+}
+
+// TestProviderReconcile_Metrics_MissingRuntimeIsErrorOutcome — Provider
+// without a `spec.runtime` block fails fast with an error and records
+// outcome=error + errors_total{reason="runtime-spec-invalid"}. This is
+// the documented contract (runtime configuration is required).
+func TestProviderReconcile_Metrics_MissingRuntimeIsErrorOutcome(t *testing.T) {
+	sch := newProviderMetricsScheme(t)
+	prov := &infravirtrigaudiov1beta1.Provider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bad-provider",
+			Namespace: "default",
+		},
+		Spec: infravirtrigaudiov1beta1.ProviderSpec{
+			// Spec.Runtime is intentionally nil.
+			Type:     "mock",
+			Endpoint: "localhost:9090",
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(prov).
+		WithStatusSubresource(&infravirtrigaudiov1beta1.Provider{}).
+		Build()
+	r := &ProviderReconciler{Client: cli, Scheme: sch}
+
+	errorLabels := map[string]string{
+		"kind":    "Provider",
+		"outcome": metrics.OutcomeError,
+	}
+	invalidLabels := map[string]string{
+		"reason":    errReasonRuntimeSpecInvalid,
+		"component": metrics.ComponentManager,
+	}
+	beforeError := counterSample(t, "virtrigaud_manager_reconcile_total", errorLabels)
+	beforeInvalid := counterSample(t, "virtrigaud_errors_total", invalidLabels)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "bad-provider", Namespace: "default"},
+	})
+	require.Error(t, err, "missing runtime spec should return an error")
+
+	afterError := counterSample(t, "virtrigaud_manager_reconcile_total", errorLabels)
+	afterInvalid := counterSample(t, "virtrigaud_errors_total", invalidLabels)
+
+	assert.Equal(t, beforeError+1, afterError,
+		"missing-runtime reconcile should increment outcome=error counter")
+	assert.Equal(t, beforeInvalid+1, afterInvalid,
+		"missing-runtime reconcile should increment errors_total{reason=runtime-spec-invalid}")
+}
+
+// TestProviderReconcile_Metrics_DurationHistogramFires — smoke that the
+// histogram receives at least one observation under kind=Provider.
+func TestProviderReconcile_Metrics_DurationHistogramFires(t *testing.T) {
+	sch := newProviderMetricsScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(sch).Build()
+	r := &ProviderReconciler{Client: cli, Scheme: sch}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "ghost", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	families, err := metrics.GetRegistry().Gather()
+	require.NoError(t, err)
+
+	var sampleCount uint64
+	for _, f := range families {
+		if f.GetName() != "virtrigaud_manager_reconcile_duration_seconds" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if labelsMatch(m.GetLabel(), map[string]string{"kind": "Provider"}) {
+				if h := m.GetHistogram(); h != nil {
+					sampleCount += h.GetSampleCount()
+				}
+			}
+		}
+	}
+	assert.Greater(t, sampleCount, uint64(0),
+		"virtrigaud_manager_reconcile_duration_seconds{kind=Provider} should have at least one observation")
+}


### PR DESCRIPTION
## Summary
Second in the G-track sequence after [#101 (G1)](https://github.com/projectbeskar/virtrigaud/pull/101). Same pattern, applied to `ProviderReconciler`:
- Deferred reconcile timer infers outcome from named return values
- 6 `metrics.RecordError(reason, ComponentManager)` calls at documented error sites
- File-scoped `errReason*` taxonomy
- 3 new metrics tests (client/fake based, no envtest)

Closes #88. Umbrella: #86.

## What metrics now emit

| Family | Labels (added by this PR) |
|--------|---------------------------|
| `virtrigaud_manager_reconcile_total` | `{kind="Provider", outcome="success"\|"error"\|"requeue"}` |
| `virtrigaud_manager_reconcile_duration_seconds` | `{kind="Provider"}` |
| `virtrigaud_errors_total` | `{reason=..., component="manager"}` — see taxonomy below |

## Reason taxonomy (file-scoped constants)

| Constant | When | Outcome pair |
|----------|------|--------------|
| `get-provider` | k8s API error fetching Provider CR (non-NotFound) | error |
| `runtime-spec-invalid` | `spec.runtime` nil or `validateRemoteRuntimeSpec` fails (2 sites) | error |
| `service-reconcile-failed` | per-Provider Service create/update failed | error + requeue |
| `deployment-reconcile-failed` | per-Provider Deployment failed | error + requeue |
| `cleanup-failed` | deletion-path cleanup failed | error + requeue |

No collisions with VirtualMachineReconciler's taxonomy (different prefixes by file context).

## Test plan

```
$ go test -v -count=1 -run TestProviderReconcile_Metrics ./internal/controller/
=== RUN   TestProviderReconcile_Metrics_NotFoundIsSuccessOutcome
--- PASS: TestProviderReconcile_Metrics_NotFoundIsSuccessOutcome (0.00s)
=== RUN   TestProviderReconcile_Metrics_MissingRuntimeIsErrorOutcome
--- PASS: TestProviderReconcile_Metrics_MissingRuntimeIsErrorOutcome (0.00s)
=== RUN   TestProviderReconcile_Metrics_DurationHistogramFires
--- PASS: TestProviderReconcile_Metrics_DurationHistogramFires (0.00s)
PASS
```

### Gates
- [x] `go fmt`, `go vet`, `golangci-lint` clean
- [x] `make test` pass; **controller pkg coverage 21.6% → 22.4%** (cumulative with G1's bump from 20.8% → 21.6%)
- [x] `make test-integration` pass (no regressions)
- [ ] **CI on this PR**: expect green; if #102 (K4 intermittent checkout) hits, `gh run rerun --failed` workaround

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (new manager image needed to emit)
- [ ] Config change only
- [ ] Documentation only

Targeted for **v0.3.5**.

## Next after merge

G3 (#89) — remaining 6 reconcilers (VMClass, VMImage, VMNetworkAttachment, VMAdoption, VMMigration, VMSnapshot). Mostly mechanical after G1+G2 establish the pattern, plus an audit of the existing `NewReconcileTimer` calls in VMMigration/VMSnapshot to verify they actually fire on every reconcile path.