### PR TITLE
feat(build): add BUILDER_IMAGE/BASE_IMAGE/GOPROXY ARGs + CA-cert handling (H1 PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-24 10:50] - feat(build): add BUILDER_IMAGE/BASE_IMAGE/GOPROXY ARGs + CA-cert handling to build/Dockerfile.manager (H1 PR-2 / closes #116)
+**Author:** @williamrizzo (William Rizzo)
+
+### Audit finding
+Second implementation chunk of the H1 build-path consolidation roadmap (`fieldTesting/ADR-0002-build-path-consolidation.md`). Audit on 2026-05-24 found that:
+- `Makefile:docker-build` already passes 10 build-args (`VERSION`, `GIT_SHA`, `TARGETOS`, `TARGETARCH`, `BUILDER_IMAGE`, `BASE_IMAGE`, `GOPROXY`, `GOINSECURE`, `GOPRIVATE`, `GOSUMDB`).
+- All 3 provider Dockerfiles (`cmd/provider-{libvirt,vsphere,proxmox}/Dockerfile`) already declare all 10 ARGs.
+- `build/Dockerfile.manager` declared only 4 of them — the other 6 were silently ignored. The manager Dockerfile was the project's only outlier.
+- The orphan root `Dockerfile` did declare all 10, **but** its CA-cert handling used `COPY *.crt /etc/ssl/certs/` which is broken in two ways: (1) the glob matches zero files on a fresh checkout (verified `ls *.crt` errors), and (2) `update-ca-certificates` reads inputs from `/usr/local/share/ca-certificates/`, not `/etc/ssl/certs/` — copying to the latter directly does nothing.
+
+### Added
+- `build/Dockerfile.manager`: `ARG BUILDER_IMAGE=docker.io/golang:1.25` and `ARG BASE_IMAGE=gcr.io/distroless/static:nonroot`, used in the corresponding `FROM` lines. Defaults match the previously-hardcoded images so upstream release builds produce byte-equivalent images.
+- `build/Dockerfile.manager`: `ARG GOPROXY=""`, `ARG GOINSECURE=""`, `ARG GOPRIVATE=""`, `ARG GOSUMDB="sum.golang.org"` with corresponding `ENV` lines. Matches the pattern used by all 3 provider Dockerfiles. Defaults preserve current upstream behaviour.
+- `build/Dockerfile.manager`: `COPY ca-certs/ /usr/local/share/ca-certificates/` + `RUN update-ca-certificates` **before** `RUN go mod download`. Required ordering so corporate TLS-intercepting proxies do not break the Go module fetch. Uses the correct Debian/Ubuntu directory (`/usr/local/share/ca-certificates/`), unlike the orphan's broken `/etc/ssl/certs/` path.
+- `ca-certs/.gitkeep`: new placeholder so the directory exists in the upstream tree. Without `.crt` files, the `COPY` + `update-ca-certificates` pair is a no-op (the script skips non-`.crt` files).
+- `ca-certs/README.md`: 50+ line operator guide. Covers when to populate this directory (corporate TLS proxies, internal module mirrors), how to use it (drop `.crt` files, rebuild), the builder-stage-only scope (NOT runtime CAs — those go via Kubernetes secrets/configmaps), and security warnings (one cert per file, never private keys, do not commit org-internal CAs to public forks).
+
+### Why
+1. **Brings the manager Dockerfile in line with the rest of the project.** All 3 provider Dockerfiles already declared these ARGs; the manager being the outlier was tech-debt that operators have to discover via failed builds in regulated environments.
+2. **Unblocks corporate / banking deployments without a Dockerfile fork.** Banking customers categorically cannot pull from `docker.io` or `gcr.io` in their production build pipelines. Without these ARGs they forked; forks drift. With them, an internal mirror override is one `--build-arg` away.
+3. **CA-cert handling fixes a latent bug from the orphan Dockerfile.** The orphan's `COPY *.crt /etc/ssl/certs/` was broken on fresh checkouts AND used the wrong directory. The corrected pattern in this PR (`ca-certs/` → `/usr/local/share/ca-certificates/`) works upstream as a no-op AND works for corporate forks that drop their certs in.
+4. **Subdirectory pattern limits the security blast radius.** ADR-0002 flagged the orphan's repo-root glob as a risk: any stray `.crt` file in the build context would have been shipped into the image. The dedicated `ca-certs/` subdirectory makes the intent explicit and confines what gets bundled.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (new manager image embeds the additional CA-cert handling layer — content-identical at defaults but cache key changes)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- Default behaviour is preserved at every level: `docker build -f build/Dockerfile.manager .` with no `--build-arg` overrides produces a functionally equivalent image to today's release. Verified pre-merge by building locally with default ARGs, then again with `--build-arg BUILDER_IMAGE=docker.io/golang:1.25 --build-arg GOSUMDB=off` — both produced runnable `--version`-correct images.
+- Manual smoke pre-merge: \
+  `docker build -f build/Dockerfile.manager --build-arg VERSION=v0.3.6-h1pr2-test --build-arg GIT_SHA=$(git rev-parse HEAD) -t virtrigaud-manager:h1pr2-test .` succeeded. \
+  `docker run --rm virtrigaud-manager:h1pr2-test --version` returned `virtrigaud-manager v0.3.6-h1pr2-test (23457f932...)` with exit 0. This proves PR-1 (`--version` handler) + PR-2 (Dockerfile parametrization) stack correctly.
+- The Makefile already passes all 10 build-args; the release workflow passes only `VERSION` + `GIT_SHA` (the new ARGs fall back to defaults — release behaviour unchanged). No Makefile or release.yml changes were needed in this PR.
+- Pre-existing `make lint` tooling drift remains as noted in #114.
+
+---
+
 ## [2026-05-24 10:09] - feat(cmd/manager): port --version flag, certwatcher, and metrics RBAC filter (H1 PR-1 / closes #114)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/build/Dockerfile.manager
+++ b/build/Dockerfile.manager
@@ -1,5 +1,15 @@
 # Build the manager binary
-FROM golang:1.25 as builder
+#
+# H1 PR-2 (#116): BUILDER_IMAGE / BASE_IMAGE are parametrised so corporate
+# / banking deployments that cannot pull from docker.io or gcr.io can
+# point at their internal mirrors (Artifactory, Harbor, etc.) without
+# patching this Dockerfile. Defaults match the previously-hardcoded
+# images so upstream release behaviour is unchanged.
+ARG BUILDER_IMAGE=docker.io/golang:1.25
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+
+FROM ${BUILDER_IMAGE} AS builder
+
 ARG TARGETOS
 ARG TARGETARCH
 # VERSION and GIT_SHA are injected into internal/version via ldflags so that
@@ -9,7 +19,35 @@ ARG TARGETARCH
 ARG VERSION=dev
 ARG GIT_SHA=unknown
 
+# H1 PR-2 (#116): GOPROXY / GOINSECURE / GOPRIVATE / GOSUMDB passthrough
+# so corporate-proxy go module fetches work without rebuilding a custom
+# builder image. Defaults are empty (no override) except GOSUMDB which
+# uses the public sum database. The Makefile already passes these as
+# --build-arg values when set in the environment; receivers (the
+# provider Dockerfiles already declared these — this brings the manager
+# Dockerfile into line with the rest of the project).
+ARG GOPROXY=""
+ENV GOPROXY=${GOPROXY}
+ARG GOINSECURE=""
+ENV GOINSECURE=${GOINSECURE}
+ARG GOPRIVATE=""
+ENV GOPRIVATE=${GOPRIVATE}
+ARG GOSUMDB="sum.golang.org"
+ENV GOSUMDB=${GOSUMDB}
+
 WORKDIR /workspace
+
+# H1 PR-2 (#116): inject any corporate CA certificates BEFORE `go mod
+# download` so TLS-intercepting proxies don't break the module fetch.
+# Standard Debian/Ubuntu flow: drop .crt files in
+# /usr/local/share/ca-certificates/ and run update-ca-certificates to
+# rebuild the trust bundle (the orphan root Dockerfile used the wrong
+# directory, /etc/ssl/certs/, which update-ca-certificates ignores).
+# Upstream releases ship an empty ca-certs/ (only .gitkeep + README.md);
+# the COPY is a no-op as update-ca-certificates skips non-.crt files.
+COPY ca-certs/ /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 # Copy the Go Modules manifests and local modules (needed for replace directives)
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -37,7 +75,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM ${BASE_IMAGE}
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/ca-certs/README.md
+++ b/ca-certs/README.md
@@ -1,0 +1,48 @@
+# Corporate CA certificates for the manager build
+
+This directory is consumed by `build/Dockerfile.manager` during the **builder stage** to install corporate / private CA certificates into the Go module fetch path. Upstream releases ship this directory empty (only `.gitkeep` + this `README.md`); the `COPY ca-certs/ /usr/local/share/ca-certificates/` step in the Dockerfile is a no-op in that case because `update-ca-certificates` skips non-`.crt` files.
+
+## When you need this
+
+You need to populate this directory if **either** of these is true for your build environment:
+
+1. Your `go mod download` traffic transits a corporate **TLS-intercepting proxy** (Zscaler, Netskope, Symantec, BlueCoat, …) that re-signs HTTPS with an internal CA, and you have not pre-baked that CA into your builder image.
+2. Your `GOPROXY` setting points at an **internal module mirror** (Artifactory, JFrog, Sonatype Nexus, GitLab Module Registry, …) that serves over HTTPS with a private CA.
+
+If neither is true, leave this directory as-is — the upstream public CA bundle is sufficient.
+
+## How to use
+
+1. Drop one or more `.crt` files (PEM-encoded X.509, one cert per file is best) into this directory:
+   ```
+   ca-certs/corporate-root-ca.crt
+   ca-certs/internal-tls-intercept.crt
+   ```
+2. Rebuild the manager image:
+   ```bash
+   make docker-build VERSION=v0.3.6 GIT_SHA=$(git rev-parse HEAD)
+   # or directly:
+   docker build -f build/Dockerfile.manager \
+       --build-arg VERSION=v0.3.6 \
+       --build-arg GIT_SHA=$(git rev-parse HEAD) \
+       -t my-registry/virtrigaud-manager:v0.3.6 .
+   ```
+3. `update-ca-certificates` runs as part of the build stage and rebuilds `/etc/ssl/certs/ca-certificates.crt` so all subsequent `go mod download` calls inside the same build trust the certs you provided.
+
+## Scope: builder only, NOT runtime
+
+These certs are installed into the **builder stage** only. The final image (`gcr.io/distroless/static:nonroot` by default) is a minimal distroless static image and is NOT rebuilt to include these custom CAs.
+
+If your **runtime** environment also needs custom CAs (for example, the manager talks to remote provider pods over HTTPS through a TLS-intercepting proxy), do **not** add them here — instead mount them into the deployed pod via a Kubernetes Secret or ConfigMap, or use a custom `BASE_IMAGE` build-arg that points at an image with your CAs already trusted.
+
+## Security notes
+
+- **One `.crt` per file, PEM-encoded.** Bundles (`.pem` files containing multiple certs) work too, but the file extension must be `.crt` for `update-ca-certificates` to pick it up.
+- **Do not commit organisation-internal CAs to a public fork.** Use `.gitignore` in your private fork to keep them local, or inject them via your CI's secrets / artifact storage at build time.
+- **No private keys, ever.** Only certificates (public, `BEGIN CERTIFICATE`). Anything starting `BEGIN PRIVATE KEY` or `BEGIN RSA PRIVATE KEY` does not belong in this directory.
+
+## Related
+
+- ADR-0002 (build-path consolidation) — `fieldTesting/ADR-0002-build-path-consolidation.md`
+- H1 PR-2 — issue #116, the change that introduced this directory
+- H1 umbrella — issue #92


### PR DESCRIPTION
## Summary
- Closes #116 (H1 PR-2). Second implementation chunk of the build-path consolidation roadmap (ADR-0002 in `fieldTesting/`).
- Brings `build/Dockerfile.manager` in line with the rest of the project — all 3 provider Dockerfiles already declared these ARGs; the manager was the outlier.
- **No code changes**; Dockerfile + new `ca-certs/` subdirectory + CHANGELOG.

## What's in this PR

### `build/Dockerfile.manager`
Adds the 6 missing ARGs (defaults preserve current upstream release behaviour):
| ARG | Default | Purpose |
|---|---|---|
| `BUILDER_IMAGE` | `docker.io/golang:1.25` | Corporate mirror override (Artifactory, Harbor, …) |
| `BASE_IMAGE` | `gcr.io/distroless/static:nonroot` | Same |
| `GOPROXY` | `""` | Corporate Go module proxy |
| `GOINSECURE` | `""` | |
| `GOPRIVATE` | `""` | |
| `GOSUMDB` | `sum.golang.org` | |

Plus CA-cert injection in the builder stage **before** `go mod download` (so TLS-intercepting proxies don't break module fetches):
```
COPY ca-certs/ /usr/local/share/ca-certificates/
RUN update-ca-certificates
```

### `ca-certs/` (new directory)
- `ca-certs/.gitkeep` — placeholder so the directory exists upstream.
- `ca-certs/README.md` — operator guide (when, how, scope, security).

Upstream ships `ca-certs/` empty (just `.gitkeep` + README); `update-ca-certificates` skips non-`.crt` files, so the COPY is a no-op upstream. Corporate forks drop their `.crt` files in and rebuild.

### `CHANGELOG.md`
Detailed entry with audit findings, defaults-preserved guarantee, security rationale.

## Why this matters
1. **All 3 provider Dockerfiles already declared these ARGs.** The manager Dockerfile being the outlier was tech-debt that operators discovered via failed builds in regulated environments.
2. **Banking customers categorically cannot pull from `docker.io` or `gcr.io`** in production. Without these ARGs they forked the Dockerfile; forks drift. One `--build-arg` override now suffices.
3. **Fixes the orphan Dockerfile's broken CA-cert handling.** The orphan did `COPY *.crt /etc/ssl/certs/` which (a) failed on fresh checkout because the glob matched zero files, and (b) used the wrong directory — `update-ca-certificates` reads inputs from `/usr/local/share/ca-certificates/`. This PR uses the correct pattern.
4. **Subdirectory pattern limits the security blast radius** vs. the orphan's repo-root glob (ADR-0002 flagged this).

## Test plan
- [x] `make fmt` clean (no Go code changes; informational)
- [x] `go vet ./...` clean
- [x] `go test ./cmd/manager/...` passes (PR-1's `TestVersionString` still green)
- [x] **Manual smoke 1 — default args**:
  ```
  docker build -f build/Dockerfile.manager \
    --build-arg VERSION=v0.3.6-h1pr2-test \
    --build-arg GIT_SHA=$(git rev-parse HEAD) \
    -t virtrigaud-manager:h1pr2-test .
  docker run --rm virtrigaud-manager:h1pr2-test --version
  # → virtrigaud-manager v0.3.6-h1pr2-test (23457f932...) exit 0
  ```
  This proves PR-1 + PR-2 stack correctly.
- [x] **Manual smoke 2 — override args**:
  ```
  docker build -f build/Dockerfile.manager \
    --build-arg VERSION=v0.3.6-h1pr2-override \
    --build-arg GIT_SHA=$(git rev-parse HEAD) \
    --build-arg BUILDER_IMAGE=docker.io/golang:1.25 \
    --build-arg GOSUMDB=off \
    -t virtrigaud-manager:h1pr2-override .
  ```
  Builds cleanly with overrides applied.
- [ ] **v0.3.6-rc1 smoke** (post-merge): the release workflow builds the manager image with `VERSION=<tag>` + `GIT_SHA=<sha>` only — the new ARGs fall back to defaults. Expected outcome: published image is content-equivalent to today's release.

## Defaults are unchanged
A default-deployed manager build (`docker build -f build/Dockerfile.manager .` with no overrides):
- Uses `docker.io/golang:1.25` as builder (was hardcoded)
- Uses `gcr.io/distroless/static:nonroot` as base (was hardcoded)
- `GOSUMDB=sum.golang.org` (matches Go default)
- `GOPROXY`/`GOINSECURE`/`GOPRIVATE` empty (no override)
- `ca-certs/` contains only `.gitkeep` + README, so `update-ca-certificates` finds nothing → no-op

The only behaviour change at defaults is one new cached layer (the `COPY ca-certs/` + `RUN update-ca-certificates` pair) which is byte-deterministic across builds.

## What's coming next in the H1 roadmap
| # | Issue | What | Release |
|---|---|---|---|
| PR-1 | #114 | Port `--version` + certwatcher + metrics RBAC | ✅ MERGED |
| **PR-2** | **#116 ← this PR** | Add `ARG BUILDER_IMAGE/BASE_IMAGE/GOPROXY` + CA-cert | v0.3.6 |
| PR-3 | (TBF) | Redirect Makefile targets to canonical Dockerfile; closes #113 (latent bug) | v0.3.6 |
| PR-4 | (TBF) | Delete `cmd/main.go` + root `Dockerfile`; closes #92 (H1 umbrella) | v0.3.6 |
| PR-5 | (TBF) | Flip `--metrics-secure` default to `true` — **BREAKING** | v0.4.0 |