### PR TITLE
feat(obs): wire CircuitBreaker into provider gRPC RPC path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-24 08:02] - feat(obs): wire CircuitBreaker into provider gRPC RPC path (closes #111)
+**Author:** @williamrizzo (William Rizzo)
+
+### Audit finding
+v0.3.5 release smoke on `vr1.lab.k8` confirmed that `virtrigaud_circuit_breaker_state` and `virtrigaud_circuit_breaker_failures_total` emit zero samples in production despite G5 (PR #108) wiring all metric emission paths correctly. Root cause: **the CircuitBreaker code in `internal/resilience/` was never instantiated by any production caller**. The gRPC client in `internal/transport/grpc/client.go` had a G4 metrics interceptor but no resilience layer. Net effect: no real circuit-breaker protection on the manager→provider RPC path, AND no breaker metrics ever emitted. The package was correct but dead.
+
+### Added
+- `internal/transport/grpc/client.go`: New `providerCircuitBreakerInterceptor` — a `grpc.UnaryClientInterceptor` that wraps every outbound RPC with `CircuitBreaker.Call`. Chained AFTER the existing G4 metrics interceptor via `grpc.WithChainUnaryInterceptor`, so circuit-breaker rejections still show up in `virtrigaud_provider_rpc_requests_total{code="Unavailable"}` (no silent drops).
+- `internal/transport/grpc/client.go`: New `isInfraFailure` classifier — pins the gRPC-code policy that decides what counts as a "provider health" failure (tripping the breaker) vs a business error (passing through). Tripping codes: `Unavailable`, `DeadlineExceeded`, `Internal`, `Unknown`. Pass-through codes: `NotFound`, `InvalidArgument`, `AlreadyExists`, `FailedPrecondition`, `PermissionDenied`, `Unauthenticated`, `Canceled`, `ResourceExhausted`, `Aborted`, `OutOfRange`, `Unimplemented`. Documented inline with rationale per code.
+- `internal/transport/grpc/client_circuitbreaker_test.go`: New file. 5 tests covering: gRPC-code classification table (15 cases), infra errors trip the breaker after `FailureThreshold`, business errors never trip regardless of count, successful calls leave the breaker Closed, and the full `Closed → Open → HalfOpen → Closed` lifecycle through the interceptor (not just the underlying breaker).
+- `cmd/manager/main.go`: Constructs a `resilience.NewRegistry(resilience.DefaultConfig())` once at startup and threads it to `remote.NewResolver`. One CircuitBreaker per Provider CR is allocated lazily by the Resolver via `Registry.GetOrCreate("rpc", providerType, providerName)`.
+- `cmd/main.go` (parallel build path, see #92 H1): same wiring so this build path retains parity.
+
+### Changed
+- `internal/transport/grpc/client.go`: `NewClient` signature now accepts `cb *resilience.CircuitBreaker` (4th parameter, before `tlsConfig`). Passing `nil` disables circuit-breaker wiring — supported for unit tests that exercise real gRPC failure semantics without the breaker interposing.
+- `internal/runtime/remote/resolver.go`: `NewResolver` signature now accepts `cbRegistry *resilience.Registry` (2nd parameter). `getRemoteProvider` calls `cbRegistry.GetOrCreate(...)` per-Provider before passing the resulting breaker to `NewClient`. `CleanupClient` also calls `cbRegistry.Remove(...)` so deleted Providers stop emitting `virtrigaud_circuit_breaker_*` series and don't leak CB instances.
+- `internal/controller/vmmigration_controller_test.go`: Test now passes `nil` registry to `remote.NewResolver` (it uses a fake k8s client; no real gRPC dialing happens, so the wiring would be inert).
+
+### Why
+1. **Real circuit-breaker protection on the RPC path.** Before this change, a flapping hypervisor (e.g. the `kex_exchange_identification` libvirt SSH issue tracked as #I1) caused the manager to keep hammering the provider with retries — v0.3.5 smoke showed 22 `DeadlineExceeded` + 9 `Canceled` Validate RPCs against libvirt in a few minutes. With G6, after `FailureThreshold=10` infra failures, the breaker opens and short-circuits subsequent RPCs for `ResetTimeout=60s`, giving the downstream hypervisor room to recover and the manager room to free up reconcile slots.
+2. **`virtrigaud_circuit_breaker_*` metric families now emit.** Closes the last empty G-track family from the v0.3.5 smoke gap analysis (6/8 → 8/8 families with samples). Operators can dashboard `virtrigaud_circuit_breaker_state{provider_type, provider}` and alert on `state > 0` to catch any provider whose breaker is non-closed.
+3. **Opinionated classification matters.** A 1000-VM reconcile loop that gets `NotFound` for one missing VM shouldn't trip the breaker — the provider is healthy; the request was bad. Conversely, a single `Unavailable` from a dead provider pod IS a health signal. The classifier encodes this distinction at one place, with documented rationale per code, so future RPCs added to the proto inherit it automatically.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (new manager binary; new metrics emit after rollout)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- Config knobs (`FailureThreshold`, `ResetTimeout`, `HalfOpenMaxCalls`) use `resilience.DefaultConfig()` globally — no per-Provider CRD field. If operators ask for per-Provider tuning later, the wiring is straightforward (add `Spec.Runtime.CircuitBreaker` to the Provider CRD and pass through the Resolver).
+- Pre-existing tooling drift discovered during verify: `.golangci.yml` is v2 syntax (commit `8d3be28`), but Makefile pins `golangci-lint v1.64.8`. `make lint` fails. Independent of this PR; should be tracked as a separate tooling issue.
+- v0.3.6-rc1 smoke checklist should include: scale a provider deployment to 0, watch the breaker's state gauge flip `0 → 2` after `FailureThreshold` infra failures within `ResetTimeout`; scale back up and watch it transition `2 → 1 → 0` through HalfOpen. This proves the wiring end-to-end on the cluster.
+
+---
+
 ## [2026-05-23 14:02] - feat(obs): document + test CircuitBreakerMetrics lifecycle (closes #91)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,6 +40,7 @@ import (
 
 	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
 	"github.com/projectbeskar/virtrigaud/internal/controller"
+	"github.com/projectbeskar/virtrigaud/internal/resilience"
 	"github.com/projectbeskar/virtrigaud/internal/runtime/remote"
 	"github.com/projectbeskar/virtrigaud/internal/version"
 )
@@ -213,8 +214,13 @@ func main() {
 
 	setupLog.Info("Starting virtrigaud manager", "version", version.String())
 
+	// G6 (#111): per-Provider CircuitBreaker registry. Mirrors the
+	// canonical cmd/manager/main.go wiring so this build path retains
+	// circuit-breaker protection if anyone ever ships it.
+	cbRegistry := resilience.NewRegistry(resilience.DefaultConfig())
+
 	// Create remote provider resolver (all providers are now remote)
-	remoteResolver := remote.NewResolver(mgr.GetClient())
+	remoteResolver := remote.NewResolver(mgr.GetClient(), cbRegistry)
 
 	setupLog.Info("Remote provider resolver initialized")
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -37,6 +37,7 @@ import (
 	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
 	"github.com/projectbeskar/virtrigaud/internal/controller"
 	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
+	"github.com/projectbeskar/virtrigaud/internal/resilience"
 	"github.com/projectbeskar/virtrigaud/internal/runtime/remote"
 	"github.com/projectbeskar/virtrigaud/internal/version"
 )
@@ -145,8 +146,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Create the per-Provider CircuitBreaker registry shared across all
+	// gRPC clients (G6 / #111). DefaultConfig: FailureThreshold=10,
+	// ResetTimeout=60s, HalfOpenMaxCalls=3. The registry allocates one
+	// breaker per Provider CR; metric series with provider_type +
+	// provider labels emit on /metrics for each.
+	cbRegistry := resilience.NewRegistry(resilience.DefaultConfig())
+
 	// Create remote provider resolver (all providers are now remote)
-	remoteResolver := remote.NewResolver(mgr.GetClient())
+	remoteResolver := remote.NewResolver(mgr.GetClient(), cbRegistry)
 
 	if err = (&controller.VirtualMachineReconciler{
 		Client:         mgr.GetClient(),

--- a/internal/controller/vmmigration_controller_test.go
+++ b/internal/controller/vmmigration_controller_test.go
@@ -54,9 +54,12 @@ var _ = Describe("VMMigration Controller", func() {
 
 		// Create reconciler with fake client
 		reconciler = &VMMigrationReconciler{
-			Client:         fakeClient,
-			Scheme:         s,
-			RemoteResolver: remote.NewResolver(fakeClient),
+			Client: fakeClient,
+			Scheme: s,
+			// Pass nil cbRegistry — this test exercises controller
+			// logic against a fake k8s client; no real gRPC dialing
+			// happens, so circuit-breaker wiring would be inert.
+			RemoteResolver: remote.NewResolver(fakeClient, nil),
 		}
 	})
 

--- a/internal/runtime/remote/resolver.go
+++ b/internal/runtime/remote/resolver.go
@@ -25,21 +25,43 @@ import (
 
 	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
 	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	"github.com/projectbeskar/virtrigaud/internal/resilience"
 	grpcClient "github.com/projectbeskar/virtrigaud/internal/transport/grpc"
 )
+
+// circuitBreakerName is the logical name passed to the resilience
+// Registry when getting/creating a CircuitBreaker per Provider CR. We
+// use a single name ("rpc") because today there is one breaker per
+// Provider that guards every RPC on that Provider's client. If we ever
+// want per-RPC-method breakers, this would become the RPC short name.
+const circuitBreakerName = "rpc"
 
 // Resolver resolves Provider objects to remote provider implementations
 type Resolver struct {
 	client       client.Client
 	clients      map[string]*grpcClient.Client
 	clientsMutex sync.RWMutex
+	// cbRegistry is the CircuitBreaker registry shared by all gRPC
+	// clients this resolver creates. May be nil — in which case clients
+	// are constructed without circuit-breaker protection (intended for
+	// tests that don't exercise the breaker path).
+	cbRegistry *resilience.Registry
 }
 
-// NewResolver creates a new remote provider resolver
-func NewResolver(k8sClient client.Client) *Resolver {
+// NewResolver creates a new remote provider resolver.
+//
+// cbRegistry is the shared CircuitBreaker registry used to allocate one
+// breaker per Provider CR. Passing nil disables circuit-breaker wiring
+// for clients created by this resolver — useful in tests with a fake
+// k8s client where the gRPC path is never actually dialed. Production
+// callers (cmd/manager/main.go) must pass a real registry so the G6
+// (#111) per-Provider breakers actually emit
+// virtrigaud_circuit_breaker_* samples.
+func NewResolver(k8sClient client.Client, cbRegistry *resilience.Registry) *Resolver {
 	return &Resolver{
-		client:  k8sClient,
-		clients: make(map[string]*grpcClient.Client),
+		client:     k8sClient,
+		clients:    make(map[string]*grpcClient.Client),
+		cbRegistry: cbRegistry,
 	}
 }
 
@@ -89,7 +111,14 @@ func (r *Resolver) getRemoteProvider(ctx context.Context, provider *infravirtrig
 
 	// provider.Spec.Type populates the `provider_type` label on every
 	// virtrigaud_provider_rpc_* sample emitted by this client (G4 / #90).
-	client, err := grpcClient.NewClient(ctx, provider.Status.Runtime.Endpoint, string(provider.Spec.Type), tlsConfig)
+	// One CircuitBreaker per Provider CR is allocated from the shared
+	// registry (G6 / #111); when cbRegistry is nil (test path), the
+	// gRPC client is constructed without breaker protection.
+	var cb *resilience.CircuitBreaker
+	if r.cbRegistry != nil {
+		cb = r.cbRegistry.GetOrCreate(circuitBreakerName, string(provider.Spec.Type), provider.Name)
+	}
+	client, err := grpcClient.NewClient(ctx, provider.Status.Runtime.Endpoint, string(provider.Spec.Type), cb, tlsConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC client: %w", err)
 	}
@@ -129,7 +158,13 @@ func (r *Resolver) buildTLSConfig(ctx context.Context, provider *infravirtrigaud
 	}, nil
 }
 
-// CleanupClient removes and closes a cached gRPC client
+// CleanupClient removes and closes a cached gRPC client.
+//
+// Also removes the per-Provider CircuitBreaker from the registry (G6 /
+// #111) so its metric series (virtrigaud_circuit_breaker_state and
+// _failures_total with this Provider's labels) stop being emitted once
+// the Provider CR is gone. Without this cleanup, deleted Providers
+// would leak both a CB struct and stale metric samples indefinitely.
 func (r *Resolver) CleanupClient(provider *infravirtrigaudiov1beta1.Provider) {
 	cacheKey := fmt.Sprintf("%s/%s", provider.Namespace, provider.Name)
 
@@ -139,6 +174,9 @@ func (r *Resolver) CleanupClient(provider *infravirtrigaudiov1beta1.Provider) {
 	if client, exists := r.clients[cacheKey]; exists {
 		client.Close() //nolint:errcheck // Client cleanup not critical
 		delete(r.clients, cacheKey)
+	}
+	if r.cbRegistry != nil {
+		r.cbRegistry.Remove(circuitBreakerName, string(provider.Spec.Type), provider.Name)
 	}
 }
 

--- a/internal/transport/grpc/client.go
+++ b/internal/transport/grpc/client.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	"github.com/projectbeskar/virtrigaud/internal/resilience"
 	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
 )
 
@@ -50,7 +51,15 @@ type Client struct {
 // on every RPC call made through this client. Passing an empty string is
 // permitted (the label will be empty) but discouraged in production —
 // makes per-provider-type alerts impossible.
-func NewClient(ctx context.Context, endpoint string, providerType string, tlsConfig *TLSConfig) (*Client, error) {
+//
+// cb is an optional CircuitBreaker wrapping every outbound RPC. When
+// non-nil, infrastructure-class gRPC errors (Unavailable, DeadlineExceeded,
+// Internal, Unknown) count toward the breaker's failure threshold; once
+// the threshold trips, subsequent RPCs short-circuit with a synthesized
+// Unavailable status until ResetTimeout elapses (G6 / #111). Pass nil to
+// disable circuit-breaker protection — useful in unit tests that exercise
+// real gRPC failure semantics without the breaker interposing.
+func NewClient(ctx context.Context, endpoint string, providerType string, cb *resilience.CircuitBreaker, tlsConfig *TLSConfig) (*Client, error) {
 	// Connection timeout is handled by grpc.NewClient internally
 	_ = ctx // Context available for future timeout implementation
 
@@ -66,15 +75,35 @@ func NewClient(ctx context.Context, endpoint string, providerType string, tlsCon
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
+	// Build the unary interceptor chain.
+	//
+	// Order is important and deliberate:
+	//   1. providerRPCMetricsInterceptor — records EVERY RPC (including
+	//      circuit-breaker rejections, which show up as code=Unavailable).
+	//      This means dashboards see "the breaker fast-failed this RPC"
+	//      as a normal Unavailable RPC, not a silent drop.
+	//   2. providerCircuitBreakerInterceptor — wraps the actual invoker.
+	//      When the breaker is open, returns Unavailable BEFORE invoker
+	//      runs, so step 1 still observes it.
+	unaryInterceptors := []grpc.UnaryClientInterceptor{
+		// G4 (#90): record per-RPC latency + status code into the
+		// virtrigaud_provider_rpc_* metric families.
+		providerRPCMetricsInterceptor(providerType),
+	}
+	if cb != nil {
+		// G6 (#111): wrap RPCs with circuit-breaker fast-fail. Infra
+		// errors count toward the threshold; business errors (NotFound,
+		// InvalidArgument, ...) pass through without tripping.
+		unaryInterceptors = append(unaryInterceptors, providerCircuitBreakerInterceptor(cb))
+	}
+
 	// Add retry and timeout configurations
 	opts = append(opts,
 		// grpc.WithBlock() removed as it's deprecated in newer gRPC versions
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
 		),
-		// G4 (#90): record per-RPC latency + status code into the
-		// virtrigaud_provider_rpc_* metric families.
-		grpc.WithUnaryInterceptor(providerRPCMetricsInterceptor(providerType)),
+		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 	)
 
 	conn, err := grpc.NewClient(endpoint, opts...)
@@ -136,6 +165,99 @@ func shortRPCMethod(fullMethod string) string {
 // codes.Code.String() so metric labels match the gRPC reference docs.
 func grpcCodeString(err error) string {
 	return status.Code(err).String()
+}
+
+// providerCircuitBreakerInterceptor returns a UnaryClientInterceptor that
+// wraps every outbound RPC with the supplied CircuitBreaker. Implements
+// G6 / #111.
+//
+// Behaviour:
+//   - When the breaker is Closed or HalfOpen, the invoker runs normally.
+//     If it returns an infrastructure-class error (see isInfraFailure),
+//     that counts as a failure toward the breaker's threshold. Business
+//     errors (NotFound, InvalidArgument, ...) are returned to the caller
+//     unchanged AND do not trip the breaker — those are signs the
+//     provider is healthy and the request was bad, not the other way.
+//   - When the breaker is Open, the invoker does NOT run; the
+//     interceptor synthesises a codes.Unavailable status so the rest of
+//     the stack (the G4 metrics interceptor, c.mapGRPCError, callers
+//     doing `errors.Is(err, contracts.RetryableError)`) all treat it
+//     uniformly with any other "provider down" signal.
+//
+// The interceptor MUST NOT panic. If it did, every provider RPC would
+// break. We deliberately keep it small and free of allocation-heavy work.
+func providerCircuitBreakerInterceptor(cb *resilience.CircuitBreaker) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		fullMethod string,
+		req, reply interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		var invokerErr error
+		cbErr := cb.Call(ctx, func(ctx context.Context) error {
+			invokerErr = invoker(ctx, fullMethod, req, reply, cc, opts...)
+			// Only infra failures count toward the breaker's threshold.
+			// Business errors are returned out-of-band via invokerErr.
+			if isInfraFailure(invokerErr) {
+				return invokerErr
+			}
+			return nil
+		})
+		// Circuit is open and rejected the call before the invoker ran:
+		// cb.Call returned an error but invokerErr is still its zero value.
+		// Synthesise a canonical gRPC Unavailable so downstream code paths
+		// (metrics interceptor, mapGRPCError, retry loops) behave as if the
+		// provider itself returned Unavailable.
+		if cbErr != nil && invokerErr == nil {
+			return status.Errorf(codes.Unavailable, "circuit breaker open: %v", cbErr)
+		}
+		return invokerErr
+	}
+}
+
+// isInfraFailure reports whether the given error is an infrastructure-
+// class gRPC failure that should count toward a CircuitBreaker's failure
+// threshold. Treats the following codes as infra failures:
+//
+//   - Unavailable        — provider pod down, network partition
+//   - DeadlineExceeded   — provider hung past the call timeout
+//   - Internal           — provider crashed mid-call
+//   - Unknown            — non-gRPC error from the transport layer
+//
+// Codes deliberately NOT counted as infra failures:
+//
+//   - OK                 — obviously a success
+//   - Canceled           — caller gave up, not the provider failing
+//   - NotFound,
+//     InvalidArgument,
+//     AlreadyExists,
+//     FailedPrecondition,
+//     PermissionDenied,
+//     Unauthenticated    — application/business errors: the provider is
+//     healthy, the request was bad
+//   - ResourceExhausted  — rate-limit signal: caller should back off this
+//     one call, not stop talking to the provider
+//   - Aborted, OutOfRange,
+//     Unimplemented      — protocol-level issues unrelated to provider
+//     health
+//
+// The classification is opinionated; rationale is documented in the G6
+// PR (#111) and CHANGELOG entry.
+func isInfraFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch status.Code(err) {
+	case codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.Internal,
+		codes.Unknown:
+		return true
+	default:
+		return false
+	}
 }
 
 // Close closes the gRPC connection

--- a/internal/transport/grpc/client_circuitbreaker_test.go
+++ b/internal/transport/grpc/client_circuitbreaker_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	"github.com/projectbeskar/virtrigaud/internal/resilience"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestIsInfraFailure exhaustively pins the gRPC-code classification used
+// by the CircuitBreaker interceptor (G6 / #111). Any future change to
+// this table needs a deliberate review — the classification policy is
+// load-bearing for what counts as "provider health" vs "business error."
+func TestIsInfraFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// Counted as infra failure (would trip the breaker).
+		{"unavailable", status.Error(codes.Unavailable, "down"), true},
+		{"deadline exceeded", status.Error(codes.DeadlineExceeded, "timeout"), true},
+		{"internal", status.Error(codes.Internal, "panic in provider"), true},
+		{"unknown", status.Error(codes.Unknown, "unspecified"), true},
+		{"non-grpc error treated as Unknown -> infra", errors.New("raw transport err"), true},
+
+		// Not counted — business / application / out-of-scope.
+		{"nil is not infra", nil, false},
+		{"ok is not infra", status.Error(codes.OK, ""), false},
+		{"not found is business", status.Error(codes.NotFound, "vm missing"), false},
+		{"invalid argument is business", status.Error(codes.InvalidArgument, "bad spec"), false},
+		{"already exists is business", status.Error(codes.AlreadyExists, "dup"), false},
+		{"failed precondition is business", status.Error(codes.FailedPrecondition, "wrong state"), false},
+		{"permission denied is auth", status.Error(codes.PermissionDenied, "no"), false},
+		{"unauthenticated is auth", status.Error(codes.Unauthenticated, "who?"), false},
+		{"canceled is caller", status.Error(codes.Canceled, "ctx done"), false},
+		{"resource exhausted is rate-limit", status.Error(codes.ResourceExhausted, "slow down"), false},
+		{"aborted is protocol", status.Error(codes.Aborted, "txn conflict"), false},
+		{"out of range is protocol", status.Error(codes.OutOfRange, "bounds"), false},
+		{"unimplemented is protocol", status.Error(codes.Unimplemented, "no rpc"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isInfraFailure(tt.err))
+		})
+	}
+}
+
+// newTestClientWithCB is a sibling of newTestClient (in
+// client_metrics_test.go) but also chains the CircuitBreaker interceptor
+// AFTER the metrics interceptor, matching the production order set by
+// NewClient. Returns the client and the breaker so tests can assert on
+// the breaker's state directly.
+func newTestClientWithCB(t *testing.T, dialer func(context.Context, string) (net.Conn, error), providerType, providerName string, cfg *resilience.Config) (*Client, *resilience.CircuitBreaker) {
+	t.Helper()
+	cb := resilience.NewCircuitBreaker("rpc", providerType, providerName, cfg)
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChainUnaryInterceptor(
+			providerRPCMetricsInterceptor(providerType),
+			providerCircuitBreakerInterceptor(cb),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return &Client{conn: conn, client: providerv1.NewProviderClient(conn)}, cb
+}
+
+// TestProviderCircuitBreakerInterceptor_InfraErrorsTripBreaker drives
+// the breaker through enough Unavailable RPCs to trip it, then asserts
+// the next call short-circuits with codes.Unavailable WITHOUT the
+// invoker running on the server. The test deliberately uses a
+// FailureThreshold of 2 to keep the loop short.
+func TestProviderCircuitBreakerInterceptor_InfraErrorsTripBreaker(t *testing.T) {
+	serverCalls := 0
+	dialer, cleanup := startBufconnServer(t, &fakeProviderServer{
+		ValidateFn: func(ctx context.Context, req *providerv1.ValidateRequest) (*providerv1.ValidateResponse, error) {
+			serverCalls++
+			return nil, status.Error(codes.Unavailable, "provider is down")
+		},
+	})
+	defer cleanup()
+
+	cli, cb := newTestClientWithCB(t, dialer, "g6-trip", "g6-trip-provider", &resilience.Config{
+		FailureThreshold: 2,
+		ResetTimeout:     30 * time.Second, // long — we don't want HalfOpen during this test
+		HalfOpenMaxCalls: 1,
+	})
+
+	// First two failures count toward the threshold; breaker still closed
+	// or just-tripped, but the invoker DOES run.
+	require.Error(t, cli.Validate(context.Background()))
+	require.Error(t, cli.Validate(context.Background()))
+	require.Equal(t, 2, serverCalls, "first two calls should reach the server")
+	require.Equal(t, resilience.StateOpen, cb.GetState(), "breaker should be Open after threshold")
+
+	// Third call must be rejected by the breaker BEFORE the invoker runs.
+	err := cli.Validate(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 2, serverCalls, "third call must NOT reach the server (breaker open)")
+
+	// Confirm the error code surfaced to the caller is Unavailable — so
+	// downstream retry/mapping logic treats it like any other infra
+	// failure rather than a business error.
+	//
+	// NOTE: c.Validate() wraps the gRPC error via mapGRPCError into a
+	// contracts.RetryableError. We inspect via the underlying gRPC
+	// status code by re-running through the raw client.
+	rawErr := func() error {
+		_, e := cli.client.Validate(context.Background(), &providerv1.ValidateRequest{})
+		return e
+	}()
+	require.Error(t, rawErr)
+	assert.Equal(t, codes.Unavailable, status.Code(rawErr),
+		"breaker-open rejection must surface as codes.Unavailable for uniform downstream handling")
+}
+
+// TestProviderCircuitBreakerInterceptor_BusinessErrorsDoNotTrip pins the
+// classification policy: a stream of NotFound / InvalidArgument
+// responses must NOT trip the breaker, no matter how many. The provider
+// is healthy; the requests are just bad.
+func TestProviderCircuitBreakerInterceptor_BusinessErrorsDoNotTrip(t *testing.T) {
+	dialer, cleanup := startBufconnServer(t, &fakeProviderServer{
+		ValidateFn: func(ctx context.Context, req *providerv1.ValidateRequest) (*providerv1.ValidateResponse, error) {
+			return nil, status.Error(codes.NotFound, "vm missing")
+		},
+	})
+	defer cleanup()
+
+	cli, cb := newTestClientWithCB(t, dialer, "g6-business", "g6-business-provider", &resilience.Config{
+		FailureThreshold: 2,
+		ResetTimeout:     30 * time.Second,
+		HalfOpenMaxCalls: 1,
+	})
+
+	// Fire 5 NotFound responses — well past the FailureThreshold of 2.
+	for i := 0; i < 5; i++ {
+		require.Error(t, cli.Validate(context.Background()))
+	}
+	assert.Equal(t, resilience.StateClosed, cb.GetState(),
+		"breaker must stay Closed for business errors (NotFound), regardless of count")
+	assert.Equal(t, 0, cb.GetFailures(),
+		"breaker failure counter must not increment on business errors")
+}
+
+// TestProviderCircuitBreakerInterceptor_SuccessKeepsBreakerClosed
+// confirms the happy path: successful RPCs leave the breaker Closed
+// with zero failures. Catches regressions where, e.g., a refactor
+// accidentally records every call as a failure.
+func TestProviderCircuitBreakerInterceptor_SuccessKeepsBreakerClosed(t *testing.T) {
+	dialer, cleanup := startBufconnServer(t, &fakeProviderServer{
+		ValidateFn: func(ctx context.Context, req *providerv1.ValidateRequest) (*providerv1.ValidateResponse, error) {
+			return &providerv1.ValidateResponse{Ok: true}, nil
+		},
+	})
+	defer cleanup()
+
+	cli, cb := newTestClientWithCB(t, dialer, "g6-success", "g6-success-provider", &resilience.Config{
+		FailureThreshold: 2,
+		ResetTimeout:     30 * time.Second,
+		HalfOpenMaxCalls: 1,
+	})
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, cli.Validate(context.Background()))
+	}
+	assert.Equal(t, resilience.StateClosed, cb.GetState(), "successful calls must leave the breaker Closed")
+	assert.Equal(t, 0, cb.GetFailures(), "successful calls must not increment failure counter")
+}
+
+// TestProviderCircuitBreakerInterceptor_RecoversToClosed exercises the
+// full Closed -> Open -> HalfOpen -> Closed lifecycle through the
+// interceptor (not just the raw breaker). Verifies the wiring across
+// the cb.Call boundary: after ResetTimeout elapses, the next successful
+// call transitions to HalfOpen, and after HalfOpenMaxCalls successes
+// the breaker closes again.
+func TestProviderCircuitBreakerInterceptor_RecoversToClosed(t *testing.T) {
+	// Server toggles: first 2 calls fail, then succeed forever.
+	failuresLeft := 2
+	dialer, cleanup := startBufconnServer(t, &fakeProviderServer{
+		ValidateFn: func(ctx context.Context, req *providerv1.ValidateRequest) (*providerv1.ValidateResponse, error) {
+			if failuresLeft > 0 {
+				failuresLeft--
+				return nil, status.Error(codes.Unavailable, "down")
+			}
+			return &providerv1.ValidateResponse{Ok: true}, nil
+		},
+	})
+	defer cleanup()
+
+	cli, cb := newTestClientWithCB(t, dialer, "g6-recover", "g6-recover-provider", &resilience.Config{
+		FailureThreshold: 2,
+		ResetTimeout:     30 * time.Millisecond,
+		HalfOpenMaxCalls: 2,
+	})
+
+	// Trip the breaker.
+	require.Error(t, cli.Validate(context.Background()))
+	require.Error(t, cli.Validate(context.Background()))
+	require.Equal(t, resilience.StateOpen, cb.GetState())
+
+	// Wait past ResetTimeout — next call transitions Open -> HalfOpen
+	// (and per the #96 fix, counts as the first half-open call).
+	time.Sleep(60 * time.Millisecond)
+
+	// Two successful half-open calls -> breaker closes.
+	require.NoError(t, cli.Validate(context.Background()))
+	require.NoError(t, cli.Validate(context.Background()))
+	assert.Equal(t, resilience.StateClosed, cb.GetState(),
+		"breaker should return to Closed after HalfOpenMaxCalls successful half-open calls")
+}


### PR DESCRIPTION
## Summary
- Closes #111 (G6). v0.3.5 smoke confirmed `virtrigaud_circuit_breaker_state` and `_failures_total` emit zero samples in production — the CircuitBreaker code in `internal/resilience/` was correct + G5-instrumented but **never instantiated by any production caller**.
- New `providerCircuitBreakerInterceptor` chains after the G4 metrics interceptor in `internal/transport/grpc/client.go` and wraps every outbound RPC with `CircuitBreaker.Call`. One CB per Provider CR, allocated lazily from a shared `resilience.Registry` owned by the manager. `Resolver.CleanupClient` also tears down the CB so deleted Providers don't leak metric series.
- Opinionated error classification: infra failures (`Unavailable`, `DeadlineExceeded`, `Internal`, `Unknown`) count toward the threshold; business errors (`NotFound`, `InvalidArgument`, …) pass through without tripping. Full table + rationale documented in `isInfraFailure` GoDoc and exhaustively pinned in `TestIsInfraFailure` (15 cases).
- Circuit-open rejections synthesize a `codes.Unavailable` status so the G4 metrics interceptor still observes them (`virtrigaud_provider_rpc_requests_total{code="Unavailable"}` — no silent drops) and downstream retry/mapping logic treats them like any other infra failure.

## What's in this PR
- `internal/transport/grpc/client.go`: new interceptor + classifier; `NewClient` gains a `cb *resilience.CircuitBreaker` parameter (nil-permissive for tests).
- `internal/transport/grpc/client_circuitbreaker_test.go`: new file. 5 tests: classification table (15 cases), infra-trips-breaker, business-doesn't-trip, success-keeps-closed, full closed→open→half-open→closed lifecycle through the interceptor.
- `internal/runtime/remote/resolver.go`: `NewResolver` gains a `cbRegistry *resilience.Registry` parameter; allocates one CB per Provider via `Registry.GetOrCreate("rpc", providerType, providerName)`. `CleanupClient` removes the CB on Provider deletion.
- `cmd/manager/main.go` + `cmd/main.go` (parallel build path, #92 H1): construct `resilience.NewRegistry(resilience.DefaultConfig())` once and thread to the Resolver.
- `internal/controller/vmmigration_controller_test.go`: pass `nil` registry (uses fake k8s client, no real gRPC dialing).
- `CHANGELOG.md`: detailed entry with audit finding, classification rationale, impact, and v0.3.6-rc1 smoke checklist note.

## Why this matters
v0.3.5 smoke showed 22 `DeadlineExceeded` + 9 `Canceled` Validate RPCs against the libvirt provider in a few minutes (`kex_exchange_identification` data-plane issue, #I1) — the manager kept hammering because nothing tripped a breaker. With G6, after `FailureThreshold=10` infra failures the breaker opens for `ResetTimeout=60s`, freeing manager reconcile slots and giving the downstream hypervisor room to recover.

## Test plan
- [x] `make fmt` clean
- [x] `go vet ./...` clean (note: `make lint` fails on a pre-existing tooling drift — `.golangci.yml` is v2 syntax but Makefile pins golangci-lint v1.64.8; independent of this PR, should be tracked separately)
- [x] `make test` all packages pass; new `internal/transport/grpc/client_circuitbreaker_test.go` (5 tests) green
- [x] `make build` clean
- [x] `make test-integration` clean (was wired by #93)
- [ ] **v0.3.6-rc1 smoke on `vr1.lab.k8`** (post-merge): scale a provider deployment to 0 → watch `virtrigaud_circuit_breaker_state{provider_type, provider}` flip 0 → 2 after threshold; scale back up → watch it transition 2 → 1 → 0 through HalfOpen. Closes the v0.3.5 observability gap.

## Design decisions (pre-approved by maintainer)
- **Per-Provider CR granularity** (not per provider-type). Matches existing gRPC client cache; two `Provider`s of type `vsphere` may point at different vCenters.
- **Globals for config** (`FailureThreshold=10`, `ResetTimeout=60s`, `HalfOpenMaxCalls=3`). No per-Provider CRD field in this PR; deferred to a follow-up if operators ask.
- **`ResourceExhausted` does NOT trip** the breaker — rate-limit is "back off this call," not "stop talking to the provider."

## Follow-ups
- v0.3.6-rc1 smoke checklist update (C3 in TODO) needs the CB lifecycle step.
- Pre-existing `make lint` tooling drift (`.golangci.yml` v2 vs `golangci-lint v1.64.8`) should be tracked as a separate issue — out of scope here.