### PR TITLE
fix(make): redirect build/run/docker-build/docker-buildx to canonical path (H1 PR-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-24 11:38] - fix(make): redirect build/run/docker-build/docker-buildx to canonical path; closes latent #113 (H1 PR-3 / closes #118)
+**Author:** @williamrizzo (William Rizzo)
+
+### Audit finding
+Third implementation chunk of the H1 build-path consolidation roadmap (`fieldTesting/ADR-0002-build-path-consolidation.md`). The Makefile's local-dev build targets (`make build`, `make run`, `make docker-build`, `make docker-build-multiplatform`, `make docker-buildx`) all invoked the orphan path — `cmd/main.go` and the root `Dockerfile`. That orphan path produces an **incomplete manager binary** (this is #113, the latent bug discovered during the H1 audit):
+
+- **No `metrics.SetupMetrics()` call** — local-dev manager never emits `virtrigaud_build_info`.
+- **VMSnapshot controller NOT registered** — local-dev manager could not reconcile `VMSnapshot` CRs at all.
+- **VMMigration controller NOT registered** — local-dev manager could not reconcile `VMMigration` CRs at all.
+
+Anyone using `make docker-build`, `make build`, `make run` for local testing has been running a half-working binary ever since these paths diverged.
+
+### Changed
+- `Makefile:build` target — now `go build ... ./cmd/manager` (was `cmd/main.go`).
+- `Makefile:run` target — now `go run ./cmd/manager` (was `./cmd/main.go`).
+- `Makefile:docker-build` target — now `$(CONTAINER_TOOL) build -f build/Dockerfile.manager ...` (was implicit `-f Dockerfile` pointing at the orphan root Dockerfile). All 10 `--build-arg` flags are preserved verbatim.
+- `Makefile:docker-build-multiplatform` target — same `-f build/Dockerfile.manager` redirect.
+- `Makefile:docker-buildx` target — `sed` source is now `build/Dockerfile.manager` (was root `Dockerfile`). The transformed `Dockerfile.cross` output continues to be written to and cleaned up from repo root.
+
+All five edits carry an inline `# H1 PR-3 (#118): ...` comment block explaining the redirect and pointing at #113.
+
+### Fixed
+- **#113** — `make docker-build`, `make build`, and `make run` now produce a manager binary functionally equivalent to the released image: emits `virtrigaud_build_info`, registers all 8 controllers (including VMSnapshot + VMMigration), exposes the `--version` handler from PR #115 (H1 PR-1).
+
+### Why
+1. **Fixes the silent #113 bug** at its root cause: the Makefile targets pointed at the wrong files. Every local-dev manager build before this commit was missing real functionality.
+2. **Cleans up the H1 surface area** before PR-4 (orphan deletion): after this PR lands, `cmd/main.go` and root `Dockerfile` are truly orphaned — no Makefile target, no CI workflow, no hack script references them anymore. (Verified — `hack/dev-deploy.sh` already used `-f build/Dockerfile.manager`; the CI `Build (manager)` matrix job already used `go build ./cmd/manager` directly.)
+3. **Brings local-dev parity with CI and release**: CI's `Build (manager)` job and the release workflow both target `cmd/manager/main.go` + `build/Dockerfile.manager`. Now `make build` matches.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout — only for local-dev workflows: anyone doing `make dev-deploy` after running `make docker-build` will pick up a manager binary with NEW controllers (VMSnapshot, VMMigration) and NEW metrics emission they were previously missing. This is the desired behaviour, but if local CRs of those kinds were left in a stale state, they will start being reconciled. Call out to local-dev users: review your VMSnapshot / VMMigration CRs after upgrading. CI and release builds are unaffected (already on canonical).
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- **CI is unaffected.** `.github/workflows/ci.yml` line 256 uses `go build -o bin/manager ./cmd/manager` directly (not `make build`). Line 343's container-image matrix uses `./build/Dockerfile.manager` for manager (not `make docker-build`). The CI `Build (manager)` job was already on canonical; only local-dev workflows shift with this PR.
+- **`make dev-deploy` is unaffected.** `hack/dev-deploy.sh` line 148 already used `-f build/Dockerfile.manager`. The bug only bit users who reached for raw `make docker-build` or `make build`.
+- Manual smoke pre-merge:
+  - `make build` → `./bin/manager --version` returned `virtrigaud-manager v0.3.5-6-g4c1746d-dirty (4c1746da3...)`, exit 0.
+  - `strings ./bin/manager | grep -E 'vmsnapshot-controller|vmmigration-controller'` → both symbols present.
+  - `make docker-build CONTROLLER_IMG=virtrigaud-manager:h1pr3-test VERSION=v0.3.6-h1pr3-test` → image built; `docker run --rm virtrigaud-manager:h1pr3-test --version` returned `virtrigaud-manager v0.3.6-h1pr3-test (4c1746d...)`, exit 0.
+- This is the third PR in the H1 roadmap; PR-4 (delete `cmd/main.go` + root `Dockerfile`) is now unblocked and can land next.
+
+---
+
 ## [2026-05-24 10:50] - feat(build): add BUILDER_IMAGE/BASE_IMAGE/GOPROXY ARGs + CA-cert handling to build/Dockerfile.manager (H1 PR-2 / closes #116)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,11 @@ proto-breaking: buf ## Check for breaking changes in protocol buffer definitions
 
 .PHONY: build
 build: gen-crds generate fmt vet ## Build manager binary.
-	go build -ldflags "$(LDFLAGS)" -o bin/manager cmd/main.go
+	# H1 PR-3 (#118): build the CANONICAL manager entrypoint (cmd/manager/main.go),
+	# matching what build/Dockerfile.manager and the release pipeline build.
+	# The previous target built cmd/main.go which was silently missing
+	# metrics.SetupMetrics + VMSnapshot + VMMigration controllers (see #113).
+	go build -ldflags "$(LDFLAGS)" -o bin/manager ./cmd/manager
 
 .PHONY: build-provider-libvirt
 build-provider-libvirt: proto ## Build libvirt provider binary (requires CGO)
@@ -221,7 +225,8 @@ build-providers: build-provider-libvirt build-provider-vsphere build-provider-pr
 
 .PHONY: run
 run: gen-crds generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+	# H1 PR-3 (#118): run the CANONICAL manager entrypoint. See `build` target above.
+	go run ./cmd/manager
 
 ##@ Module Release
 
@@ -281,7 +286,11 @@ release-sdk: ## Release SDK module with tags and generate docs
 #   make docker-buildx BUILD_PLATFORMS=linux/arm64,linux/amd64  # Build and push for multiple platforms
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build --platform $(PLATFORM) -t ${CONTROLLER_IMG} \
+	# H1 PR-3 (#118): -f build/Dockerfile.manager — use the CANONICAL Dockerfile
+	# (same one the release pipeline uses). The previous implicit `-f Dockerfile`
+	# pointed at the root Dockerfile + cmd/main.go, which was missing metrics
+	# setup + VMSnapshot + VMMigration controllers (see #113).
+	$(CONTAINER_TOOL) build --platform $(PLATFORM) -f build/Dockerfile.manager -t ${CONTROLLER_IMG} \
 		--build-arg VERSION="$(VERSION)" \
 		--build-arg GIT_SHA="$(GIT_SHA)" \
 		--build-arg TARGETOS="$(shell echo $(PLATFORM) | cut -d'/' -f1)" \
@@ -296,7 +305,8 @@ docker-build: ## Build docker image with the manager.
 
 .PHONY: docker-build-multiplatform
 docker-build-multiplatform: ## Build docker image for multiple platforms (without push)
-	$(CONTAINER_TOOL) buildx build --platform $(BUILD_PLATFORMS) -t ${CONTROLLER_IMG} \
+	# H1 PR-3 (#118): same redirect as `docker-build` — see comment above.
+	$(CONTAINER_TOOL) buildx build --platform $(BUILD_PLATFORMS) -f build/Dockerfile.manager -t ${CONTROLLER_IMG} \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GIT_SHA=$(GIT_SHA) \
 		--load \
@@ -393,8 +403,11 @@ docker-provider-proxmox-multiplatform: ## Build proxmox provider for multiple pl
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	# H1 PR-3 (#118): sed-transform the CANONICAL Dockerfile (build/Dockerfile.manager)
+	# into Dockerfile.cross at repo root, inserting --platform=${BUILDPLATFORM}
+	# into the FROM line(s). Was previously transforming the orphan root
+	# Dockerfile, building the wrong binary across all platforms (see #113).
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' build/Dockerfile.manager > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name virtrigaud-builder
 	$(CONTAINER_TOOL) buildx use virtrigaud-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${CONTROLLER_IMG} -f Dockerfile.cross \


### PR DESCRIPTION
## Summary
- Closes **#118** (H1 PR-3 sub-issue) AND **#113** (the latent bug: local-dev `make docker-build` / `make build` / `make run` produced an incomplete manager binary).
- Third implementation chunk of the build-path consolidation roadmap (ADR-0002 in `fieldTesting/`).
- Five Makefile targets redirected from the orphan path (`cmd/main.go` + root `Dockerfile`) to the canonical path (`cmd/manager/main.go` + `build/Dockerfile.manager`).

## The bug (#113), demonstrated

Before this PR, on `main`:
```
$ grep -c metrics.SetupMetrics cmd/main.go cmd/manager/main.go
cmd/main.go:0
cmd/manager/main.go:1

$ grep -c SetupWithManager cmd/main.go cmd/manager/main.go
cmd/main.go:6
cmd/manager/main.go:8       # 2 extra: VMSnapshot + VMMigration
```

So `make docker-build` and `make build` shipped a manager binary that:
- never emitted `virtrigaud_build_info` (so operators couldn't tell which version they were running)
- couldn't reconcile `VMSnapshot` CRs (no controller registered)
- couldn't reconcile `VMMigration` CRs (no controller registered)

## What's in this PR

Five Makefile targets, one CHANGELOG entry. Each Makefile edit carries an inline `# H1 PR-3 (#118): ...` comment explaining the redirect.

| Target | Before | After |
|---|---|---|
| `make build` | `go build ... cmd/main.go` | `go build ... ./cmd/manager` |
| `make run` | `go run ./cmd/main.go` | `go run ./cmd/manager` |
| `make docker-build` | implicit `-f Dockerfile` (root) | `-f build/Dockerfile.manager` |
| `make docker-build-multiplatform` | implicit `-f Dockerfile` (root) | `-f build/Dockerfile.manager` |
| `make docker-buildx` | `sed ... Dockerfile > Dockerfile.cross` | `sed ... build/Dockerfile.manager > Dockerfile.cross` |

## What this PR does NOT touch
- **CI workflows.** `.github/workflows/ci.yml` line 256 already used `go build ./cmd/manager` directly; line 343's manager-image matrix already used `./build/Dockerfile.manager`. CI was already on canonical and will see zero behaviour change.
- **`make dev-deploy`.** `hack/dev-deploy.sh` line 148 already used `-f build/Dockerfile.manager`. Users of `make dev-deploy` were NOT affected by #113.
- **The orphan files themselves.** `cmd/main.go` and root `Dockerfile` stay in place. PR-4 (H1 roadmap) will delete them after this lands — at which point they are truly orphans (no Makefile target, no CI workflow, no hack script references them).

## Test plan
- [x] `make fmt` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/manager/...` passes (PR-1's `TestVersionString` still green)
- [x] **Manual smoke 1 — `make build`**: `./bin/manager --version` → `virtrigaud-manager v0.3.5-6-g4c1746d-dirty (4c1746da3...)`, exit 0.
- [x] **Bug-fix canary**: `strings ./bin/manager | grep -E 'vmsnapshot-controller|vmmigration-controller'` → both symbols present. (Before this PR, only the canonical Dockerfile-built binary had them; `make build` produced a binary missing both.)
- [x] **Manual smoke 2 — `make docker-build`**: `make docker-build CONTROLLER_IMG=virtrigaud-manager:h1pr3-test VERSION=v0.3.6-h1pr3-test` → image built; `docker run --rm virtrigaud-manager:h1pr3-test --version` → `virtrigaud-manager v0.3.6-h1pr3-test (4c1746d...)`, exit 0. This proves PR-1 + PR-2 + PR-3 stack correctly.
- [ ] **v0.3.6-rc1 smoke** (post-merge): default-deployed manager on `vr1.lab.k8` continues to behave correctly. Smoke checklist should include checking that local-dev workflows (`make dev-deploy` on a kind cluster) produce a manager that emits `virtrigaud_build_info` AND has VMSnapshot/VMMigration controllers running.

## Behaviour change called out
Anyone running `make docker-build` (or downstream like `make dev-deploy` IF they had been bypassing the script) for local dev will now get a manager binary with **VMSnapshot + VMMigration controllers running**. If they had stale CRs of those kinds lying around, those CRs will start being reconciled — that is desired behaviour but it IS a change. CHANGELOG entry calls this out.

## What's coming next in the H1 roadmap
| # | Issue | What | Release |
|---|---|---|---|
| PR-1 | #114 | Port `--version` + certwatcher + metrics RBAC | ✅ MERGED |
| PR-2 | #116 | Add `ARG BUILDER_IMAGE/BASE_IMAGE/GOPROXY` + CA-cert | ✅ MERGED |
| **PR-3** | **#118 ← this PR** | Redirect Makefile targets; closes #113 | v0.3.6 |
| PR-4 | (TBF) | Delete `cmd/main.go` + root `Dockerfile`; closes #92 | v0.3.6 |
| PR-5 | (TBF) | Flip `--metrics-secure` default to `true` — **BREAKING** | v0.4.0 |