### PR TITLE
feat(obs): wire virtrigaud_ip_discovery_duration_seconds in VM reconciler (G7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-25 06:24] - feat(obs): wire virtrigaud_ip_discovery_duration_seconds in VirtualMachineReconciler (G7.2 / closes #127)
+**Author:** @williamrizzo (William Rizzo)
+
+### Audit finding
+Second sub-PR of the G7 umbrella (#123). `virtrigaud_ip_discovery_duration_seconds{provider_type}` was registered in `internal/obs/metrics/metrics.go` with helper `metrics.RecordIPDiscovery(providerType, duration)` — same dead-code-paradox shape that G7.1 / G6 / etc. fixed: zero production callsites. The histogram has buckets 100ms-~51s which fits "VM CR creation → first IP visible" durations.
+
+### Added
+- `internal/controller/virtualmachine_controller.go`: new pure helper `recordIPDiscoveryIfFirstSeen(currentIPs, descIPs []string, creationTime metav1.Time, providerType string)`. Gates on three conditions (currentIPs empty, descIPs non-empty, creationTime non-zero) and records `metrics.RecordIPDiscovery(providerType, time.Since(creationTime.Time))` when all three hold. Pure function (no reconciler state) so it is unit-testable without standing up the envtest harness.
+- `internal/controller/virtualmachine_ip_discovery_test.go` (new): 4 tests pinning all 4 gate paths:
+  - `TestRecordIPDiscoveryIfFirstSeen_NoIPsToNoIPs` — common "still waiting for DHCP" case; must NOT record.
+  - `TestRecordIPDiscoveryIfFirstSeen_FirstIPDiscovered` — load-bearing success path; records exactly 1 sample with correct `provider_type` label, sample-sum delta ≈ time-since-creationTime (4s-60s window absorbs CI scheduling jitter without flakiness).
+  - `TestRecordIPDiscoveryIfFirstSeen_AlreadyHadIPs` — idempotency-after-restart contract; must NOT re-record because `vm.Status.IPs` persists in etcd and subsequent reconciles see currentIPs non-empty.
+  - `TestRecordIPDiscoveryIfFirstSeen_ZeroCreationTimeIsSkipped` — defensive; must NOT record when CreationTimestamp is zero (would emit nonsensical durations like `time.Since(epoch)`).
+- `internal/controller/virtualmachine_ip_discovery_test.go`: also introduces two local histogram-introspection helpers (`histogramSampleCount`, `histogramSampleSum`) that mirror the existing `counterSample` pattern but for `*dto.Histogram` samples. Kept package-local so the helpers don't leak into production code.
+
+### Changed
+- `internal/controller/virtualmachine_controller.go`: in `Reconcile`, call `recordIPDiscoveryIfFirstSeen(vm.Status.IPs, desc.IPs, vm.CreationTimestamp, string(provider.Spec.Type))` **immediately before** `vm.Status.IPs = desc.IPs`. The ordering is load-bearing — the gate inspects the **pre-update** value of `vm.Status.IPs`. Inline comment block points at #127 and explains the ordering.
+
+### Why
+1. **Closes G7.2 of the G7 umbrella (#123).** Second of 4 deferred metric families to wire.
+2. **Operator-facing SLO answer.** "How long from `kubectl apply` to the VM having an IP?" was previously unanswerable from metrics; required scraping events and timestamps off `kubectl describe vm`. Post-PR: `histogram_quantile(0.95, sum(rate(virtrigaud_ip_discovery_duration_seconds_bucket{provider_type="libvirt"}[5m])) by (le))` gives the p95 IP-discovery latency for libvirt VMs over the last 5 minutes.
+3. **Adoption case handled**: an adopted VM (CR created against an existing running VM) will have `CreationTimestamp` = adoption time and IPs already populated by Describe on the first reconcile. The gate fires once on first observation with a small positive duration (adoption → reconcile latency), which is the correct semantic — operators learn how quickly post-adoption their metrics surfaced the VM state. Documented in the helper's GoDoc.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager binary gains new metric emission)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- The helper is **package-private** intentionally: it has no callers outside the reconciler today. If a different reconciler ever needs the same semantics it can be promoted to a shared helper at that point.
+- The histogram buckets (100ms-51.2s exponential) fit the expected operator-VM SLO range. Outliers above 51.2s land in the `+Inf` bucket — visible but not bucketed in detail. Acceptable for v0.3.6; can revisit if operators ask for finer resolution above 1 minute.
+- This is now **9 of 12** `virtrigaud_*` families wired (with G6 + G7.1 + G7.2 stacked). Remaining gaps: `virtrigaud_provider_tasks_inflight` (G7.3), `virtrigaud_queue_depth` (G7.4), plus the two `virtrigaud_circuit_breaker_*` families that emit on `vr1.lab.k8` only after a v0.3.6-rc1 deploy (the CB code is in main already since G6 / PR #112).
+- Pre-merge verification: `make fmt` clean; `go vet ./...` clean; `make test` 12/12 packages pass with 0 FAIL; new test file 4/4 sub-cases green; `make build` produces a working `bin/manager` with `--version` exit 0.
+- Next in G7: G7.3 (file sub-issue when starting) — wire `virtrigaud_provider_tasks_inflight` (per-Provider async task tracker).
+
+---
+
 ## [2026-05-25 05:35] - feat(obs): wire virtrigaud_vm_operations_total in gRPC client VM-operation methods (G7.1 / closes #124)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/internal/controller/virtualmachine_controller.go
+++ b/internal/controller/virtualmachine_controller.go
@@ -270,6 +270,14 @@ func (r *VirtualMachineReconciler) reconcileVM(ctx context.Context, vm *infravir
 		return r.createVM(ctx, vm, providerInstance, vmClass, vmImage, networks)
 	}
 
+	// G7.2 (#127): record virtrigaud_ip_discovery_duration_seconds on
+	// the first reconcile that observes the no-IPs → has-IPs transition
+	// for this VM. Must be called BEFORE the vm.Status.IPs = desc.IPs
+	// assignment below so the gate sees the pre-update value of
+	// vm.Status.IPs. Idempotent across manager restarts because
+	// vm.Status.IPs is persisted in etcd.
+	recordIPDiscoveryIfFirstSeen(vm.Status.IPs, desc.IPs, vm.CreationTimestamp, string(provider.Spec.Type))
+
 	// Update status with current state
 	vm.Status.PowerState = infravirtrigaudiov1beta1.PowerState(desc.PowerState)
 	vm.Status.IPs = desc.IPs
@@ -1045,6 +1053,47 @@ func (r *VirtualMachineReconciler) getProviderInstance(ctx context.Context, prov
 	}
 
 	return r.RemoteResolver.GetProvider(ctx, provider) //nolint:wrapcheck
+}
+
+// recordIPDiscoveryIfFirstSeen emits a single
+// virtrigaud_ip_discovery_duration_seconds sample on the no-IPs →
+// has-IPs transition for this VM. Pure function (no reconciler state)
+// so it is unit-testable without standing up the full envtest harness.
+//
+// Inputs:
+//   - currentIPs: the value of vm.Status.IPs BEFORE the reconciler
+//     overwrites it with descIPs. The pre-update value is what tells us
+//     whether the VM has previously been observed with IPs.
+//   - descIPs:    the IPs the provider just reported via Describe.
+//   - creationTime: vm.CreationTimestamp. Used as the baseline for the
+//     duration measurement, so the metric reads as "kubectl apply →
+//     first IP visible". Zero-valued (defensive) → skip.
+//   - providerType: the value of provider.Spec.Type, used as the
+//     provider_type metric label.
+//
+// Gate semantics (all three must hold; otherwise skip silently):
+//  1. currentIPs is empty (we have not previously observed any IP)
+//  2. descIPs is non-empty (the provider just gave us an IP)
+//  3. creationTime is non-zero (CreationTimestamp is present)
+//
+// Idempotency across manager restarts is achieved at the persistence
+// layer: vm.Status.IPs is committed to etcd as soon as the gate fires
+// once (the very next line in Reconcile does
+// `vm.Status.IPs = desc.IPs`), so subsequent reconciles after the
+// transition see currentIPs non-empty and the gate short-circuits.
+//
+// G7.2 / #127.
+func recordIPDiscoveryIfFirstSeen(currentIPs, descIPs []string, creationTime metav1.Time, providerType string) {
+	if len(currentIPs) != 0 {
+		return // already observed IPs in a previous reconcile
+	}
+	if len(descIPs) == 0 {
+		return // VM still doesn't have an IP this round
+	}
+	if creationTime.IsZero() {
+		return // defensive — CRs fetched via the API server always have this
+	}
+	metrics.RecordIPDiscovery(providerType, time.Since(creationTime.Time))
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/virtualmachine_ip_discovery_test.go
+++ b/internal/controller/virtualmachine_ip_discovery_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dto "github.com/prometheus/client_model/go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
+)
+
+// histogramSampleCount returns the cumulative sample count for the
+// given histogram metric family matching the supplied labels. Returns
+// 0 when no matching sample exists (so before/after subtraction yields
+// the increment, matching the counterSample helper pattern in this
+// package).
+func histogramSampleCount(t *testing.T, family string, want map[string]string) uint64 {
+	t.Helper()
+	families, err := metrics.GetRegistry().Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != family {
+			continue
+		}
+		var total uint64
+		for _, m := range f.GetMetric() {
+			if !labelsMatch(m.GetLabel(), want) {
+				continue
+			}
+			if h := m.GetHistogram(); h != nil {
+				total += h.GetSampleCount()
+			}
+		}
+		return total
+	}
+	return 0
+}
+
+// histogramSampleSum returns the cumulative observed-value sum across
+// all samples matching the supplied labels. Used to assert that the
+// recorded duration was non-zero (and roughly within the expected
+// range) without flaky time-based equality.
+func histogramSampleSum(t *testing.T, family string, want map[string]string) float64 {
+	t.Helper()
+	families, err := metrics.GetRegistry().Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != family {
+			continue
+		}
+		var total float64
+		for _, m := range f.GetMetric() {
+			if !labelsMatch(m.GetLabel(), want) {
+				continue
+			}
+			if h := m.GetHistogram(); h != nil {
+				total += h.GetSampleSum()
+			}
+		}
+		return total
+	}
+	return 0
+}
+
+// _ keeps the dto import live for histogram callers above (the helper
+// uses h.GetSampleCount which is on *dto.Histogram).
+var _ = (*dto.Histogram)(nil)
+
+// TestRecordIPDiscoveryIfFirstSeen_NoIPsToNoIPs pins gate path 1:
+// VM had no IPs before AND no IPs in this Describe → MUST NOT record.
+// This is the common "still waiting for DHCP" case.
+//
+// G7.2 / #127.
+func TestRecordIPDiscoveryIfFirstSeen_NoIPsToNoIPs(t *testing.T) {
+	const providerType = "g72-no-to-no"
+	labels := map[string]string{"provider_type": providerType}
+
+	beforeCount := histogramSampleCount(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+	beforeSum := histogramSampleSum(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+
+	creationTime := metav1.NewTime(time.Now().Add(-30 * time.Second))
+	recordIPDiscoveryIfFirstSeen(nil, nil, creationTime, providerType)
+	recordIPDiscoveryIfFirstSeen([]string{}, []string{}, creationTime, providerType)
+
+	afterCount := histogramSampleCount(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+	afterSum := histogramSampleSum(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+
+	assert.Equal(t, beforeCount, afterCount,
+		"sample count must not change when neither side has IPs")
+	assert.Equal(t, beforeSum, afterSum,
+		"sample sum must not change when neither side has IPs")
+}
+
+// TestRecordIPDiscoveryIfFirstSeen_FirstIPDiscovered pins gate path 2
+// (the load-bearing success path): VM had no IPs before AND has IPs
+// now → MUST record exactly one sample with the correct
+// provider_type label, and the observed duration must be positive
+// (≈ time.Since(creationTime)).
+//
+// G7.2 / #127.
+func TestRecordIPDiscoveryIfFirstSeen_FirstIPDiscovered(t *testing.T) {
+	const providerType = "g72-first-ip"
+	labels := map[string]string{"provider_type": providerType}
+
+	beforeCount := histogramSampleCount(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+	beforeSum := histogramSampleSum(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+
+	creationTime := metav1.NewTime(time.Now().Add(-5 * time.Second))
+	recordIPDiscoveryIfFirstSeen(nil, []string{"10.0.0.42"}, creationTime, providerType)
+
+	afterCount := histogramSampleCount(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+	afterSum := histogramSampleSum(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+
+	assert.Equal(t, beforeCount+1, afterCount,
+		"first-IP transition must increment the histogram sample count by exactly 1")
+
+	delta := afterSum - beforeSum
+	// Expect roughly 5 seconds; allow a generous window to absorb scheduling
+	// jitter on slow CI machines without flakiness.
+	assert.Greater(t, delta, 4.0,
+		"observed duration must be at least the elapsed wall-clock time since creationTime (got %.3fs)", delta)
+	assert.Less(t, delta, 60.0,
+		"observed duration must not be wildly large (got %.3fs)", delta)
+}
+
+// TestRecordIPDiscoveryIfFirstSeen_AlreadyHadIPs pins gate path 3
+// (the idempotency-after-restart contract): VM had IPs before → MUST
+// NOT re-record, even though the Describe still returns IPs. Catches
+// the regression class where a manager restart re-fires the metric for
+// every existing VM at reconcile-resume time.
+//
+// G7.2 / #127.
+func TestRecordIPDiscoveryIfFirstSeen_AlreadyHadIPs(t *testing.T) {
+	const providerType = "g72-idempotent"
+	labels := map[string]string{"provider_type": providerType}
+
+	beforeCount := histogramSampleCount(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+
+	creationTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	// VM has been observed with IPs in a prior reconcile (or after a
+	// restart, persisted in etcd). Describe still returns IPs.
+	recordIPDiscoveryIfFirstSeen([]string{"10.0.0.42"}, []string{"10.0.0.42", "fe80::1"}, creationTime, providerType)
+	recordIPDiscoveryIfFirstSeen([]string{"10.0.0.42"}, []string{"10.0.0.42"}, creationTime, providerType)
+
+	afterCount := histogramSampleCount(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+
+	assert.Equal(t, beforeCount, afterCount,
+		"sample count must NOT increase when VM already had IPs (idempotency across reconciles + restarts)")
+}
+
+// TestRecordIPDiscoveryIfFirstSeen_ZeroCreationTimeIsSkipped pins gate
+// path 4 (defensive): CreationTimestamp zero → skip. CRs fetched via
+// the API server always have a non-zero CreationTimestamp, but this
+// defensive branch prevents the helper from emitting nonsensical
+// durations like time.Since(epoch) = decades.
+//
+// G7.2 / #127.
+func TestRecordIPDiscoveryIfFirstSeen_ZeroCreationTimeIsSkipped(t *testing.T) {
+	const providerType = "g72-zero-time"
+	labels := map[string]string{"provider_type": providerType}
+
+	beforeCount := histogramSampleCount(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+
+	var zeroTime metav1.Time // explicitly zero
+	require.True(t, zeroTime.IsZero(), "test precondition: zero-value metav1.Time must IsZero()")
+	recordIPDiscoveryIfFirstSeen(nil, []string{"10.0.0.42"}, zeroTime, providerType)
+
+	afterCount := histogramSampleCount(t, "virtrigaud_ip_discovery_duration_seconds", labels)
+
+	assert.Equal(t, beforeCount, afterCount,
+		"sample count must NOT increase when CreationTimestamp is zero")
+}


### PR DESCRIPTION
## Summary
- Closes **#127** (G7.2 sub-issue of umbrella #123).
- Second of 4 G7 sub-PRs. Wires `virtrigaud_ip_discovery_duration_seconds` so the histogram emits per-Provider-type IP-discovery latency.
- **Same shape as G7.1 / G6**: the family was registered, helpered, even unit-test-ready — but had zero production callsites.

## Why this matters
"How long from `kubectl apply` to the VM having an IP?" was previously unanswerable from `/metrics`; required scraping events and timestamps off `kubectl describe vm`.

Post-PR PromQL:
```
histogram_quantile(0.95,
  sum(rate(virtrigaud_ip_discovery_duration_seconds_bucket{provider_type="libvirt"}[5m]))
  by (le))
```
gives the p95 IP-discovery latency for libvirt VMs over the last 5 minutes.

## Implementation

New pure helper `recordIPDiscoveryIfFirstSeen` in `internal/controller/virtualmachine_controller.go`:

```go
func recordIPDiscoveryIfFirstSeen(currentIPs, descIPs []string, creationTime metav1.Time, providerType string) {
    if len(currentIPs) != 0 { return }   // already observed IPs
    if len(descIPs) == 0    { return }   // still no IPs this round
    if creationTime.IsZero(){ return }   // defensive
    metrics.RecordIPDiscovery(providerType, time.Since(creationTime.Time))
}
```

Called from `Reconcile` immediately **before** `vm.Status.IPs = desc.IPs` so the gate inspects the pre-update value:

```go
recordIPDiscoveryIfFirstSeen(vm.Status.IPs, desc.IPs, vm.CreationTimestamp, string(provider.Spec.Type))
vm.Status.PowerState = ...
vm.Status.IPs = desc.IPs
```

**Idempotency across manager restarts** is provided by etcd persistence: `vm.Status.IPs` is committed by the very next reconcile line, so subsequent reconciles see currentIPs non-empty and the gate short-circuits. A manager restart re-reads `vm.Status.IPs` populated → re-fire prevented.

**Adopted VM** edge case: a CR created against an existing running VM has CreationTimestamp = adoption time and IPs populated by Describe on the first reconcile. Records a small duration (adoption → reconcile latency), which is the correct semantic. Documented in helper GoDoc.

## Tests (new file `internal/controller/virtualmachine_ip_discovery_test.go`)

4 sub-cases pinning all 4 gate paths:
| Test | Pins |
|---|---|
| `TestRecordIPDiscoveryIfFirstSeen_NoIPsToNoIPs` | Common DHCP-pending case — must NOT record |
| `TestRecordIPDiscoveryIfFirstSeen_FirstIPDiscovered` | Load-bearing success — exactly 1 sample, observed duration within window |
| `TestRecordIPDiscoveryIfFirstSeen_AlreadyHadIPs` | Idempotency contract — must NOT re-record across reconciles or restarts |
| `TestRecordIPDiscoveryIfFirstSeen_ZeroCreationTimeIsSkipped` | Defensive — must NOT emit nonsensical durations like `time.Since(epoch)` |

Plus local `histogramSampleCount` / `histogramSampleSum` helpers mirroring the existing `counterSample` pattern for histogram introspection (package-local, won't leak into production).

## Test plan
- [x] `make fmt` clean
- [x] `go vet ./...` clean
- [x] `make test` 12/12 packages pass, 0 FAIL
- [x] New 4 sub-tests green individually (`go test -run TestRecordIPDiscoveryIfFirstSeen -v`)
- [x] `make build` clean; `./bin/manager --version` works
- [ ] **v0.3.6-rc1 smoke** (post-merge): create a fresh VirtualMachine CR on `vr1.lab.k8`; observe `virtrigaud_ip_discovery_duration_seconds_count{provider_type="libvirt"}` increment by 1 when the VM gets its first IP. (Currently blocked on the I1 libvirt SSH issue — but the metric will at least register zero samples until then; on a healthy provider it will populate.)

## Defaults / breakage
- **No breaking change.** No public API or signature changes.
- Metric emission is additive — operators see one new family on `/metrics` post-deploy.

## After this lands
**9 of 12 expected `virtrigaud_*` families wired in code** (G6 + G7.1 + G7.2 stacked).

Remaining G7 work:
| # | Issue | What | Status |
|---|---|---|---|
| G7.1 | #124 | `vm_operations_total` | ✅ MERGED (#126) |
| **G7.2** | **#127 ← this PR** | `ip_discovery_duration_seconds` | v0.3.6 |
| G7.3 | (file when starting) | `provider_tasks_inflight` | next |
| G7.4 | (file when starting) | `queue_depth` | closes G7 umbrella #123 |