### PR TITLE
feat(obs): wire virtrigaud_vm_operations_total in gRPC client (G7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-25 05:35] - feat(obs): wire virtrigaud_vm_operations_total in gRPC client VM-operation methods (G7.1 / closes #124)
+**Author:** @williamrizzo (William Rizzo)
+
+### Audit finding
+First implementation chunk of the G7 umbrella (#123). The `virtrigaud_vm_operations_total{operation,provider_type,provider,outcome}` metric family was registered in `internal/obs/metrics/metrics.go` and had a helper `(*VMOperationMetrics).RecordOperation(op, outcome)` — but **zero production callsites called the helper**. Same shape of dead-code-paradox bug that G6 (#111) closed for CircuitBreaker metrics.
+
+The G4 metrics interceptor (PR #107) already records the lower-level `virtrigaud_provider_rpc_requests_total{provider_type, method, code}` — the per-gRPC-method counter. G7.1 adds the **higher-level** per-VM-operation counter, which is what operators dashboard for questions like "how often does Create fail on the vsphere-prod Provider?" without having to know the gRPC method shape.
+
+### Added
+- `internal/transport/grpc/client.go`: `Client.vmOps *metrics.VMOperationMetrics` field, initialised by `NewClient` from the new `providerName` parameter (paired with the existing `providerType`).
+- `internal/transport/grpc/client.go`: `(*Client).recordVMOp(op string, retErr *error)` helper. Designed to be called via `defer c.recordVMOp(metrics.OpCreate, &retErr)` from each VM-operation method, with a named `retErr` return value. The pointer-to-error indirection is the load-bearing piece: it lets the deferred call evaluate the FINAL return value rather than the value at defer-time (always nil). Nil-safe on `c.vmOps` so tests that construct `&Client{...}` directly don't panic.
+- `internal/transport/grpc/client_vm_operations_test.go` (new): 4 tests covering:
+  - `TestRecordVMOp_NilVMOpsIsSafe` — pins the nil-safety contract on the helper.
+  - `TestRecordVMOp_OutcomeDerivation` — pins success vs error outcome derivation, including the defensive nil-`*error` path.
+  - `TestClient_VMOperations_RecordOnSuccess` — table-driven canary, all 5 VM-op methods × success path, asserts per-operation counter increments by exactly 1.
+  - `TestClient_VMOperations_RecordOnError` — same table × error path, asserts the `{outcome="error"}` sample increments. Catches the regression class where outcome derivation inverts.
+- `internal/transport/grpc/client_vm_operations_test.go`: new `fakeVMOpsServer` that implements all 5 VM-operation server handlers with a `fail` toggle. Single bufconn server can produce both metric outcomes without re-instantiating.
+
+### Changed
+- `internal/transport/grpc/client.go`: `NewClient` signature gains a `providerName string` parameter between `providerType` and `cb`. Empty string is permitted (label will be empty) but discouraged in production — `provider` is the second half of the `{provider_type, provider}` label pair that lets operators distinguish multiple Providers of the same type.
+- `internal/transport/grpc/client.go`: 5 VM-operation methods refactored to use named return values + `defer c.recordVMOp(metrics.Op<X>, &retErr)`:
+  - `Create` → `(result contracts.CreateResponse, retErr error)`
+  - `Delete` → `(taskRef string, retErr error)`
+  - `Power` → `(taskRef string, retErr error)`
+  - `Describe` → `(result contracts.DescribeResponse, retErr error)`
+  - `Reconfigure` → `(taskRef string, retErr error)`
+  Same shape as G1's named-return reconcile-timer pattern (PR #101). All other method bodies are unchanged.
+- `internal/runtime/remote/resolver.go`: passes `provider.Name` as the new `providerName` parameter to `NewClient`. Doc comment updated to call out which label `provider.Name` populates.
+- `internal/transport/grpc/client_metrics_test.go`: `newTestClient` initialises the new `vmOps` field so deferred `recordVMOp` calls in production methods remain safe under this test path.
+- `internal/transport/grpc/client_circuitbreaker_test.go`: same change to `newTestClientWithCB`; added `metrics` import.
+
+### Why
+1. **Closes the G7.1 part of the G7 umbrella (#123).** First of 4 deferred-from-G-track metric families to wire up.
+2. **Operator-facing signal that's been missing.** "How often is Create failing on this Provider?" is a routine question for an operator on call. Today (pre-merge) the answer requires knowing the gRPC method names and joining `virtrigaud_provider_rpc_requests_total` on labels. After this PR the answer is a single PromQL query on `virtrigaud_vm_operations_total{operation="Create", outcome="error"}`.
+3. **Sets the wiring pattern for the rest of G7.** The named-return + defer + nil-safe helper combo is the canonical pattern this codebase has converged on (G1 reconcile timer, G3 double-count fix, G6 circuit breaker). G7.2/G7.3/G7.4 should reuse it.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager binary gains new metric emission; new metric series appear on `/metrics` after rollout)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- `NewClient` signature change ripples to 3 call sites: `internal/runtime/remote/resolver.go` (production — passes `provider.Name`), and the two test helpers in `internal/transport/grpc/` (test — pass synthetic provider names). No other production callers exist.
+- The `Validate` RPC and the snapshot/task/disk-related methods are intentionally NOT instrumented with `vm_operations_total` — they are not VM operations in the operator-facing sense. The G4 interceptor still records every RPC at the lower level via `virtrigaud_provider_rpc_requests_total`.
+- Pre-merge verification: `make fmt` clean; `go vet ./...` clean; `make test` 12/12 packages pass with 0 FAIL; `make build` produces a working `bin/manager` with `--version` exit 0. The new test file adds 12 sub-test cases (4 tests × multiple operations).
+- Next in G7: G7.2 (file sub-issue when starting) — wire `virtrigaud_ip_discovery_duration_seconds` in the VirtualMachineReconciler IP-discovery path.
+
+---
+
 ## [2026-05-24 21:27] - chore: bump Go toolchain floor to 1.26.0 and pin Dockerfiles to golang:1.26.3 (closes #122)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/internal/runtime/remote/resolver.go
+++ b/internal/runtime/remote/resolver.go
@@ -111,6 +111,8 @@ func (r *Resolver) getRemoteProvider(ctx context.Context, provider *infravirtrig
 
 	// provider.Spec.Type populates the `provider_type` label on every
 	// virtrigaud_provider_rpc_* sample emitted by this client (G4 / #90).
+	// provider.Name populates the `provider` label on every
+	// virtrigaud_vm_operations_total sample (G7.1 / #124).
 	// One CircuitBreaker per Provider CR is allocated from the shared
 	// registry (G6 / #111); when cbRegistry is nil (test path), the
 	// gRPC client is constructed without breaker protection.
@@ -118,7 +120,7 @@ func (r *Resolver) getRemoteProvider(ctx context.Context, provider *infravirtrig
 	if r.cbRegistry != nil {
 		cb = r.cbRegistry.GetOrCreate(circuitBreakerName, string(provider.Spec.Type), provider.Name)
 	}
-	client, err := grpcClient.NewClient(ctx, provider.Status.Runtime.Endpoint, string(provider.Spec.Type), cb, tlsConfig)
+	client, err := grpcClient.NewClient(ctx, provider.Status.Runtime.Endpoint, string(provider.Spec.Type), provider.Name, cb, tlsConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC client: %w", err)
 	}

--- a/internal/transport/grpc/client.go
+++ b/internal/transport/grpc/client.go
@@ -42,6 +42,14 @@ import (
 type Client struct {
 	conn   *grpc.ClientConn
 	client providerv1.ProviderClient
+	// vmOps records per-VM-operation counters (G7.1 / #124). Always
+	// non-nil for production clients constructed via NewClient — the
+	// constructor initialises it from (providerType, providerName) even
+	// when those are empty strings, so recordVMOp can call into it
+	// without a nil check. May be nil in tests that bypass NewClient
+	// (e.g. construct &Client{...} directly); recordVMOp is nil-safe to
+	// support that path.
+	vmOps *metrics.VMOperationMetrics
 }
 
 // NewClient creates a new gRPC provider client.
@@ -52,6 +60,12 @@ type Client struct {
 // permitted (the label will be empty) but discouraged in production —
 // makes per-provider-type alerts impossible.
 //
+// providerName is the Provider CR's metadata.name (e.g. "vsphere-prod",
+// "libvirt-lab"). Used as the `provider` label on
+// virtrigaud_vm_operations_total samples emitted by this client (G7.1 /
+// #124). Empty string is permitted (label will be empty); discouraged
+// in production for the same reason as providerType.
+//
 // cb is an optional CircuitBreaker wrapping every outbound RPC. When
 // non-nil, infrastructure-class gRPC errors (Unavailable, DeadlineExceeded,
 // Internal, Unknown) count toward the breaker's failure threshold; once
@@ -59,7 +73,7 @@ type Client struct {
 // Unavailable status until ResetTimeout elapses (G6 / #111). Pass nil to
 // disable circuit-breaker protection — useful in unit tests that exercise
 // real gRPC failure semantics without the breaker interposing.
-func NewClient(ctx context.Context, endpoint string, providerType string, cb *resilience.CircuitBreaker, tlsConfig *TLSConfig) (*Client, error) {
+func NewClient(ctx context.Context, endpoint string, providerType string, providerName string, cb *resilience.CircuitBreaker, tlsConfig *TLSConfig) (*Client, error) {
 	// Connection timeout is handled by grpc.NewClient internally
 	_ = ctx // Context available for future timeout implementation
 
@@ -115,6 +129,11 @@ func NewClient(ctx context.Context, endpoint string, providerType string, cb *re
 	return &Client{
 		conn:   conn,
 		client: client,
+		// G7.1 (#124): per-VM-operation counter, labelled by
+		// providerType + providerName so dashboards can answer
+		// "how often does Create fail on the vsphere-prod Provider?"
+		// independently of the gRPC-method-level G4 view.
+		vmOps: metrics.NewVMOperationMetrics(providerType, providerName),
 	}, nil
 }
 
@@ -260,6 +279,37 @@ func isInfraFailure(err error) bool {
 	}
 }
 
+// recordVMOp records a virtrigaud_vm_operations_total sample for the
+// given operation. G7.1 / #124.
+//
+// Designed to be called via `defer c.recordVMOp(metrics.OpCreate,
+// &retErr)` from each VM-operation method, with a named `retErr` return
+// value. The pointer-to-error indirection is required so the deferred
+// call evaluates the FINAL return value of the enclosing function, not
+// the value of err at defer-time (which would always be nil, since the
+// defer runs before any explicit `return ...` evaluates).
+//
+// Nil-safe on c.vmOps (tests that construct &Client{...} directly
+// bypass NewClient and may not have it set). Production clients via
+// NewClient always have it initialised.
+//
+// Outcome derivation matches G1-G3's named-return reconcile pattern:
+//   - retErr == nil  → metrics.OutcomeSuccess
+//   - retErr != nil  → metrics.OutcomeError
+//
+// The provider/provider_type labels come from the values passed to
+// NewVMOperationMetrics at NewClient construction time.
+func (c *Client) recordVMOp(op string, retErr *error) {
+	if c.vmOps == nil {
+		return
+	}
+	outcome := metrics.OutcomeSuccess
+	if retErr != nil && *retErr != nil {
+		outcome = metrics.OutcomeError
+	}
+	c.vmOps.RecordOperation(op, outcome)
+}
+
 // Close closes the gRPC connection
 func (c *Client) Close() error {
 	return c.conn.Close()
@@ -282,8 +332,13 @@ func (c *Client) Validate(ctx context.Context) error {
 	return nil
 }
 
-// Create implements contracts.Provider
-func (c *Client) Create(ctx context.Context, req contracts.CreateRequest) (contracts.CreateResponse, error) {
+// Create implements contracts.Provider.
+//
+// Records virtrigaud_vm_operations_total{operation="Create",...} via
+// deferred recordVMOp using the named retErr return value (G7.1 / #124).
+func (c *Client) Create(ctx context.Context, req contracts.CreateRequest) (result contracts.CreateResponse, retErr error) {
+	defer c.recordVMOp(metrics.OpCreate, &retErr)
+
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
@@ -297,7 +352,7 @@ func (c *Client) Create(ctx context.Context, req contracts.CreateRequest) (contr
 		return contracts.CreateResponse{}, c.mapGRPCError("create", err)
 	}
 
-	result := contracts.CreateResponse{
+	result = contracts.CreateResponse{
 		ID: resp.Id,
 	}
 
@@ -308,8 +363,13 @@ func (c *Client) Create(ctx context.Context, req contracts.CreateRequest) (contr
 	return result, nil
 }
 
-// Delete implements contracts.Provider
-func (c *Client) Delete(ctx context.Context, id string) (taskRef string, err error) {
+// Delete implements contracts.Provider.
+//
+// Records virtrigaud_vm_operations_total{operation="Delete",...} via
+// deferred recordVMOp using the named retErr return value (G7.1 / #124).
+func (c *Client) Delete(ctx context.Context, id string) (taskRef string, retErr error) {
+	defer c.recordVMOp(metrics.OpDelete, &retErr)
+
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
@@ -325,8 +385,13 @@ func (c *Client) Delete(ctx context.Context, id string) (taskRef string, err err
 	return "", nil
 }
 
-// Power implements contracts.Provider
-func (c *Client) Power(ctx context.Context, id string, op contracts.PowerOp) (taskRef string, err error) {
+// Power implements contracts.Provider.
+//
+// Records virtrigaud_vm_operations_total{operation="Power",...} via
+// deferred recordVMOp using the named retErr return value (G7.1 / #124).
+func (c *Client) Power(ctx context.Context, id string, op contracts.PowerOp) (taskRef string, retErr error) {
+	defer c.recordVMOp(metrics.OpPower, &retErr)
+
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
@@ -357,8 +422,14 @@ func (c *Client) Power(ctx context.Context, id string, op contracts.PowerOp) (ta
 	return "", nil
 }
 
-// Reconfigure implements contracts.Provider
-func (c *Client) Reconfigure(ctx context.Context, id string, desired contracts.CreateRequest) (taskRef string, err error) {
+// Reconfigure implements contracts.Provider.
+//
+// Records virtrigaud_vm_operations_total{operation="Reconfigure",...}
+// via deferred recordVMOp using the named retErr return value (G7.1 /
+// #124).
+func (c *Client) Reconfigure(ctx context.Context, id string, desired contracts.CreateRequest) (taskRef string, retErr error) {
+	defer c.recordVMOp(metrics.OpReconfigure, &retErr)
+
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
@@ -382,8 +453,13 @@ func (c *Client) Reconfigure(ctx context.Context, id string, desired contracts.C
 	return "", nil
 }
 
-// Describe implements contracts.Provider
-func (c *Client) Describe(ctx context.Context, id string) (contracts.DescribeResponse, error) {
+// Describe implements contracts.Provider.
+//
+// Records virtrigaud_vm_operations_total{operation="Describe",...} via
+// deferred recordVMOp using the named retErr return value (G7.1 / #124).
+func (c *Client) Describe(ctx context.Context, id string) (result contracts.DescribeResponse, retErr error) {
+	defer c.recordVMOp(metrics.OpDescribe, &retErr)
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/internal/transport/grpc/client_circuitbreaker_test.go
+++ b/internal/transport/grpc/client_circuitbreaker_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 	"github.com/projectbeskar/virtrigaud/internal/resilience"
 	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
 )
@@ -93,7 +94,16 @@ func newTestClientWithCB(t *testing.T, dialer func(context.Context, string) (net
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
-	return &Client{conn: conn, client: providerv1.NewProviderClient(conn)}, cb
+	// vmOps initialised so the deferred recordVMOp in production
+	// methods is safe — these CB tests only call Validate which does
+	// not record vm_operations_total, but the field needs to be
+	// non-nil for any future test that adds a VM-operation call here
+	// (G7.1 / #124).
+	return &Client{
+		conn:   conn,
+		client: providerv1.NewProviderClient(conn),
+		vmOps:  metrics.NewVMOperationMetrics(providerType, providerName),
+	}, cb
 }
 
 // TestProviderCircuitBreakerInterceptor_InfraErrorsTripBreaker drives

--- a/internal/transport/grpc/client_metrics_test.go
+++ b/internal/transport/grpc/client_metrics_test.go
@@ -166,7 +166,15 @@ func newTestClient(t *testing.T, dialer func(context.Context, string) (net.Conn,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
-	return &Client{conn: conn, client: providerv1.NewProviderClient(conn)}
+	// vmOps initialised with providerType + empty providerName — keeps
+	// recordVMOp's defer in production methods nil-safe for this test
+	// path (G7.1 / #124). Tests asserting on vm_operations_total labels
+	// use a non-empty providerName per-call.
+	return &Client{
+		conn:   conn,
+		client: providerv1.NewProviderClient(conn),
+		vmOps:  metrics.NewVMOperationMetrics(providerType, ""),
+	}
 }
 
 // TestProviderRPCMetricsInterceptor_SuccessfulCall verifies that a

--- a/internal/transport/grpc/client_vm_operations_test.go
+++ b/internal/transport/grpc/client_vm_operations_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// fakeVMOpsServer implements enough of providerv1.ProviderServer to drive
+// the five VM-operation methods (Create / Delete / Power / Describe /
+// Reconfigure) exercised by G7.1 wiring. fail toggles every handler's
+// response between success and an Unavailable error so a single bufconn
+// server can produce both metric outcomes without re-instantiating.
+type fakeVMOpsServer struct {
+	providerv1.UnimplementedProviderServer
+	fail bool
+}
+
+func (f *fakeVMOpsServer) Create(ctx context.Context, req *providerv1.CreateRequest) (*providerv1.CreateResponse, error) {
+	if f.fail {
+		return nil, status.Error(codes.Unavailable, "induced create failure")
+	}
+	return &providerv1.CreateResponse{Id: "test-vm-id"}, nil
+}
+
+func (f *fakeVMOpsServer) Delete(ctx context.Context, req *providerv1.DeleteRequest) (*providerv1.TaskResponse, error) {
+	if f.fail {
+		return nil, status.Error(codes.Unavailable, "induced delete failure")
+	}
+	return &providerv1.TaskResponse{}, nil
+}
+
+func (f *fakeVMOpsServer) Power(ctx context.Context, req *providerv1.PowerRequest) (*providerv1.TaskResponse, error) {
+	if f.fail {
+		return nil, status.Error(codes.Unavailable, "induced power failure")
+	}
+	return &providerv1.TaskResponse{}, nil
+}
+
+func (f *fakeVMOpsServer) Describe(ctx context.Context, req *providerv1.DescribeRequest) (*providerv1.DescribeResponse, error) {
+	if f.fail {
+		return nil, status.Error(codes.Unavailable, "induced describe failure")
+	}
+	return &providerv1.DescribeResponse{Exists: true, PowerState: "On"}, nil
+}
+
+func (f *fakeVMOpsServer) Reconfigure(ctx context.Context, req *providerv1.ReconfigureRequest) (*providerv1.TaskResponse, error) {
+	if f.fail {
+		return nil, status.Error(codes.Unavailable, "induced reconfigure failure")
+	}
+	return &providerv1.TaskResponse{}, nil
+}
+
+// newTestClientForVMOps brings up an in-process gRPC server backed by
+// bufconn and returns a Client wired to it. vmOps is initialised with
+// the supplied provider labels so vm_operations_total samples carry the
+// right { provider_type, provider } pair for the assertions.
+//
+// This intentionally does NOT chain the CircuitBreaker interceptor —
+// these tests cover the G7.1 wiring path without entangling it with G6
+// semantics.
+func newTestClientForVMOps(t *testing.T, srv providerv1.ProviderServer, providerType, providerName string) *Client {
+	t.Helper()
+	dialer, cleanup := startBufconnServer(t, srv)
+	t.Cleanup(cleanup)
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return dialer(ctx, "") }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(providerRPCMetricsInterceptor(providerType)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return &Client{
+		conn:   conn,
+		client: providerv1.NewProviderClient(conn),
+		vmOps:  metrics.NewVMOperationMetrics(providerType, providerName),
+	}
+}
+
+// TestRecordVMOp_NilVMOpsIsSafe pins the nil-safety contract on
+// recordVMOp. Tests that construct &Client{...} directly (bypassing
+// NewClient) may leave vmOps unset; the helper must not panic.
+//
+// G7.1 / #124.
+func TestRecordVMOp_NilVMOpsIsSafe(t *testing.T) {
+	c := &Client{} // vmOps left nil on purpose
+	var nilErr error
+	// Must not panic. Outcome derivation is irrelevant when vmOps is nil.
+	c.recordVMOp(metrics.OpCreate, &nilErr)
+
+	err := assert.AnError
+	c.recordVMOp(metrics.OpDelete, &err)
+}
+
+// TestRecordVMOp_OutcomeDerivation pins the success vs error contract.
+// A nil *error gives Success; a non-nil *error containing a real error
+// gives Error; a non-nil *error containing nil gives Success.
+//
+// G7.1 / #124.
+func TestRecordVMOp_OutcomeDerivation(t *testing.T) {
+	const providerType, provider = "g71-derivation", "g71-derivation-provider"
+	c := &Client{vmOps: metrics.NewVMOperationMetrics(providerType, provider)}
+
+	wantSuccess := map[string]string{
+		"operation": metrics.OpCreate, "provider_type": providerType,
+		"provider": provider, "outcome": metrics.OutcomeSuccess,
+	}
+	wantError := map[string]string{
+		"operation": metrics.OpDelete, "provider_type": providerType,
+		"provider": provider, "outcome": metrics.OutcomeError,
+	}
+
+	successBefore := counterSampleByLabels(t, "virtrigaud_vm_operations_total", wantSuccess)
+	errorBefore := counterSampleByLabels(t, "virtrigaud_vm_operations_total", wantError)
+
+	// Nil retErr pointer → treated as success (defensive path).
+	c.recordVMOp(metrics.OpCreate, nil)
+	// Non-nil pointer to nil error → success.
+	var nilErr error
+	c.recordVMOp(metrics.OpCreate, &nilErr)
+	// Non-nil pointer to real error → error.
+	realErr := assert.AnError
+	c.recordVMOp(metrics.OpDelete, &realErr)
+
+	successAfter := counterSampleByLabels(t, "virtrigaud_vm_operations_total", wantSuccess)
+	errorAfter := counterSampleByLabels(t, "virtrigaud_vm_operations_total", wantError)
+
+	assert.Equal(t, successBefore+2, successAfter,
+		"two nil-error calls must each increment the success sample")
+	assert.Equal(t, errorBefore+1, errorAfter,
+		"one real-error call must increment the error sample exactly once")
+}
+
+// TestClient_VMOperations_RecordOnSuccess verifies the five VM-
+// operation methods each increment
+// virtrigaud_vm_operations_total{operation=<Op>, outcome="success"} by
+// exactly one when the underlying gRPC call returns success.
+//
+// G7.1 / #124. Pinned per-operation so a regression that drops the
+// defer on (say) Reconfigure but not the others is caught.
+func TestClient_VMOperations_RecordOnSuccess(t *testing.T) {
+	const providerType, provider = "g71-success", "g71-success-provider"
+	cli := newTestClientForVMOps(t, &fakeVMOpsServer{fail: false}, providerType, provider)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		op   string
+		fn   func() error
+	}{
+		{"Create", metrics.OpCreate, func() error {
+			_, e := cli.Create(ctx, contracts.CreateRequest{Name: "vm-1"})
+			return e
+		}},
+		{"Delete", metrics.OpDelete, func() error {
+			_, e := cli.Delete(ctx, "vm-1")
+			return e
+		}},
+		{"Power", metrics.OpPower, func() error {
+			_, e := cli.Power(ctx, "vm-1", contracts.PowerOpOn)
+			return e
+		}},
+		{"Describe", metrics.OpDescribe, func() error {
+			_, e := cli.Describe(ctx, "vm-1")
+			return e
+		}},
+		{"Reconfigure", metrics.OpReconfigure, func() error {
+			_, e := cli.Reconfigure(ctx, "vm-1", contracts.CreateRequest{Name: "vm-1"})
+			return e
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := map[string]string{
+				"operation":     tt.op,
+				"provider_type": providerType,
+				"provider":      provider,
+				"outcome":       metrics.OutcomeSuccess,
+			}
+			before := counterSampleByLabels(t, "virtrigaud_vm_operations_total", want)
+			require.NoError(t, tt.fn(), "%s call must succeed against the fake server", tt.name)
+			after := counterSampleByLabels(t, "virtrigaud_vm_operations_total", want)
+			assert.Equal(t, before+1, after,
+				"%s success must increment virtrigaud_vm_operations_total{operation=%s, outcome=success} by 1",
+				tt.name, tt.op)
+		})
+	}
+}
+
+// TestClient_VMOperations_RecordOnError verifies the five VM-operation
+// methods each increment
+// virtrigaud_vm_operations_total{operation=<Op>, outcome="error"} by
+// exactly one when the underlying gRPC call returns an error.
+//
+// G7.1 / #124. Catches the regression class where outcome derivation
+// inverts (success becomes error or vice-versa).
+func TestClient_VMOperations_RecordOnError(t *testing.T) {
+	const providerType, provider = "g71-error", "g71-error-provider"
+	cli := newTestClientForVMOps(t, &fakeVMOpsServer{fail: true}, providerType, provider)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		op   string
+		fn   func() error
+	}{
+		{"Create", metrics.OpCreate, func() error {
+			_, e := cli.Create(ctx, contracts.CreateRequest{Name: "vm-1"})
+			return e
+		}},
+		{"Delete", metrics.OpDelete, func() error {
+			_, e := cli.Delete(ctx, "vm-1")
+			return e
+		}},
+		{"Power", metrics.OpPower, func() error {
+			_, e := cli.Power(ctx, "vm-1", contracts.PowerOpOn)
+			return e
+		}},
+		{"Describe", metrics.OpDescribe, func() error {
+			_, e := cli.Describe(ctx, "vm-1")
+			return e
+		}},
+		{"Reconfigure", metrics.OpReconfigure, func() error {
+			_, e := cli.Reconfigure(ctx, "vm-1", contracts.CreateRequest{Name: "vm-1"})
+			return e
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := map[string]string{
+				"operation":     tt.op,
+				"provider_type": providerType,
+				"provider":      provider,
+				"outcome":       metrics.OutcomeError,
+			}
+			before := counterSampleByLabels(t, "virtrigaud_vm_operations_total", want)
+			require.Error(t, tt.fn(), "%s call must surface the induced Unavailable error", tt.name)
+			after := counterSampleByLabels(t, "virtrigaud_vm_operations_total", want)
+			assert.Equal(t, before+1, after,
+				"%s error must increment virtrigaud_vm_operations_total{operation=%s, outcome=error} by 1",
+				tt.name, tt.op)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Closes **#124** (first sub-PR of the G7 umbrella **#123**).
- Wires `virtrigaud_vm_operations_total` from the gRPC client's 5 VM-operation methods (Create / Delete / Power / Describe / Reconfigure).
- Same dead-code-paradox shape that G6 (#111 / PR #112) closed for CircuitBreaker metrics: the family was registered, helpered, even unit-tested at the metric level — but no production callsite called the helper.

## What's in this PR

### `internal/transport/grpc/client.go`
- `Client.vmOps *metrics.VMOperationMetrics` field, initialised by `NewClient` from the new `providerName` parameter (paired with the existing `providerType`).
- `NewClient` signature gains `providerName string` between `providerType` and `cb`. Resolver passes `provider.Name`.
- New `(*Client).recordVMOp(op string, retErr *error)` helper — designed for deferred call from each VM-op method using a named `retErr` return value. Pointer-to-error indirection is load-bearing: lets the deferred call evaluate the FINAL return value rather than the value at defer-time (always nil). Nil-safe on `c.vmOps` for tests that construct `&Client{...}` directly.
- 5 VM-op methods (Create / Delete / Power / Describe / Reconfigure) refactored to use named returns + `defer recordVMOp`. **Method bodies otherwise unchanged.** Same pattern as G1's reconcile-timer (PR #101).

### `internal/transport/grpc/client_vm_operations_test.go` (new)
12 sub-test cases across 4 tests:
| Test | Sub-cases | What it pins |
|---|---|---|
| `TestRecordVMOp_NilVMOpsIsSafe` | 2 | The helper must not panic when `c.vmOps == nil` |
| `TestRecordVMOp_OutcomeDerivation` | 3 | Success vs error outcome derivation, including the defensive nil-`*error` path |
| `TestClient_VMOperations_RecordOnSuccess` | 5 (one per op) | Each VM-op method increments `{outcome="success"}` by exactly 1 |
| `TestClient_VMOperations_RecordOnError` | 5 (one per op) | Each VM-op method increments `{outcome="error"}` by exactly 1 (catches outcome-inversion regressions) |

New `fakeVMOpsServer` implements all 5 server handlers with a `fail` toggle so a single bufconn server can produce both metric outcomes.

### `internal/runtime/remote/resolver.go`
Passes `provider.Name` as the new `providerName` parameter to `NewClient`. Doc comment updated to call out the label population.

### `internal/transport/grpc/client_{metrics,circuitbreaker}_test.go`
Both test helpers updated to initialise `vmOps` so the deferred `recordVMOp` in production methods remains safe under their test paths. `client_circuitbreaker_test.go` gains a `metrics` import.

## Why this matters
"How often is Create failing on this Provider?" is a routine operator question. Pre-PR the answer requires knowing the gRPC method names and joining `virtrigaud_provider_rpc_requests_total` on labels. Post-PR it's a single PromQL: `virtrigaud_vm_operations_total{operation="Create", outcome="error"}`. Closes the operator-facing observability gap for VM-op outcomes.

## Test plan
- [x] `make fmt` clean
- [x] `go vet ./...` clean
- [x] `make test` 12/12 packages pass; 0 FAIL; new 4-test/12-sub-case file green
- [x] `make build` clean; `./bin/manager --version` works (exit 0)
- [ ] **v0.3.6-rc1 smoke** (post-merge): `curl /metrics | grep virtrigaud_vm_operations_total` shows at least one sample per active VM-op on `vr1.lab.k8`. With G4 + G6 + G7.1 all live, that's 8 of 12 expected `virtrigaud_*` families emitting (G7.2/.3/.4 will fill the rest).

## Defaults / breakage
- **No breaking change.** Method signatures gain named returns but the function shape (parameter list + return types) is identical from the caller's perspective.
- **`NewClient` signature does change.** Three call sites updated in this PR (resolver + 2 test helpers). Any out-of-tree code building against this package needs to pass an additional `providerName` argument; pass `""` for an empty `provider` label if you don't have a meaningful name.

## What's next in G7
| # | Issue | What | Status |
|---|---|---|---|
| **G7.1** | **#124 ← this PR** | Wire `vm_operations_total` from gRPC client | v0.3.6 |
| G7.2 | (file when starting) | Wire `ip_discovery_duration_seconds` in VirtualMachineReconciler IP-discovery path | next |
| G7.3 | (file when starting) | Wire `provider_tasks_inflight` (per-Provider task tracker) | after G7.2 |
| G7.4 | (file when starting) | Wire `queue_depth` (per-reconciler workqueue introspection) | closes G7 umbrella #123 |