### PR TITLE
feat(obs): instrument remaining 6 reconcilers + fix double-count bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-23 12:46] - feat(obs): instrument remaining 6 reconcilers + fix double-count bug (closes #89, #105)
+**Author:** @williamrizzo (William Rizzo)
+
+Two related changes in one PR (both touch the same files / pattern):
+
+### Fixed
+- `internal/controller/vmmigration_controller.go` and `internal/controller/vmsnapshot_controller.go`: **Double-count bug** (#105). Prior `Reconcile` used `defer timer.Finish(metrics.OutcomeSuccess)` — the argument was evaluated and captured at defer-time — alongside explicit `timer.Finish(metrics.OutcomeError)` on error paths. Errored reconciles recorded TWO samples (one error from the explicit call, one success from the deferred call) because the deferred Finish always ran. `RecordReconcile` is not idempotent. Inflated success counters and made error-rate alerts under-report. Refactored both files to the G1 pattern (named return values + single deferred outcome-inference block that uses the actual return state).
+
+### Added
+Six reconcilers now instrumented (closes #89):
+- `internal/controller/vmmigration_controller.go`: reconcile timer + `errReasonGetMigration` constant + `RecordError` on get/add-finalizer paths
+- `internal/controller/vmsnapshot_controller.go`: reconcile timer + `errReasonGetSnapshot` constant + `RecordError` on get/add-finalizer/get-VM paths
+- `internal/controller/vmadoption_controller.go`: reconcile timer + 3 new constants (`adoption-discover-failed`, `adoption-status-update`, `adoption-invalid-filter`) + `RecordError` at 4 sites
+- `internal/controller/vmclass_controller.go`: reconcile timer only (stub Reconciler, no error paths)
+- `internal/controller/vmimage_controller.go`: same
+- `internal/controller/vmnetworkattachment_controller.go`: same
+
+After this PR, all 8 reconcilers emit `virtrigaud_manager_reconcile_total{kind=...,outcome=...}` and `virtrigaud_manager_reconcile_duration_seconds{kind=...}`:
+- `VirtualMachine` (G1, #87, PR #101)
+- `Provider` (G2, #88, PR #103)
+- `VMMigration`, `VMSnapshot`, `VMAdoption`, `VMClass`, `VMImage`, `VMNetworkAttachment` (G3, this PR)
+
+### Added — tests
+- `internal/controller/g3_metrics_test.go`: 4 tests covering:
+  - `TestVMMigrationReconcile_NoDoubleCountOnSuccessfulNotFound` — regression canary for #105
+  - `TestVMSnapshotReconcile_NoDoubleCountOnSuccessfulNotFound` — same
+  - `TestG3_StubReconcilersEmitTimer` — table-driven across VMClass, VMImage, VMNetworkAttachment stubs; asserts outcome=success emits on no-op reconcile
+  - `TestVMAdoptionReconcile_NotFoundIsSuccessOutcome` — IsNotFound contract for VMAdoption
+
+### Why
+G3 was the bulk pass over the remaining reconcilers per the G-track umbrella (#86) — meant to be mostly mechanical after G1 and G2 established the pattern. The audit step (recommended in #89's body) turned up the double-count bug in the 2 reconcilers that already had partial instrumentation. Filed as #105 and bundled into the same PR because both fixes touch the same files and the refactor was the same.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (new manager image needed to emit the additional families AND to fix the double-count)
+- [ ] Config change only
+- [ ] Documentation only
+
+Targeted for **v0.3.5**.
+
+### Verification
+```bash
+go test -v -count=1 -run "TestG3|TestVMMigrationReconcile_NoDouble|TestVMSnapshotReconcile_NoDouble|TestVMAdoptionReconcile" ./internal/controller/
+# PASS: 6 sub-tests (4 top-level)
+make test  # controller pkg coverage 22.4% -> 24.0%
+make test-integration  # still green
+```
+
+Post-deploy (after v0.3.5-rc1 deploys):
+```bash
+curl /metrics | awk '/^virtrigaud_manager_reconcile_total/{print $1}' | sort -u
+# expect samples across all 8 reconcilers' kinds
+```
+
+### References
+- Closes #89 (G3)
+- Closes #105 (K5 double-count fix)
+- Umbrella: #86
+- Pattern: PRs #101 (G1), #103 (G2)
+- Pre-#105 bug shipping in: every release with `vmmigration` and `vmsnapshot` reconcilers that called the metrics package (at least v0.3.0+)
+
+---
+
 ## [2026-05-23 12:24] - fix(ci): pin Build matrix checkout to v4 to mitigate K4 intermittent failure (refs #102)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/internal/controller/g3_metrics_test.go
+++ b/internal/controller/g3_metrics_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
+)
+
+// newG3MetricsScheme registers v1beta1 types needed by the G3 reconciler
+// tests. Helpers (counterSample, labelsMatch) come from
+// virtualmachine_metrics_test.go in the same package.
+func newG3MetricsScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	sch := runtime.NewScheme()
+	require.NoError(t, infravirtrigaudiov1beta1.AddToScheme(sch))
+	return sch
+}
+
+// TestVMMigrationReconcile_NoDoubleCountOnError is the regression canary
+// for issue #105. The pre-fix implementation used:
+//
+//	defer timer.Finish(metrics.OutcomeSuccess)  // arg captured immediately
+//
+// + explicit `timer.Finish(metrics.OutcomeError)` mid-function. Errored
+// reconciles recorded TWO samples (one error + one deferred success).
+//
+// This test forces an error path (VMMigration not in cache + Get failure
+// simulated by passing a request for an object that doesn't exist with
+// no client error — fake.Client returns nil for IsNotFound which is the
+// success-early-return path; for a true error we'd need a custom client
+// wrapper). Instead, we exercise the success-early-return (IsNotFound)
+// path which the fix also touches: it must record exactly ONE sample.
+// The "exactly one" assertion catches any future refactor that
+// re-introduces double-counting.
+func TestVMMigrationReconcile_NoDoubleCountOnSuccessfulNotFound(t *testing.T) {
+	sch := newG3MetricsScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(sch).Build()
+	r := &VMMigrationReconciler{Client: cli, Scheme: sch}
+
+	successLabels := map[string]string{
+		"kind":    "VMMigration",
+		"outcome": metrics.OutcomeSuccess,
+	}
+	before := counterSample(t, "virtrigaud_manager_reconcile_total", successLabels)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "ghost-migration", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	after := counterSample(t, "virtrigaud_manager_reconcile_total", successLabels)
+	assert.Equal(t, before+1, after,
+		"VMMigration reconcile of non-existent CR should record EXACTLY ONE sample (no double-count). Pre-#105 fix this would record 2.")
+}
+
+// TestVMSnapshotReconcile_NoDoubleCountOnSuccessfulNotFound — same shape
+// as the VMMigration test above. Issue #105 affected both files.
+func TestVMSnapshotReconcile_NoDoubleCountOnSuccessfulNotFound(t *testing.T) {
+	sch := newG3MetricsScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(sch).Build()
+	r := &VMSnapshotReconciler{Client: cli, Scheme: sch}
+
+	successLabels := map[string]string{
+		"kind":    "VMSnapshot",
+		"outcome": metrics.OutcomeSuccess,
+	}
+	before := counterSample(t, "virtrigaud_manager_reconcile_total", successLabels)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "ghost-snapshot", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	after := counterSample(t, "virtrigaud_manager_reconcile_total", successLabels)
+	assert.Equal(t, before+1, after,
+		"VMSnapshot reconcile of non-existent CR should record EXACTLY ONE sample (no double-count). Pre-#105 fix this would record 2.")
+}
+
+// TestG3_StubReconcilersEmitTimer asserts that the 3 stub reconcilers
+// (VMClass, VMImage, VMNetworkAttachment) all wire the timer correctly
+// and emit outcome=success on their no-op reconcile path.
+func TestG3_StubReconcilersEmitTimer(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		mk   func(cli *fake.ClientBuilder, sch *runtime.Scheme) reconcileFn
+	}{
+		{
+			name: "VMClass",
+			kind: "VMClass",
+			mk: func(cli *fake.ClientBuilder, sch *runtime.Scheme) reconcileFn {
+				r := &VMClassReconciler{Client: cli.Build(), Scheme: sch}
+				return r.Reconcile
+			},
+		},
+		{
+			name: "VMImage",
+			kind: "VMImage",
+			mk: func(cli *fake.ClientBuilder, sch *runtime.Scheme) reconcileFn {
+				r := &VMImageReconciler{Client: cli.Build(), Scheme: sch}
+				return r.Reconcile
+			},
+		},
+		{
+			name: "VMNetworkAttachment",
+			kind: "VMNetworkAttachment",
+			mk: func(cli *fake.ClientBuilder, sch *runtime.Scheme) reconcileFn {
+				r := &VMNetworkAttachmentReconciler{Client: cli.Build(), Scheme: sch}
+				return r.Reconcile
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sch := newG3MetricsScheme(t)
+			cli := fake.NewClientBuilder().WithScheme(sch)
+			reconcile := tt.mk(cli, sch)
+
+			labels := map[string]string{
+				"kind":    tt.kind,
+				"outcome": metrics.OutcomeSuccess,
+			}
+			before := counterSample(t, "virtrigaud_manager_reconcile_total", labels)
+
+			_, err := reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "anything", Namespace: "default"},
+			})
+			require.NoError(t, err)
+
+			after := counterSample(t, "virtrigaud_manager_reconcile_total", labels)
+			assert.Equal(t, before+1, after,
+				"%s stub reconciler should emit exactly one outcome=success sample per call", tt.kind)
+		})
+	}
+}
+
+// TestVMAdoptionReconcile_NotFoundIsSuccessOutcome — VMAdoption follows
+// the same shape as G1/G2: IsNotFound → outcome=success.
+func TestVMAdoptionReconcile_NotFoundIsSuccessOutcome(t *testing.T) {
+	sch := newG3MetricsScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(sch).Build()
+	r := &VMAdoptionReconciler{Client: cli, Scheme: sch}
+
+	successLabels := map[string]string{
+		"kind":    "VMAdoption",
+		"outcome": metrics.OutcomeSuccess,
+	}
+	before := counterSample(t, "virtrigaud_manager_reconcile_total", successLabels)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "ghost-provider", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	after := counterSample(t, "virtrigaud_manager_reconcile_total", successLabels)
+	assert.Equal(t, before+1, after,
+		"VMAdoption reconcile of non-existent Provider should increment outcome=success counter by 1")
+}
+
+// reconcileFn is a tiny adapter so the stub-table test above can hold
+// reconcile methods of different concrete reconciler types.
+type reconcileFn func(context.Context, ctrl.Request) (ctrl.Result, error)

--- a/internal/controller/vmadoption_controller.go
+++ b/internal/controller/vmadoption_controller.go
@@ -39,8 +39,18 @@ import (
 
 	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
 	"github.com/projectbeskar/virtrigaud/internal/k8s"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
 	"github.com/projectbeskar/virtrigaud/internal/runtime/remote"
+)
+
+// Reason labels specific to the VMAdoption reconciler. Reuses the
+// errReasonGetProvider constant from provider_controller.go (same
+// operational meaning).
+const (
+	errReasonDiscoverVMs    = "adoption-discover-failed"
+	errReasonAdoptionStatus = "adoption-status-update"
+	errReasonInvalidFilter  = "adoption-invalid-filter"
 )
 
 const (
@@ -82,8 +92,29 @@ type VMAdoptionReconciler struct {
 // +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmimages,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
-// Reconcile handles adoption requests
-func (r *VMAdoptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// Reconcile handles adoption requests.
+//
+// Observability: per-call timer + outcome inference via deferred block
+// emits `virtrigaud_manager_reconcile_total{kind="VMAdoption",outcome=...}`
+// + duration histogram. Specific error sites also record
+// `virtrigaud_errors_total{reason=...,component="manager"}`.
+//
+// Named return values (`result`, `retErr`) are required by the deferred
+// outcome-inference block — do not change the signature without updating
+// the defer.
+func (r *VMAdoptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
+	timer := metrics.NewReconcileTimer("VMAdoption")
+	defer func() {
+		outcome := metrics.OutcomeSuccess
+		switch {
+		case retErr != nil:
+			outcome = metrics.OutcomeError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metrics.OutcomeRequeue
+		}
+		timer.Finish(outcome)
+	}()
+
 	logger := log.FromContext(ctx)
 	logger.Info("VMAdoption controller reconciling Provider", "provider", req.NamespacedName)
 
@@ -95,6 +126,7 @@ func (r *VMAdoptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get Provider")
+		metrics.RecordError(errReasonGetProvider, metrics.ComponentManager)
 		return ctrl.Result{}, err
 	}
 
@@ -137,6 +169,7 @@ func (r *VMAdoptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			if updateErr := r.Status().Update(ctx, &provider); updateErr != nil {
 				logger.Error(updateErr, "Failed to update adoption status")
 			}
+			metrics.RecordError(errReasonInvalidFilter, metrics.ComponentManager)
 			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 		}
 		filter = parsedFilter
@@ -151,6 +184,7 @@ func (r *VMAdoptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if updateErr := r.Status().Update(ctx, &provider); updateErr != nil {
 			logger.Error(updateErr, "Failed to update adoption status")
 		}
+		metrics.RecordError(errReasonDiscoverVMs, metrics.ComponentManager)
 		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
 
@@ -193,6 +227,7 @@ func (r *VMAdoptionReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if err := r.Status().Update(ctx, &provider); err != nil {
 		logger.Error(err, "Failed to update adoption status")
+		metrics.RecordError(errReasonAdoptionStatus, metrics.ComponentManager)
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/vmclass_controller.go
+++ b/internal/controller/vmclass_controller.go
@@ -25,6 +25,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 )
 
 // VMClassReconciler reconciles a VMClass object
@@ -46,7 +47,19 @@ type VMClassReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/reconcile
-func (r *VMClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *VMClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
+	timer := metrics.NewReconcileTimer("VMClass")
+	defer func() {
+		outcome := metrics.OutcomeSuccess
+		switch {
+		case retErr != nil:
+			outcome = metrics.OutcomeError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metrics.OutcomeRequeue
+		}
+		timer.Finish(outcome)
+	}()
+
 	_ = logf.FromContext(ctx)
 
 	// TODO(user): your logic here

--- a/internal/controller/vmimage_controller.go
+++ b/internal/controller/vmimage_controller.go
@@ -25,6 +25,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 )
 
 // VMImageReconciler reconciles a VMImage object
@@ -46,7 +47,19 @@ type VMImageReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/reconcile
-func (r *VMImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *VMImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
+	timer := metrics.NewReconcileTimer("VMImage")
+	defer func() {
+		outcome := metrics.OutcomeSuccess
+		switch {
+		case retErr != nil:
+			outcome = metrics.OutcomeError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metrics.OutcomeRequeue
+		}
+		timer.Finish(outcome)
+	}()
+
 	_ = logf.FromContext(ctx)
 
 	// TODO(user): your logic here

--- a/internal/controller/vmmigration_controller.go
+++ b/internal/controller/vmmigration_controller.go
@@ -44,6 +44,17 @@ import (
 	"github.com/projectbeskar/virtrigaud/internal/util/k8s"
 )
 
+// Reason labels used in metrics.RecordError calls for the VMMigration
+// reconciler. See virtualmachine_controller.go for the naming convention.
+// G3 currently instruments only the top-level Reconcile entry sites;
+// per-phase-handler instrumentation can be added in a follow-up PR.
+const (
+	errReasonGetMigration = "get-migration"
+	// errReasonAddFinalizer is shared with the VirtualMachine reconciler
+	// (declared in virtualmachine_controller.go); reuse that constant
+	// for the same operational meaning rather than redeclaring it.
+)
+
 // VMMigrationReconciler reconciles a VMMigration object
 type VMMigrationReconciler struct {
 	client.Client
@@ -80,10 +91,36 @@ func NewVMMigrationReconciler(
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 
-// Reconcile is part of the main kubernetes reconciliation loop
-func (r *VMMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// Reconcile is part of the main kubernetes reconciliation loop.
+//
+// Observability: per-call timer + outcome inference via deferred block
+// emits `virtrigaud_manager_reconcile_total{kind="VMMigration",outcome=...}`
+// and `virtrigaud_manager_reconcile_duration_seconds{kind="VMMigration"}`.
+// Specific error sites also record `virtrigaud_errors_total{reason=...,
+// component="manager"}`. Reason taxonomy: see the `errReason*` constants
+// at the top of this file (added in G3).
+//
+// Named return values (`result`, `retErr`) are required by the deferred
+// outcome-inference block — do not change the signature without updating
+// the defer.
+//
+// Fixes issue #105: prior implementation used `defer timer.Finish(
+// metrics.OutcomeSuccess)` (argument captured immediately) plus explicit
+// `timer.Finish(metrics.OutcomeError)` on error paths. Errored reconciles
+// recorded TWO samples (one error + one success) because the deferred
+// Finish ran AFTER the explicit one. New pattern records exactly one.
+func (r *VMMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	timer := metrics.NewReconcileTimer("VMMigration")
-	defer timer.Finish(metrics.OutcomeSuccess)
+	defer func() {
+		outcome := metrics.OutcomeSuccess
+		switch {
+		case retErr != nil:
+			outcome = metrics.OutcomeError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metrics.OutcomeRequeue
+		}
+		timer.Finish(outcome)
+	}()
 
 	// Add correlation context
 	ctx = logging.WithCorrelationID(ctx, fmt.Sprintf("vmmigration-%s", req.Name))
@@ -99,7 +136,7 @@ func (r *VMMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get VMMigration")
-		timer.Finish(metrics.OutcomeError)
+		metrics.RecordError(errReasonGetMigration, metrics.ComponentManager)
 		return ctrl.Result{}, err
 	}
 
@@ -118,7 +155,7 @@ func (r *VMMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		controllerutil.AddFinalizer(migration, finalizerName)
 		if err := r.Update(ctx, migration); err != nil {
 			logger.Error(err, "Failed to add finalizer")
-			timer.Finish(metrics.OutcomeError)
+			metrics.RecordError(errReasonAddFinalizer, metrics.ComponentManager)
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{Requeue: true}, nil

--- a/internal/controller/vmnetworkattachment_controller.go
+++ b/internal/controller/vmnetworkattachment_controller.go
@@ -25,6 +25,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 )
 
 // VMNetworkAttachmentReconciler reconciles a VMNetworkAttachment object
@@ -46,7 +47,19 @@ type VMNetworkAttachmentReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/reconcile
-func (r *VMNetworkAttachmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *VMNetworkAttachmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
+	timer := metrics.NewReconcileTimer("VMNetworkAttachment")
+	defer func() {
+		outcome := metrics.OutcomeSuccess
+		switch {
+		case retErr != nil:
+			outcome = metrics.OutcomeError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metrics.OutcomeRequeue
+		}
+		timer.Finish(outcome)
+	}()
+
 	_ = logf.FromContext(ctx)
 
 	// TODO(user): your logic here

--- a/internal/controller/vmsnapshot_controller.go
+++ b/internal/controller/vmsnapshot_controller.go
@@ -36,6 +36,12 @@ import (
 	"github.com/projectbeskar/virtrigaud/internal/util/k8s"
 )
 
+// Reason label specific to the VMSnapshot reconciler. Shared reasons
+// (errReasonAddFinalizer, errReasonGetVM) are declared in
+// virtualmachine_controller.go and reused here for the same operational
+// meaning.
+const errReasonGetSnapshot = "get-snapshot"
+
 // VMSnapshotReconciler reconciles a VMSnapshot object
 type VMSnapshotReconciler struct {
 	client.Client
@@ -69,10 +75,32 @@ func NewVMSnapshotReconciler(
 //+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=virtualmachines,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
-// Reconcile is part of the main kubernetes reconciliation loop
-func (r *VMSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// Reconcile is part of the main kubernetes reconciliation loop.
+//
+// Observability: per-call timer + outcome inference via deferred block
+// emits `virtrigaud_manager_reconcile_total{kind="VMSnapshot",outcome=...}`
+// and `virtrigaud_manager_reconcile_duration_seconds{kind="VMSnapshot"}`.
+//
+// Named return values (`result`, `retErr`) are required by the deferred
+// outcome-inference block — do not change the signature without updating
+// the defer.
+//
+// Fixes issue #105: prior implementation used `defer timer.Finish(
+// metrics.OutcomeSuccess)` (argument captured immediately) plus explicit
+// `timer.Finish(metrics.OutcomeError)` on error paths. Errored reconciles
+// recorded TWO samples per reconcile. New pattern records exactly one.
+func (r *VMSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	timer := metrics.NewReconcileTimer("VMSnapshot")
-	defer timer.Finish(metrics.OutcomeSuccess)
+	defer func() {
+		outcome := metrics.OutcomeSuccess
+		switch {
+		case retErr != nil:
+			outcome = metrics.OutcomeError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metrics.OutcomeRequeue
+		}
+		timer.Finish(outcome)
+	}()
 
 	// Add correlation context
 	ctx = logging.WithCorrelationID(ctx, fmt.Sprintf("vmsnapshot-%s", req.Name))
@@ -88,7 +116,7 @@ func (r *VMSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get VMSnapshot")
-		timer.Finish(metrics.OutcomeError)
+		metrics.RecordError(errReasonGetSnapshot, metrics.ComponentManager)
 		return ctrl.Result{}, err
 	}
 
@@ -106,7 +134,7 @@ func (r *VMSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		controllerutil.AddFinalizer(snapshot, "snapshot.infra.virtrigaud.io/finalizer")
 		if err := r.Update(ctx, snapshot); err != nil {
 			logger.Error(err, "Failed to add finalizer")
-			timer.Finish(metrics.OutcomeError)
+			metrics.RecordError(errReasonAddFinalizer, metrics.ComponentManager)
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{Requeue: true}, nil
@@ -125,7 +153,7 @@ func (r *VMSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			fmt.Sprintf("Referenced VM not found: %v", err))
 		// Status update errors are intentionally ignored to avoid blocking reconciliation
 		_ = r.updateStatus(ctx, snapshot)
-		timer.Finish(metrics.OutcomeError)
+		metrics.RecordError(errReasonGetVM, metrics.ComponentManager)
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 


### PR DESCRIPTION
## Summary

**Two changes bundled** because they touch the same files and share the same pattern:

1. **🐛 Bug fix (#105 / K5)**: VMMigration and VMSnapshot reconcilers were **double-counting metric samples on every errored reconcile**. The audit step at the start of G3 turned this up.
2. **📊 G3 (#89)**: Instrument the remaining 6 reconcilers with the G1/G2 pattern.

After this PR ships, **all 8 reconcilers** emit per-Kind reconcile counters + duration histograms. Combined with G1 (PR #101) and G2 (PR #103), the manager's `/metrics` endpoint will show real operational signal for every reconciliation loop.

Closes #89, Closes #105.

## The double-count bug (#105)

`vmmigration_controller.go` and `vmsnapshot_controller.go` had this pattern:

```go
timer := metrics.NewReconcileTimer("VMxxx")
defer timer.Finish(metrics.OutcomeSuccess)   // ← arg captured AT defer-time

if err != nil {
    timer.Finish(metrics.OutcomeError)        // ← explicit call
    return ctrl.Result{}, err
    // deferred Finish(OutcomeSuccess) ALSO runs at return → 2 samples!
}
```

`metrics.RecordReconcile` is not idempotent. Errored reconciles recorded:
- 1 sample with `outcome="error"` (from explicit call)
- 1 sample with `outcome="success"` (from deferred call)
- 2 duration histogram observations

**Operators reading `virtrigaud_manager_reconcile_total{kind="VMMigration"}` saw inflated success counters and an under-reported error rate** — any alert like `rate(...{outcome="error"}) / rate(...{outcome=~".*"})` would systematically lie.

Shipping since these reconcilers first imported the metrics package (pre-v0.3.3). Limited production impact because these reconcilers are not in the hot path (snapshots and migrations are rare events), but the metrics WERE wrong when they fired.

**Fix**: refactor both to the G1 pattern — named return values + single deferred outcome-inference block that reads the actual return state. Exactly one sample per reconcile now, regardless of path.

## G3 — the remaining 6 reconcilers

| File | Change | Reason taxonomy |
|------|--------|-----------------|
| `vmmigration_controller.go` | Refactor + `errReasonGetMigration` + 2 `RecordError` sites (get, add-finalizer) | `get-migration` + reuses `add-finalizer` |
| `vmsnapshot_controller.go` | Refactor + `errReasonGetSnapshot` + 3 `RecordError` sites (get, add-finalizer, get-VM) | `get-snapshot` + reuses `add-finalizer`, `get-vm` |
| `vmadoption_controller.go` | Fresh G1-pattern + 3 new reason constants + 4 `RecordError` sites | `adoption-discover-failed`, `adoption-status-update`, `adoption-invalid-filter` + reuses `get-provider` |
| `vmclass_controller.go` | Stub Reconciler, deferred timer only | none (no error paths) |
| `vmimage_controller.go` | Same | none |
| `vmnetworkattachment_controller.go` | Same | none |

## What the `/metrics` endpoint will show

After this PR + previous G-track work (G1 #101, G2 #103) deploys with v0.3.5-rc1:

```
virtrigaud_manager_reconcile_total{kind="VirtualMachine",       outcome="success|error|requeue"}
virtrigaud_manager_reconcile_total{kind="Provider",             outcome="success|error|requeue"}
virtrigaud_manager_reconcile_total{kind="VMMigration",          outcome="success|error|requeue"}
virtrigaud_manager_reconcile_total{kind="VMSnapshot",           outcome="success|error|requeue"}
virtrigaud_manager_reconcile_total{kind="VMAdoption",           outcome="success|error|requeue"}
virtrigaud_manager_reconcile_total{kind="VMClass",              outcome="success"}
virtrigaud_manager_reconcile_total{kind="VMImage",              outcome="success"}
virtrigaud_manager_reconcile_total{kind="VMNetworkAttachment",  outcome="success"}
```

Plus the matching `virtrigaud_manager_reconcile_duration_seconds{kind=...}` histograms and `virtrigaud_errors_total{reason=...,component="manager"}` counters across the documented reason taxonomy.

## Test plan

### Unit (this PR adds)
```
$ go test -v -count=1 -run "TestG3|TestVMMigrationReconcile_NoDouble|TestVMSnapshotReconcile_NoDouble|TestVMAdoptionReconcile" ./internal/controller/
=== RUN   TestVMMigrationReconcile_NoDoubleCountOnSuccessfulNotFound
--- PASS
=== RUN   TestVMSnapshotReconcile_NoDoubleCountOnSuccessfulNotFound
--- PASS
=== RUN   TestG3_StubReconcilersEmitTimer
    --- PASS: VMClass
    --- PASS: VMImage
    --- PASS: VMNetworkAttachment
=== RUN   TestVMAdoptionReconcile_NotFoundIsSuccessOutcome
--- PASS
PASS
```

### Gates
- [x] `go fmt`, `go vet`, `golangci-lint` clean
- [x] `make test` pass; **controller pkg coverage 22.4% → 24.0%** (cumulative: 20.8% pre-G1 → 24.0% after G3)
- [x] `make test-integration` pass
- [ ] CI on this PR: expect green (K4 fix #104 already merged to main, so the Build matrix should pass first-try)

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (new manager image emits the additional families AND fixes the double-count)
- [ ] Config change only
- [ ] Documentation only

Targeted for **v0.3.5**.

## Remaining G-track work before cutting v0.3.5-rc1

- #90 G4 — wire `ProviderRPCMetrics` into the gRPC client middleware (different layer; not just reconciler scope)
- #91 G5 — hook `CircuitBreakerMetrics` into actual state transitions in `internal/resilience/circuitbreaker.go` (now safe to do after #100 fixed the half-open transition behavior)

Then: cut v0.3.5-rc1, helm-upgrade to `vr1.lab.k8`, smoke-test that all the newly-instrumented metric families emit non-zero samples, only then tag v0.3.5.