### PR TITLE
fix(ci): pin Build matrix checkout to v4 to mitigate K4 intermittent failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,15 @@ jobs:
       matrix:
         component: [manager, provider-libvirt, provider-vsphere, provider-proxmox]
     steps:
+      # K4 / #102: this matrix job is intermittently failing on
+      # actions/checkout@v6.0.2 with "fatal: could not read Username for
+      # https://github.com" during the fetch of pull/<N>/merge or post-merge
+      # SHA. The same v6.0.2 works fine in the test, lint, security, and
+      # build-images jobs in this same workflow. Pinning back to v4 here
+      # while we investigate. DO NOT bump this specific entry to v6 without
+      # resolving #102 first.
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4 (pinned for #102)
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-23 12:24] - fix(ci): pin Build matrix checkout to v4 to mitigate K4 intermittent failure (refs #102)
+**Author:** @williamrizzo (William Rizzo)
+
+### Fixed
+- `.github/workflows/ci.yml`: Pinned the `build` matrix job's `actions/checkout` from v6.0.2 (`de0fac2e...`) back to v4 (`34e114876b...`). Added a `DO NOT bump without resolving #102` comment so future contributors don't silently re-introduce the issue.
+
+### Why
+The `Build (...)` matrix in `ci.yml` (4 components: manager + 3 providers) has been intermittently failing during the `actions/checkout@v6.0.2` step with `fatal: could not read Username for 'https://github.com': terminal prompts disabled` (3 observed occurrences in 24 hours; tracked as #102). The same `v6.0.2` works fine on every other job in the same workflow (test, lint, security, build-tools, build-images). The asymmetry suggests something specific to this matrix's checkout invocation — possibly the parallel-fetch of the `pull/<N>/merge` ref racing against GitHub-side ref availability, or a regression introduced when PR #74 bumped checkout from v4 → v6 (PR #74 only touched ci.yml, not release.yml).
+
+This is a **partial fix** targeted at the most common K4 occurrence shape:
+- ✅ Addresses 2 of 3 observed occurrences (both in `ci.yml`'s `build` matrix)
+- ⚠️ Does NOT address release-time K4 (`release.yml`'s `build-and-push` matrix was already on v4 when occurrence 1 hit during the failed v0.3.3.1 release attempt; root cause likely different)
+- ⚠️ Does NOT pin `ci.yml`'s `build-images` matrix (no observed failures there; pinning preventively is over-fitting)
+
+If K4 continues to fire after this pin lands, the next move is to wrap the affected checkout in a retry action (e.g., `nick-fields/retry`) as a belt-and-suspenders measure regardless of root cause.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] Config change only (CI workflow)
+- [ ] Documentation only
+
+CI-only change.
+
+### Verification
+- [x] YAML syntax is valid (will be confirmed by CI's own self-load on this PR)
+- [ ] **CI on this PR runs cleanly** — if green on first try, the pin works AND we've already broken K4's per-PR pattern.
+- [ ] **Next ~5 PRs in the G-track also run cleanly on first try** — that's the real evidence the pin solved the per-cycle friction.
+
+If K4 still hits a future PR's `build` matrix despite this pin, that disproves the v6-regression hypothesis and we widen the search (retry wrapper, GitHub Actions infra investigation, etc.).
+
+### References
+- Refs #102 (not Closes — see "partial fix" caveat above; close #102 after we see ~10 consecutive K4-free CI runs across the next few PRs)
+- Original v4→v6 bump: PR #74
+- Affected runs: PR #101 CI (run 26331518215, succeeded on rerun), post-#101 main CI (run 26331986052, succeeded on rerun), failed v0.3.3.1 release attempt (run 26329718832, never re-attempted; re-cut as v0.3.4)
+
+---
+
 ## [2026-05-23 11:58] - feat(obs): instrument ProviderReconciler with reconcile timer + error counter (closes #88)
 **Author:** @williamrizzo (William Rizzo)
 


### PR DESCRIPTION
## Summary
One-line change to `.github/workflows/ci.yml`: pin the `Build (...)` matrix's `actions/checkout` from v6.0.2 → v4 to mitigate the K4 intermittent checkout failure pattern.

Refs #102. **Not Closes** — see partial-fix caveats below.

## The K4 pattern, in data

3 observations in 24 hours:

| # | When | Workflow | Job | Checkout @ | Outcome |
|---|------|----------|-----|------------|---------|
| 1 | 2026-05-22 | `release.yml` | `Build and Push Images (provider-proxmox)` | v4 | failed |
| 2 | 2026-05-23 morning | `ci.yml` | `Build (provider-proxmox)` | v6.0.2 | failed (rerun fixed) |
| 3 | 2026-05-23 mid-morning | `ci.yml` | `Build (manager)` | v6.0.2 | failed (rerun fixed) |

Error consistently:
```
[command]/usr/bin/git -c protocol.version=2 fetch ...
##[error]fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

The auth header IS configured (visible in logs) but the fetch doesn't seem to use it. 3 internal retries (12s spacing) all fail the same way. Manual `gh run rerun --failed` succeeds cleanly.

## Why pin specifically `ci.yml`'s `build` matrix

- Both `ci.yml` K4 occurrences are in this exact matrix entry
- The same `v6.0.2` works fine on every other `ci.yml` job (test, lint, security, build-tools, build-images)
- This is the matrix that gates everything else in `ci.yml` via `needs: build` — when it fails, downstream jobs cancel
- 5 LOC change, minimal blast radius

## ⚠️ This is a PARTIAL fix

Honest framing:

| What it addresses | What it doesn't |
|-------------------|-----------------|
| 2 of 3 observed K4 occurrences (both in `ci.yml` v6.0.2) | Release-time K4 (occurrence 1 was already on v4) |
| Per-PR friction from the Build matrix | Anything in `release.yml`'s matrix |
| Stops the most common pattern | Doesn't pin `ci.yml`'s `build-images` matrix preventively (no failures observed there) |

**Why not also pin `build-images` and `release.yml`?**
- `build-images` hasn't been observed failing K4. Pinning it without evidence would be over-fitting; the v4↔v6 difference isn't a guaranteed cure (occurrence 1 disproves that). If `build-images` hits K4 later, we'll have evidence then.
- `release.yml` was already on v4 when it hit K4. Pinning it to v4 (it already is) wouldn't change anything. A separate investigation is needed for the release-time pattern — possibly a retry-wrapper approach.

If this pin doesn't eliminate K4 on `ci.yml`'s Build matrix going forward, the next move is wrapping the checkout step in `nick-fields/retry@v3` regardless of root cause.

## Files changed
- `.github/workflows/ci.yml` — one checkout SHA changed (line 231) + an inline comment explaining why and warning future contributors not to bump it back to v6 without resolving #102
- `CHANGELOG.md` — entry with William Rizzo attribution + the full partial-fix framing

## Test plan
- [x] YAML syntactically valid (gates self-load on this PR)
- [ ] **CI on this PR runs cleanly on first attempt** — primary evidence. If green, the pin works AND we've already broken the per-PR pattern.
- [ ] **Next ~5 G-track PRs also run cleanly on first try** — that's the real evidence we've solved the per-cycle friction.

## Closing criteria for #102
Close #102 after **~10 consecutive K4-free CI runs across the next few PRs**. Until then keep the issue open with the partial-fix note.

## Impact
- [ ] Breaking change
- [ ] Requires cluster rollout
- [x] Config change only (CI workflow)
- [ ] Documentation only

CI-only.

## Sequence after merge
Once this merges and the next ~5 PRs confirm the pattern is broken, we resume the G-track:
- #89 G3 — remaining 6 reconcilers (mechanical mirror of G1/G2)
- #90 G4 — gRPC client middleware
- #91 G5 — circuit breaker hooks
- #92 H1 — orphan files cleanup
- #94 C2-B — Dependabot Tier B pair