### PR TITLE
feat(obs): wire ProviderRPCMetrics into gRPC client middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-23 13:31] - feat(obs): wire ProviderRPCMetrics into gRPC client middleware (closes #90)
+**Author:** @williamrizzo (William Rizzo)
+
+### Added
+- `internal/transport/grpc/client.go`: New `providerRPCMetricsInterceptor(providerType)` returns a `grpc.UnaryClientInterceptor` that wraps every outbound provider RPC. On each call it records `virtrigaud_provider_rpc_requests_total{provider_type,method,code}` and `virtrigaud_provider_rpc_latency_seconds{provider_type,method}` via the existing `metrics.NewRPCTimer` API.
+- `internal/transport/grpc/client.go`: New `shortRPCMethod(fullMethod)` helper that extracts the RPC name from gRPC's full path (`/provider.v1.Provider/Validate` → `Validate`).
+- `internal/transport/grpc/client.go`: New `grpcCodeString(err)` helper that returns the canonical gRPC status code string (`"OK"`, `"Unavailable"`, `"DeadlineExceeded"`, etc.) for the metric `code` label.
+- `internal/transport/grpc/client_metrics_test.go`: New file. 5 tests / 15 sub-cases covering: `shortRPCMethod` parsing (6 edge cases), `grpcCodeString` mapping (5 codes incl. nil and non-gRPC errors), and 4 bufconn-based integration tests exercising the interceptor against an in-process gRPC server (successful call, error propagation, latency histogram, deadline-exceeded). No real network.
+
+### Changed
+- `internal/transport/grpc/client.go`: `NewClient` signature now takes a `providerType string` parameter inserted between `endpoint` and `tlsConfig`. The new parameter populates the `provider_type` metric label on every RPC made through this client. Empty string is permitted (label will be empty) but production callers should pass `provider.Spec.Type`.
+- `internal/runtime/remote/resolver.go`: Updated the sole caller of `NewClient` to pass `string(provider.Spec.Type)` (the only callsite repo-wide; verified by `grep -rn "transport/grpc\".NewClient" --include="*.go"`).
+
+### Why
+Fourth in the G-track. Per-RPC latency + error code is the most operationally valuable single signal for the remote-provider architecture: it answers "which RPC method is slow?", "which provider type is flapping?", "are gRPC errors concentrated on specific endpoints?", and "what's our SLO baseline?" — questions that per-Kind reconcile counters (G1-G3) can't.
+
+The interceptor is the natural insertion point — every gRPC call goes through it without per-callsite changes. The 17+ `c.client.XXX(...)` callsites in `client.go` need no edits.
+
+Coordinates with ADR-0001 follow-up F3 (interceptor coverage audit) — this PR establishes the metrics interceptor; future PRs can layer logging/tracing interceptors using the same pattern.
+
+### Impact
+- [ ] Breaking change to public API (the `NewClient` signature change is internal-only; only `internal/runtime/remote/resolver.go` uses it; verified)
+- [x] Requires cluster rollout (new manager image needed to emit the additional families)
+- [ ] Config change only
+- [ ] Documentation only
+
+Targeted for **v0.3.5**.
+
+### Verification
+```bash
+go test -v -count=1 -run "TestShortRPCMethod|TestGrpcCodeString|TestProviderRPCMetricsInterceptor" ./internal/transport/grpc/
+# PASS: 5 tests / 15 sub-cases
+make test  # transport/grpc pkg coverage 0% -> 9.2% (first tests in this package)
+make test-integration  # still green
+```
+
+Post-deploy (after v0.3.5-rc1):
+```bash
+curl /metrics | grep '^virtrigaud_provider_rpc_requests_total'
+# expect samples with provider_type=libvirt|vsphere|proxmox, method=Validate|Create|Describe|..., code=OK|Unavailable|...
+curl /metrics | grep '^virtrigaud_provider_rpc_latency_seconds_bucket'
+# expect populated histogram per provider_type x method combination
+```
+
+### References
+- Closes #90
+- Umbrella: #86
+- Pattern: PRs #101 (G1), #103 (G2), #106 (G3 + K5)
+- Coordinates with ADR-0001 F3
+
+---
+
 ## [2026-05-23 12:46] - feat(obs): instrument remaining 6 reconcilers + fix double-count bug (closes #89, #105)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/internal/runtime/remote/resolver.go
+++ b/internal/runtime/remote/resolver.go
@@ -87,7 +87,9 @@ func (r *Resolver) getRemoteProvider(ctx context.Context, provider *infravirtrig
 		return nil, fmt.Errorf("failed to build TLS config: %w", err)
 	}
 
-	client, err := grpcClient.NewClient(ctx, provider.Status.Runtime.Endpoint, tlsConfig)
+	// provider.Spec.Type populates the `provider_type` label on every
+	// virtrigaud_provider_rpc_* sample emitted by this client (G4 / #90).
+	client, err := grpcClient.NewClient(ctx, provider.Status.Runtime.Endpoint, string(provider.Spec.Type), tlsConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC client: %w", err)
 	}

--- a/internal/transport/grpc/client.go
+++ b/internal/transport/grpc/client.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -31,6 +32,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
 	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
 )
@@ -41,8 +43,14 @@ type Client struct {
 	client providerv1.ProviderClient
 }
 
-// NewClient creates a new gRPC provider client
-func NewClient(ctx context.Context, endpoint string, tlsConfig *TLSConfig) (*Client, error) {
+// NewClient creates a new gRPC provider client.
+//
+// providerType is the value of the Provider CR's spec.type field (e.g.
+// "vsphere", "libvirt", "proxmox", "mock") and is used as a metric label
+// on every RPC call made through this client. Passing an empty string is
+// permitted (the label will be empty) but discouraged in production —
+// makes per-provider-type alerts impossible.
+func NewClient(ctx context.Context, endpoint string, providerType string, tlsConfig *TLSConfig) (*Client, error) {
 	// Connection timeout is handled by grpc.NewClient internally
 	_ = ctx // Context available for future timeout implementation
 
@@ -64,6 +72,9 @@ func NewClient(ctx context.Context, endpoint string, tlsConfig *TLSConfig) (*Cli
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
 		),
+		// G4 (#90): record per-RPC latency + status code into the
+		// virtrigaud_provider_rpc_* metric families.
+		grpc.WithUnaryInterceptor(providerRPCMetricsInterceptor(providerType)),
 	)
 
 	conn, err := grpc.NewClient(endpoint, opts...)
@@ -76,6 +87,55 @@ func NewClient(ctx context.Context, endpoint string, tlsConfig *TLSConfig) (*Cli
 		conn:   conn,
 		client: client,
 	}, nil
+}
+
+// providerRPCMetricsInterceptor returns a UnaryClientInterceptor that
+// records every outbound RPC call's latency and gRPC status code to
+// virtrigaud_provider_rpc_requests_total{provider_type,method,code} and
+// virtrigaud_provider_rpc_latency_seconds{provider_type,method}.
+//
+// `method` is the proto-RPC short name (e.g. "Validate", "Create",
+// "Describe"), extracted from the full gRPC method path. `code` is the
+// stringified gRPC status code ("OK", "Unavailable", "DeadlineExceeded",
+// etc.). On nil error, code is "OK" by gRPC convention.
+//
+// The interceptor must never fail (panic, etc.) — if it did, every
+// provider RPC would break. We keep it intentionally minimal.
+func providerRPCMetricsInterceptor(providerType string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		fullMethod string,
+		req, reply interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		shortMethod := shortRPCMethod(fullMethod)
+		timer := metrics.NewRPCTimer(providerType, shortMethod)
+		err := invoker(ctx, fullMethod, req, reply, cc, opts...)
+		timer.Finish(grpcCodeString(err))
+		return err
+	}
+}
+
+// shortRPCMethod extracts the RPC method name from a full gRPC method
+// path. gRPC formats the path as "/<package>.<Service>/<Method>"
+// (e.g. "/provider.v1.Provider/Validate" -> "Validate"). Falls back to
+// the input unchanged if the format is unexpected, keeping the metric
+// label stable rather than silently dropping data.
+func shortRPCMethod(fullMethod string) string {
+	if idx := strings.LastIndex(fullMethod, "/"); idx >= 0 && idx < len(fullMethod)-1 {
+		return fullMethod[idx+1:]
+	}
+	return fullMethod
+}
+
+// grpcCodeString returns the stringified gRPC status code for the given
+// error. nil error -> "OK". Non-gRPC errors -> "Unknown" (matching gRPC's
+// own convention). The string is the canonical short form from
+// codes.Code.String() so metric labels match the gRPC reference docs.
+func grpcCodeString(err error) string {
+	return status.Code(err).String()
 }
 
 // Close closes the gRPC connection

--- a/internal/transport/grpc/client_metrics_test.go
+++ b/internal/transport/grpc/client_metrics_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestShortRPCMethod covers the path-stripping helper that turns gRPC's
+// full method path "/<pkg>.<Service>/<Method>" into just "<Method>" for
+// use as a metric label. Includes a few edge cases to pin behavior.
+func TestShortRPCMethod(t *testing.T) {
+	tests := []struct {
+		name string
+		full string
+		want string
+	}{
+		{"standard gRPC method path", "/provider.v1.Provider/Validate", "Validate"},
+		{"another method", "/provider.v1.Provider/SnapshotCreate", "SnapshotCreate"},
+		{"deeper package path", "/foo.bar.baz.Service/Method", "Method"},
+		{"no slash returns input unchanged", "BareName", "BareName"},
+		{"trailing slash falls back to full input", "/provider.v1.Provider/", "/provider.v1.Provider/"},
+		{"empty string returns empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shortRPCMethod(tt.full))
+		})
+	}
+}
+
+// TestGrpcCodeString verifies the err -> code-string mapping used by
+// the metric label. Pins canonical gRPC strings so dashboards keep working.
+func TestGrpcCodeString(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil error is OK", nil, codes.OK.String()},
+		{"unavailable", status.Error(codes.Unavailable, "down"), codes.Unavailable.String()},
+		{"deadline exceeded", status.Error(codes.DeadlineExceeded, "timeout"), codes.DeadlineExceeded.String()},
+		{"not found", status.Error(codes.NotFound, "missing"), codes.NotFound.String()},
+		{"non-grpc error becomes Unknown", errors.New("raw"), codes.Unknown.String()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, grpcCodeString(tt.err))
+		})
+	}
+}
+
+// counterSampleByLabels returns the current value of a counter sample
+// matching the given metric family name and labels. Helper for this file
+// only — controller-package tests have their own copy under a different
+// import path; intentionally not exported because metrics_test cross-file
+// helpers shouldn't leak into production code.
+func counterSampleByLabels(t *testing.T, family string, want map[string]string) float64 {
+	t.Helper()
+	families, err := metrics.GetRegistry().Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != family {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if labelsMatchPairs(m.GetLabel(), want) {
+				if c := m.GetCounter(); c != nil {
+					return c.GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func labelsMatchPairs(got []*dto.LabelPair, want map[string]string) bool {
+	for k, v := range want {
+		found := false
+		for _, lp := range got {
+			if lp.GetName() == k && lp.GetValue() == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// fakeProviderServer implements providerv1.ProviderServer for the
+// interceptor integration tests. ValidateFn is configurable so tests
+// can simulate success and error responses.
+type fakeProviderServer struct {
+	providerv1.UnimplementedProviderServer
+	ValidateFn func(ctx context.Context, req *providerv1.ValidateRequest) (*providerv1.ValidateResponse, error)
+}
+
+func (f *fakeProviderServer) Validate(ctx context.Context, req *providerv1.ValidateRequest) (*providerv1.ValidateResponse, error) {
+	if f.ValidateFn != nil {
+		return f.ValidateFn(ctx, req)
+	}
+	return &providerv1.ValidateResponse{Ok: true}, nil
+}
+
+// startBufconnServer brings up an in-process gRPC server backed by
+// google.golang.org/grpc/test/bufconn. Returns a dialer + cleanup func.
+// Avoids touching real TCP for the integration tests.
+func startBufconnServer(t *testing.T, srv providerv1.ProviderServer) (func(context.Context, string) (net.Conn, error), func()) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	gsrv := grpc.NewServer()
+	providerv1.RegisterProviderServer(gsrv, srv)
+	go func() { _ = gsrv.Serve(lis) }()
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }
+	cleanup := func() {
+		gsrv.Stop()
+		_ = lis.Close()
+	}
+	return dialer, cleanup
+}
+
+// newTestClient builds a *Client wired to the in-process bufconn server,
+// with the production interceptor in place. Used by integration tests
+// to verify the interceptor emits the right metric samples.
+func newTestClient(t *testing.T, dialer func(context.Context, string) (net.Conn, error), providerType string) *Client {
+	t.Helper()
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(providerRPCMetricsInterceptor(providerType)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return &Client{conn: conn, client: providerv1.NewProviderClient(conn)}
+}
+
+// TestProviderRPCMetricsInterceptor_SuccessfulCall verifies that a
+// normal RPC records virtrigaud_provider_rpc_requests_total{provider_type,
+// method,code="OK"} += 1 and observes the latency histogram.
+func TestProviderRPCMetricsInterceptor_SuccessfulCall(t *testing.T) {
+	dialer, cleanup := startBufconnServer(t, &fakeProviderServer{
+		ValidateFn: func(ctx context.Context, req *providerv1.ValidateRequest) (*providerv1.ValidateResponse, error) {
+			return &providerv1.ValidateResponse{Ok: true}, nil
+		},
+	})
+	defer cleanup()
+	cli := newTestClient(t, dialer, "test-success")
+
+	wantLabels := map[string]string{
+		"provider_type": "test-success",
+		"method":        "Validate",
+		"code":          codes.OK.String(),
+	}
+	before := counterSampleByLabels(t, "virtrigaud_provider_rpc_requests_total", wantLabels)
+
+	err := cli.Validate(context.Background())
+	require.NoError(t, err)
+
+	after := counterSampleByLabels(t, "virtrigaud_provider_rpc_requests_total", wantLabels)
+	assert.Equal(t, before+1, after,
+		"successful Validate RPC should increment requests_total{code=OK} by 1")
+}
+
+// TestProviderRPCMetricsInterceptor_ErrorPropagatesCode verifies that
+// gRPC errors are recorded with their canonical code string. Important
+// for operators alerting on `code=~"Unavailable|DeadlineExceeded|..."`.
+func TestProviderRPCMetricsInterceptor_ErrorPropagatesCode(t *testing.T) {
+	dialer, cleanup := startBufconnServer(t, &fakeProviderServer{
+		ValidateFn: func(ctx context.Context, req *providerv1.ValidateRequest) (*providerv1.ValidateResponse, error) {
+			return nil, status.Error(codes.Unavailable, "provider is down")
+		},
+	})
+	defer cleanup()
+	cli := newTestClient(t, dialer, "test-error")
+
+	wantLabels := map[string]string{
+		"provider_type": "test-error",
+		"method":        "Validate",
+		"code":          codes.Unavailable.String(),
+	}
+	before := counterSampleByLabels(t, "virtrigaud_provider_rpc_requests_total", wantLabels)
+
+	err := cli.Validate(context.Background())
+	require.Error(t, err)
+
+	after := counterSampleByLabels(t, "virtrigaud_provider_rpc_requests_total", wantLabels)
+	assert.Equal(t, before+1, after,
+		"Unavailable RPC should increment requests_total{code=Unavailable} by 1")
+}
+
+// TestProviderRPCMetricsInterceptor_LatencyHistogramFires — smoke that
+// the latency histogram receives at least one observation per RPC call.
+func TestProviderRPCMetricsInterceptor_LatencyHistogramFires(t *testing.T) {
+	dialer, cleanup := startBufconnServer(t, &fakeProviderServer{})
+	defer cleanup()
+	cli := newTestClient(t, dialer, "test-latency")
+
+	err := cli.Validate(context.Background())
+	require.NoError(t, err)
+
+	families, err := metrics.GetRegistry().Gather()
+	require.NoError(t, err)
+
+	var sampleCount uint64
+	for _, f := range families {
+		if f.GetName() != "virtrigaud_provider_rpc_latency_seconds" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if labelsMatchPairs(m.GetLabel(), map[string]string{
+				"provider_type": "test-latency",
+				"method":        "Validate",
+			}) {
+				if h := m.GetHistogram(); h != nil {
+					sampleCount += h.GetSampleCount()
+				}
+			}
+		}
+	}
+	assert.Greater(t, sampleCount, uint64(0),
+		"virtrigaud_provider_rpc_latency_seconds{provider_type=test-latency,method=Validate} should have at least one observation")
+}
+
+// TestProviderRPCMetricsInterceptor_DeadlineExceeded — pins the deadline-
+// exceeded case, which is what happens in production when a provider
+// goes silent and the client's ctx times out before the server responds.
+func TestProviderRPCMetricsInterceptor_DeadlineExceeded(t *testing.T) {
+	dialer, cleanup := startBufconnServer(t, &fakeProviderServer{
+		ValidateFn: func(ctx context.Context, req *providerv1.ValidateRequest) (*providerv1.ValidateResponse, error) {
+			// Sleep longer than the client's deadline.
+			select {
+			case <-time.After(2 * time.Second):
+				return &providerv1.ValidateResponse{Ok: true}, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	})
+	defer cleanup()
+	cli := newTestClient(t, dialer, "test-deadline")
+
+	wantLabels := map[string]string{
+		"provider_type": "test-deadline",
+		"method":        "Validate",
+		"code":          codes.DeadlineExceeded.String(),
+	}
+	before := counterSampleByLabels(t, "virtrigaud_provider_rpc_requests_total", wantLabels)
+
+	// 50ms deadline — much shorter than the server's 2s sleep.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := cli.Validate(ctx)
+	require.Error(t, err)
+
+	after := counterSampleByLabels(t, "virtrigaud_provider_rpc_requests_total", wantLabels)
+	assert.Equal(t, before+1, after,
+		"deadline-exceeded RPC should increment requests_total{code=DeadlineExceeded} by 1")
+}


### PR DESCRIPTION
## Summary
Fourth in the G-track (#86 umbrella). Adds a `UnaryClientInterceptor` to the gRPC client in `internal/transport/grpc/client.go` that records per-RPC latency + status code for every outbound provider call. All 17+ existing RPC callsites need zero edits — the interceptor sits at the connection level.

Closes #90.

## What metrics now emit

| Family | Labels |
|--------|--------|
| `virtrigaud_provider_rpc_requests_total` | `{provider_type, method, code}` |
| `virtrigaud_provider_rpc_latency_seconds` | `{provider_type, method}` (histogram) |

`provider_type` comes from `provider.Spec.Type` ("vsphere"/"libvirt"/"proxmox"/"mock"). `method` is the proto-RPC short name ("Validate", "Create", "Describe", etc.). `code` is the canonical gRPC status code string ("OK", "Unavailable", "DeadlineExceeded", "NotFound", "Unknown" for non-gRPC errors).

## API change (internal-only)

`NewClient` signature now takes `providerType string`:
```diff
-func NewClient(ctx context.Context, endpoint string, tlsConfig *TLSConfig) (*Client, error)
+func NewClient(ctx context.Context, endpoint string, providerType string, tlsConfig *TLSConfig) (*Client, error)
```

Verified via `grep -rn 'transport/grpc".NewClient'` that the only caller is `internal/runtime/remote/resolver.go:90`, which has the Provider CR in scope. Updated to pass `string(provider.Spec.Type)`. Empty string is permitted (label will be empty) but discouraged.

## Why per-RPC instrumentation matters

Per-Kind reconcile counters from G1-G3 answer "is this controller doing work?" but can't answer the operationally critical questions:
- Which RPC method is slow? (Reconfigure on vSphere vs Describe on Proxmox?)
- Which provider type is flapping? (libvirt with SSH issues?)
- Are gRPC errors concentrated on specific endpoints?
- What's our normal-operation SLO baseline?

This PR establishes the foundation for those dashboards.

## Test plan

```
$ go test -v -count=1 -run "TestShortRPCMethod|TestGrpcCodeString|TestProviderRPCMetricsInterceptor" ./internal/transport/grpc/
=== RUN   TestShortRPCMethod                              (6 sub-cases)  PASS
=== RUN   TestGrpcCodeString                              (5 sub-cases)  PASS
=== RUN   TestProviderRPCMetricsInterceptor_SuccessfulCall                PASS
=== RUN   TestProviderRPCMetricsInterceptor_ErrorPropagatesCode           PASS
=== RUN   TestProviderRPCMetricsInterceptor_LatencyHistogramFires         PASS
=== RUN   TestProviderRPCMetricsInterceptor_DeadlineExceeded              PASS
```

The 4 integration tests use `google.golang.org/grpc/test/bufconn` for an in-process server — no real network. Hermetic and fast (~50ms total).

### Gates
- [x] `go fmt`, `go vet`, `golangci-lint` clean (0 issues)
- [x] `make test` pass; **`internal/transport/grpc` pkg coverage 0% → 9.2%** (first tests ever in this package)
- [x] `make test-integration` pass
- [ ] CI on this PR: expect green (K4 v4-pin from #104 is in place)

## Files changed
- `internal/transport/grpc/client.go` — interceptor + 2 helpers (`shortRPCMethod`, `grpcCodeString`); `NewClient` signature extended
- `internal/transport/grpc/client_metrics_test.go` — new file, 5 tests / 15 sub-cases
- `internal/runtime/remote/resolver.go` — pass `provider.Spec.Type` to `NewClient`
- `CHANGELOG.md` — entry

## Impact
- [ ] Breaking change (internal API change to `NewClient`; no public API exposed)
- [x] Requires cluster rollout
- [ ] Config change only
- [ ] Documentation only

## After this merges

Only **G5 (#91)** remains in the G-track before cutting v0.3.5-rc1. G5 hooks `CircuitBreakerMetrics` into the actual state transitions in `internal/resilience/circuitbreaker.go` — small change, made safer by #100 having fixed the half-open transition bug first.

After G5: cut v0.3.5-rc1, smoke on `vr1.lab.k8`, tag v0.3.5.

## Coordinates with ADR-0001 F3
Per the architectural decision: this PR establishes the metrics interceptor. Logging and tracing interceptors can be layered using the same `WithUnaryInterceptor` pattern in future PRs.