### PR TITLE
feat(cmd/manager): port --version, certwatcher, metrics RBAC filter (H1 PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-24 10:09] - feat(cmd/manager): port --version flag, certwatcher, and metrics RBAC filter (H1 PR-1 / closes #114)
+**Author:** @williamrizzo (William Rizzo)
+
+### Audit finding
+First implementation chunk of the H1 build-path consolidation roadmap (see `fieldTesting/ADR-0002-build-path-consolidation.md`). Three features the local-dev orphan `cmd/main.go` had but the canonical `cmd/manager/main.go` lacked are now ported into the canonical entrypoint, with defaults preserved so existing deployments see zero behaviour change.
+
+### Added
+- `cmd/manager/main.go`: `versionString()` helper — single-line banner emitted by `--version`. Extracted from main() so it is unit-testable without subprocess execution. Format is `virtrigaud-manager <version.String()>`, pinned by `TestVersionString` so release-verification grep patterns stay stable.
+- `cmd/manager/main.go`: `--version` flag handler at the top of main(). Mirrors the cmd/main.go behaviour. Uses `os.Args[1]` lookup (not `flag.BoolVar` + `flag.Parse`) so `--version` works even when invalid flags follow and avoids the long help text on error.
+- `cmd/manager/main.go`: certificate-rotation flag set — `--webhook-cert-path`, `--webhook-cert-name`, `--webhook-cert-key`, `--metrics-cert-path`, `--metrics-cert-name`, `--metrics-cert-key`. All default to empty/`tls.crt`/`tls.key`, matching cmd/main.go.
+- `cmd/manager/main.go`: `sigs.k8s.io/controller-runtime/pkg/certwatcher` integration for both webhook and metrics endpoints. Hot cert rotation works once `--*-cert-path` is set. Watchers are registered as Runnables on the manager after controllers and are nil-guarded so zero-overhead at defaults.
+- `cmd/manager/main.go`: `sigs.k8s.io/controller-runtime/pkg/metrics/filters.WithAuthenticationAndAuthorization` wiring on the metrics endpoint. **Activates ONLY when `--metrics-secure=true`**, which currently defaults to `false`. When enabled, `/metrics` becomes an RBAC-checked resource (only ServiceAccounts with `get` on the `/metrics` nonResourceURL can scrape).
+- `cmd/manager/main.go`: imports `fmt`, `path/filepath`, `sigs.k8s.io/controller-runtime/pkg/certwatcher`, `sigs.k8s.io/controller-runtime/pkg/metrics/filters`. Renamed metrics-server alias from `server` to `metricsserver` for clarity (the prior unqualified name collided readability-wise with the controller-runtime `webhook` package).
+- `cmd/manager/main_test.go`: new file. `TestVersionString` pins the banner format and the contract that it delegates to `internal/version.String()` (the same source of truth as the `virtrigaud_build_info` metric label).
+
+### Changed
+- `cmd/manager/main.go`: webhook server construction now uses `webhookTLSOpts` (base `tlsOpts` plus the webhook certwatcher's `GetCertificate` callback when `--webhook-cert-path` is set). When the flag is unset, `webhookTLSOpts == tlsOpts` — no change vs. pre-PR.
+- `cmd/manager/main.go`: metrics server options are now built as a `metricsServerOptions` variable (rather than constructed inline inside `ctrl.NewManager`) so the `FilterProvider` and the metrics certwatcher's `GetCertificate` callback can be layered on conditionally. At defaults (`--metrics-secure=false`, `--metrics-cert-path=""`), the resulting `metricsserver.Options{...}` is byte-for-byte equivalent to the prior inline struct.
+
+### Why
+Per ADR-0002, the H1 consolidation needs four PRs in sequence. PR-1 is the prerequisite for retiring the local-dev orphan (PR-4): the canonical path must first absorb every feature the orphan had that operators may rely on. The three features ported here are exactly the ones flagged by the 2026-05-23 audit comment on #92 — `--version` (operators script against it), certwatcher (cert-manager renewals don't require pod restarts), and the metrics RBAC filter (banking-compliance posture, anonymous /metrics exposure is a routine audit finding).
+
+By keeping `--metrics-secure=false` as the default in this PR, every existing deployment sees identical behaviour. The default flip is a separate, breaking change held for v0.4.0 (PR-5).
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout (the manager binary gains features, but their activation requires explicit flag settings)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- `make build` still builds `cmd/main.go` (the orphan) — this PR does not touch Makefile targets. That redirection is PR-3 of the H1 roadmap, which also closes the latent bug #113 (orphan binary missing `virtrigaud_build_info` emission + VMSnapshot + VMMigration controllers).
+- `make lint` continues to fail locally on the pre-existing `.golangci.yml` v2 vs `golangci-lint v1.64.8` tooling drift; CI's runner-installed version is newer and passes. Tracked separately as future tooling work.
+- Manual smoke pre-merge: built with `-ldflags '-X .../version.Version=v0.3.6-h1pr1-dev -X .../version.GitSHA=$(git rev-parse HEAD)'`, ran `./bin/manager --version`, got `virtrigaud-manager v0.3.6-h1pr1-dev (66d0fbc9cef23bd6561bb1f86239660a3601433c)` with exit 0.
+
+---
+
 ## [2026-05-24 08:02] - feat(obs): wire CircuitBreaker into provider gRPC RPC path (closes #111)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -19,7 +19,9 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -29,9 +31,11 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
@@ -57,8 +61,34 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
+// versionString returns the single-line banner printed by `--version`.
+// Extracted from main() so it can be unit-tested without spawning a
+// subprocess (the surrounding os.Exit(0) path is not directly testable).
+// Format: "virtrigaud-manager <version-string>" where the version-string
+// comes from internal/version.String() (e.g. "v0.3.6 (gitSHA=abc123 go=go1.25.10)"
+// in release builds, or "dev (gitSHA=unknown ...)" in unstamped builds).
+//
+// Ported from cmd/main.go (H1 PR-1 / #114) as part of the build-path
+// consolidation (ADR-0002).
+func versionString() string {
+	return fmt.Sprintf("virtrigaud-manager %s", version.String())
+}
+
+// nolint:gocyclo
 func main() {
+	// Handle --version flag before any other flag parsing, mirroring
+	// cmd/main.go behaviour. Using os.Args lookup (not flag.BoolVar +
+	// flag.Parse) means `--version` works even when invalid flags
+	// follow, and avoids the long help text that flag.Parse prints on
+	// error. Ported from cmd/main.go (H1 PR-1 / #114, ADR-0002).
+	if len(os.Args) > 1 && os.Args[1] == "--version" {
+		fmt.Println(versionString())
+		os.Exit(0)
+	}
+
 	var metricsAddr string
+	var metricsCertPath, metricsCertName, metricsCertKey string
+	var webhookCertPath, webhookCertName, webhookCertKey string
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -69,7 +99,23 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", false,
-		"If set the metrics endpoint is served securely")
+		"If set the metrics endpoint is served securely (HTTPS). "+
+			"When true, the metrics endpoint also enforces RBAC authn/authz "+
+			"via controller-runtime's filters.WithAuthenticationAndAuthorization.")
+	// Certificate-rotation flags (H1 PR-1 / #114). All default to empty —
+	// when both --webhook-cert-path / --metrics-cert-path are empty the
+	// behaviour matches the pre-PR canonical manager exactly (no
+	// certwatcher initialised; controller-runtime falls back to its
+	// self-signed default for the metrics endpoint).
+	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
+	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
+	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
+		"The directory that contains the metrics server certificate. "+
+			"When non-empty, the manager hot-reloads the cert via certwatcher "+
+			"so cert-manager renewals don't require a pod restart.")
+	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
+	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	opts := zap.Options{
@@ -107,9 +153,80 @@ func main() {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
 
+	// Certificate watchers for hot rotation (H1 PR-1 / #114). When the
+	// corresponding *--*-cert-path flag is empty, the watcher stays nil
+	// and downstream code paths (mgr.Add at the bottom, the GetCertificate
+	// callback wiring above the manager) are skipped — behaviour is
+	// identical to the pre-PR canonical manager.
+	var metricsCertWatcher, webhookCertWatcher *certwatcher.CertWatcher
+
+	// Initial webhook TLS options (inherits the http/2-disable hook from
+	// tlsOpts; appends certwatcher GetCertificate when the flag is set).
+	webhookTLSOpts := tlsOpts
+
+	if len(webhookCertPath) > 0 {
+		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
+			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
+
+		var err error
+		webhookCertWatcher, err = certwatcher.New(
+			filepath.Join(webhookCertPath, webhookCertName),
+			filepath.Join(webhookCertPath, webhookCertKey),
+		)
+		if err != nil {
+			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
+			os.Exit(1)
+		}
+
+		webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
+			config.GetCertificate = webhookCertWatcher.GetCertificate
+		})
+	}
+
 	webhookServer := webhook.NewServer(webhook.Options{
-		TLSOpts: tlsOpts,
+		TLSOpts: webhookTLSOpts,
 	})
+
+	// Metrics server options. Built as a variable (not inline in
+	// ctrl.Options) so we can layer on the RBAC FilterProvider and the
+	// metrics certwatcher conditionally below — neither activates at
+	// defaults (--metrics-secure=false, --metrics-cert-path="").
+	metricsServerOptions := metricsserver.Options{
+		BindAddress:   metricsAddr,
+		SecureServing: secureMetrics,
+		TLSOpts:       tlsOpts,
+	}
+
+	if secureMetrics {
+		// FilterProvider protects /metrics with authn/authz: only
+		// ServiceAccounts with `get` on the `/metrics` nonResourceURL
+		// can scrape. Activates ONLY when --metrics-secure=true, which
+		// currently defaults to false — so default deployments see no
+		// behaviour change. The PR-5 default-flip to secure=true will
+		// make this the on-by-default posture (held for v0.4.0 per
+		// ADR-0002).
+		// See: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/metrics/filters#WithAuthenticationAndAuthorization
+		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+
+	if len(metricsCertPath) > 0 {
+		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
+			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
+
+		var err error
+		metricsCertWatcher, err = certwatcher.New(
+			filepath.Join(metricsCertPath, metricsCertName),
+			filepath.Join(metricsCertPath, metricsCertKey),
+		)
+		if err != nil {
+			setupLog.Error(err, "to initialize metrics certificate watcher")
+			os.Exit(1)
+		}
+
+		metricsServerOptions.TLSOpts = append(metricsServerOptions.TLSOpts, func(config *tls.Config) {
+			config.GetCertificate = metricsCertWatcher.GetCertificate
+		})
+	}
 
 	// Configure client with rate limiting to prevent API server overload
 	// These settings prevent reconciliation storms from overwhelming etcd/API server
@@ -119,12 +236,8 @@ func main() {
 	restConfig.Burst = 40 // Allow bursts up to 40 requests
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme: scheme,
-		Metrics: server.Options{
-			BindAddress:   metricsAddr,
-			SecureServing: secureMetrics,
-			TLSOpts:       tlsOpts,
-		},
+		Scheme:                 scheme,
+		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
@@ -227,6 +340,24 @@ func main() {
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder
+
+	// Register cert watchers with the manager so they run as Runnables
+	// alongside the controllers (H1 PR-1 / #114). nil-guarded so default
+	// deployments (no cert paths set) have zero overhead.
+	if metricsCertWatcher != nil {
+		setupLog.Info("Adding metrics certificate watcher to manager")
+		if err := mgr.Add(metricsCertWatcher); err != nil {
+			setupLog.Error(err, "unable to add metrics certificate watcher to manager")
+			os.Exit(1)
+		}
+	}
+	if webhookCertWatcher != nil {
+		setupLog.Info("Adding webhook certificate watcher to manager")
+		if err := mgr.Add(webhookCertWatcher); err != nil {
+			setupLog.Error(err, "unable to add webhook certificate watcher to manager")
+			os.Exit(1)
+		}
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectbeskar/virtrigaud/internal/version"
+)
+
+// TestVersionString verifies the banner emitted by `--version`.
+//
+// We test versionString() directly rather than invoking main() with
+// os.Args = []string{"manager", "--version"}, because the production
+// handler exits the process via os.Exit(0). Subprocess execution
+// (os/exec on the built binary) is exercised by `make build` + manual
+// run; the unit test pins the *content* of the banner so dashboards or
+// release-verification scripts that grep for "virtrigaud-manager"
+// continue to work.
+//
+// Pinned by H1 PR-1 / #114.
+func TestVersionString(t *testing.T) {
+	s := versionString()
+
+	require.NotEmpty(t, s, "versionString() must never return empty")
+	assert.True(t, strings.HasPrefix(s, "virtrigaud-manager "),
+		"banner must start with 'virtrigaud-manager ' so release-verification grep patterns keep working; got %q", s)
+
+	tail := strings.TrimPrefix(s, "virtrigaud-manager ")
+	assert.NotEmpty(t, tail,
+		"banner must include the version.String() payload after the prefix; got bare %q", s)
+
+	// Pin that we delegate to internal/version.String() so the two
+	// callers (this banner + virtrigaud_build_info metric label) stay
+	// in lockstep. If someone refactors versionString() to embed a
+	// hardcoded string, this catches the regression.
+	assert.Equal(t, "virtrigaud-manager "+version.String(), s,
+		"banner must be 'virtrigaud-manager ' + version.String() verbatim")
+}


### PR DESCRIPTION
## Summary
- Closes #114 (H1 PR-1). First implementation chunk of the build-path consolidation roadmap (ADR-0002 in `fieldTesting/`).
- Ports three features from the local-dev orphan `cmd/main.go` into the canonical `cmd/manager/main.go`, preserving every default so deployed operators see zero behaviour change.
- This PR does NOT touch Makefile targets. `make build` still invokes `cmd/main.go`. PR-3 of the H1 roadmap handles that redirect (and closes #113 — the latent bug that local-dev produces an incomplete manager binary).

## What's in this PR

### `cmd/manager/main.go`
| Addition | Behaviour at defaults | Gated on |
|---|---|---|
| `--version` flag handler + `versionString()` helper | `./manager --version` prints `virtrigaud-manager <version.String()>` and exits 0 | always (no flag needed) |
| `--webhook-cert-path` / `--webhook-cert-name` / `--webhook-cert-key` | Empty path → no webhook certwatcher initialised; behaviour identical to pre-PR | `--webhook-cert-path != ""` |
| `--metrics-cert-path` / `--metrics-cert-name` / `--metrics-cert-key` | Empty path → no metrics certwatcher; controller-runtime's self-signed fallback unchanged | `--metrics-cert-path != ""` |
| `sigs.k8s.io/controller-runtime/pkg/certwatcher` integration (webhook + metrics) | nil-guarded; not added to manager Runnables when paths empty | `--*-cert-path` set |
| `sigs.k8s.io/controller-runtime/pkg/metrics/filters.WithAuthenticationAndAuthorization` | Off (default `--metrics-secure=false`) | `--metrics-secure=true` |
| Metrics server config refactored from inline literal → `metricsServerOptions` variable | Byte-equivalent at defaults | always |
| Webhook server uses `webhookTLSOpts` (= `tlsOpts` at defaults) | Identical at defaults | always |
| Imports `fmt`, `path/filepath`, `certwatcher`, `metrics/filters`; renamed `server` → `metricsserver` alias for clarity | — | — |

### `cmd/manager/main_test.go` (new)
`TestVersionString` pins:
- Banner starts with `virtrigaud-manager ` (release-verification grep contract)
- Banner is non-empty after the prefix
- Banner delegates verbatim to `internal/version.String()` — same source of truth as the `virtrigaud_build_info` metric label

## Why this matters
Per ADR-0002, the H1 consolidation needs four PRs in sequence; PR-1 is the prerequisite for retiring the orphan (PR-4). The canonical path must first absorb every feature the orphan had that operators may rely on. The three features ported are the ones the 2026-05-23 audit flagged: `--version` (operators script against it), certwatcher (cert-manager renewals don't require pod restarts), and the metrics RBAC filter (banking-compliance — anonymous /metrics exposure is a routine audit finding).

## Test plan
- [x] `make fmt` clean
- [x] `go vet ./...` clean
- [x] `make test` — all packages pass; `TestVersionString` green in `cmd/manager/`
- [x] `make build` clean
- [x] `make test-integration` clean
- [x] **Manual smoke**: built with `-ldflags '-X .../version.Version=v0.3.6-h1pr1-dev -X .../version.GitSHA=$(git rev-parse HEAD)'`, ran `./bin/manager --version`, got `virtrigaud-manager v0.3.6-h1pr1-dev (66d0fbc9cef23bd6561bb1f86239660a3601433c)` with exit 0.
- [ ] **v0.3.6-rc1 smoke checklist** (post-merge): default-deployed manager on `vr1.lab.k8` serves `/metrics` over HTTP at `:8080` (no behaviour change at defaults). Plus a manual run with `--metrics-secure=true --metrics-cert-path=/tmp/certs` to verify certwatcher hot-rotates without restart.

## Defaults are unchanged
- `--metrics-bind-address` = `:8080` (HTTP)
- `--metrics-secure` = `false`
- `--webhook-cert-path` = `""` (no certwatcher)
- `--metrics-cert-path` = `""` (no certwatcher)

A default-deployed manager produces a byte-equivalent `metricsserver.Options{}` and a byte-equivalent webhook server config to the pre-PR build.

## What's coming next in the H1 roadmap
| # | Issue | What | Release |
|---|---|---|---|
| **PR-1** | **#114 ← this PR** | Port `--version` + certwatcher + metrics RBAC | v0.3.6 |
| PR-2 | (TBF) | Add `ARG BUILDER_IMAGE/BASE_IMAGE/GOPROXY` + CA-cert to `build/Dockerfile.manager` | v0.3.6 |
| PR-3 | (TBF) | Redirect Makefile targets to canonical Dockerfile; closes #113 (latent bug) | v0.3.6 |
| PR-4 | (TBF) | Delete `cmd/main.go` + root `Dockerfile`; closes #92 (H1 umbrella) | v0.3.6 |
| PR-5 | (TBF) | Flip `--metrics-secure` default to `true` — **BREAKING** | v0.4.0 |

## Follow-ups (not blocking this PR)
- v0.3.6-rc1 smoke checklist needs a `--version` line and a certwatcher-on-cert-manager-rotation line.
- The pre-existing `make lint` tooling drift (`.golangci.yml` v2 vs `golangci-lint v1.64.8` Makefile pin) remains. CI's installed version passes; local-dev parity needs a separate small PR.