### PR TITLE
feat(obs): wire virtrigaud_provider_tasks_inflight per-Provider task tracker (G7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2026-05-25 07:12] - feat(obs): wire virtrigaud_provider_tasks_inflight per-Provider async-task tracker (G7.3 / closes #129)
+**Author:** @williamrizzo (William Rizzo)
+
+### Audit finding
+Third sub-PR of the G7 umbrella (#123). `virtrigaud_provider_tasks_inflight{provider_type, provider}` was registered in `internal/obs/metrics/metrics.go` with helper `(*TaskMetrics).SetInflightTasks(count)` — same dead-code-paradox shape that G7.1 / G7.2 / G6 each fixed: zero production callsites.
+
+Pre-PR: operators dashboarding "how many tasks is the manager currently tracking per Provider?" got an empty family.
+
+### Added
+- `internal/transport/grpc/client.go`: `Client` struct gains three fields — `tasks *metrics.TaskMetrics`, `inflightTasksMu sync.Mutex`, and `inflightTasks map[string]struct{}`. The map-based set is the source of truth; the gauge value is set to `len(map)` after each change.
+- `internal/transport/grpc/client.go`: `(*Client).trackTaskStart(taskID string)` — adds taskID to the set and pushes the new gauge value. Nil-safe on `c.tasks`. Idempotent on duplicate IDs (defends against pathological provider-server behaviour returning the same TaskRef twice).
+- `internal/transport/grpc/client.go`: `(*Client).trackTaskDone(taskID string)` — removes taskID from the set and pushes the new gauge value. Idempotent on unknown IDs (handles two real-world cases: the reconciler crashes between observing Done=true and clearing `vm.Status.LastTaskRef`, and a new manager instance polls a TaskRef recorded by the previous instance — both must NOT push the gauge negative).
+- `internal/transport/grpc/client.go`: 9 task-creating method call sites now invoke `c.trackTaskStart(resp.Task.Id)` after observing a non-nil Task field: **Create, Delete, Power, Reconfigure, SnapshotCreate, SnapshotDelete, SnapshotRevert, ExportDisk, ImportDisk**. Each call site annotated with `// G7.3 (#129)`.
+- `internal/transport/grpc/client.go`: 2 task-polling methods now invoke `c.trackTaskDone(taskRef)` on terminal completion: **IsTaskComplete** (when `resp.Done` or `resp.Error != ""`) and **TaskStatus** (same condition).
+- `internal/transport/grpc/client.go`: `NewClient` seeds the gauge to 0 via `taskMetrics.SetInflightTasks(0)` so the family appears on `/metrics` from boot — operators get a stable label set to dashboard against even before the first async task fires.
+- `internal/transport/grpc/client_tasks_inflight_test.go` (new): 7 tests covering:
+  - `TestTrackTask_NilTasksIsSafe` — pins nil-safety on both helpers
+  - `TestTrackTask_StartAndDoneCycle` — pins the success path Start("a") → 1 → Start("b") → 2 → Done("a") → 1 → Done("b") → 0
+  - `TestTrackTask_DoubleDoneIsIdempotent` — pins the double-poll contract (reconciler retry between observing Done and clearing status ref)
+  - `TestTrackTask_UnknownDoneIsNoop` — pins the post-restart contract (new manager instance's set is empty; unknown Done must not push gauge negative)
+  - `TestTrackTask_StartIdempotentOnSameID` — pins the duplicate-Start defensive path
+  - `TestTrackTask_ConcurrentStartDoneIsRaceFree` — 200 goroutines (100 Start + 100 Done), verified clean under `go test -race`
+  - `TestClient_TaskLifecycle_EndToEnd` — integration via bufconn server: Create-returning-Task → gauge=1, IsTaskComplete-returning-Done → gauge=0
+- New `fakeTasksServer` in the test file: minimal `providerv1.ProviderServer` with `CreateTaskID` and `DoneOnPoll` toggles for the integration test.
+- Local `gaugeSample` helper in the test file (mirrors the existing `counterSampleByLabels` pattern; kept package-local).
+
+### Why
+1. **Closes G7.3 of the G7 umbrella (#123).** Third of 4 deferred metric families to wire.
+2. **Operator visibility into provider load.** "Is the libvirt provider drowning in concurrent migration tasks?" — pre-PR, no metric. Post-PR: `virtrigaud_provider_tasks_inflight{provider_type="libvirt"} > 5` is a sensible alert threshold.
+3. **Correct semantic across manager restarts.** The gauge measures "tasks **this manager instance** is tracking," not "tasks the provider believes are in-flight." This is intentional and documented — the per-instance count self-corrects within seconds as tasks complete and new ones start. Documented in helper GoDoc.
+4. **Race-free under concurrent reconciler load.** The mutex-guarded map handles the realistic case of multiple VirtualMachineReconciler workers (the controller-runtime workqueue defaults to 10 concurrent reconciles per controller, per `MaxConcurrentReconciles` in `SetupWithManager`) racing on the same Client. Verified with `go test -race`.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager binary gains new gauge emission)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- 9 task-creating sites is the full set verified in the audit on `main` post-#128 (Create / Delete / Power / Reconfigure / SnapshotCreate / SnapshotDelete / SnapshotRevert / ExportDisk / ImportDisk). All return `*providerv1.TaskResponse` (or have a Task field on a richer response struct). Any future RPC that returns a TaskRef must add a `trackTaskStart` call — would surface in code review since the pattern is uniform.
+- Both `IsTaskComplete` and `TaskStatus` instrument `trackTaskDone`. They wrap the same underlying gRPC RPC; the per-Client mutex serialises updates so calling both for the same task only decrements the gauge once (because the second call sees the ID already removed from the set and no-ops).
+- Pre-merge verification: `make fmt` clean; `go vet ./...` clean; `make test` 12/12 packages with 0 FAIL; new test file 7/7 sub-cases green; `go test -race ./internal/transport/grpc/...` clean; `make build` produces working `bin/manager` with `--version` exit 0.
+- After this lands, **10 of 12 expected `virtrigaud_*` families are wired in code**. The remaining gap is G7.4 (`virtrigaud_queue_depth`) plus the two `virtrigaud_circuit_breaker_*` families that emit on `vr1.lab.k8` only after a v0.3.6-rc1 deploy (code already in main since G6 / PR #112).
+- Next in G7: G7.4 (file sub-issue when starting) — wire `virtrigaud_queue_depth` (per-reconciler workqueue depth). Closes G7 umbrella #123.
+
+---
+
 ## [2026-05-25 06:24] - feat(obs): wire virtrigaud_ip_discovery_duration_seconds in VirtualMachineReconciler (G7.2 / closes #127)
 **Author:** @williamrizzo (William Rizzo)
 

--- a/internal/transport/grpc/client.go
+++ b/internal/transport/grpc/client.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -50,6 +51,23 @@ type Client struct {
 	// (e.g. construct &Client{...} directly); recordVMOp is nil-safe to
 	// support that path.
 	vmOps *metrics.VMOperationMetrics
+
+	// tasks owns the virtrigaud_provider_tasks_inflight gauge for this
+	// Client (G7.3 / #129). Always non-nil for production clients via
+	// NewClient. trackTaskStart / trackTaskDone are nil-safe so test
+	// clients that bypass NewClient don't panic.
+	tasks *metrics.TaskMetrics
+	// inflightTasksMu guards inflightTasks.
+	inflightTasksMu sync.Mutex
+	// inflightTasks is the set of TaskRef IDs this Client returned from
+	// a task-creating RPC and has NOT yet observed Done=true on. The
+	// map-based set is what makes the gauge correct under double-poll
+	// (reconciler retries between observing Done and clearing
+	// vm.Status.LastTaskRef) and post-restart (the new manager's map
+	// starts empty; trackTaskDone on an unknown ID no-ops, which means
+	// the gauge measures "tasks THIS instance is tracking", not "tasks
+	// the provider thinks are in-flight").
+	inflightTasks map[string]struct{}
 }
 
 // NewClient creates a new gRPC provider client.
@@ -126,6 +144,13 @@ func NewClient(ctx context.Context, endpoint string, providerType string, provid
 	}
 
 	client := providerv1.NewProviderClient(conn)
+	// G7.3 (#129): per-Provider task-inflight tracker. Seed the gauge to
+	// 0 here so the virtrigaud_provider_tasks_inflight family appears on
+	// /metrics from boot (Prometheus gauges with labels don't show until
+	// first write), giving operators a stable label set to dashboard
+	// against even before the first async task fires.
+	taskMetrics := metrics.NewTaskMetrics(providerType, providerName)
+	taskMetrics.SetInflightTasks(0)
 	return &Client{
 		conn:   conn,
 		client: client,
@@ -133,7 +158,9 @@ func NewClient(ctx context.Context, endpoint string, providerType string, provid
 		// providerType + providerName so dashboards can answer
 		// "how often does Create fail on the vsphere-prod Provider?"
 		// independently of the gRPC-method-level G4 view.
-		vmOps: metrics.NewVMOperationMetrics(providerType, providerName),
+		vmOps:         metrics.NewVMOperationMetrics(providerType, providerName),
+		tasks:         taskMetrics,
+		inflightTasks: make(map[string]struct{}),
 	}, nil
 }
 
@@ -310,6 +337,66 @@ func (c *Client) recordVMOp(op string, retErr *error) {
 	c.vmOps.RecordOperation(op, outcome)
 }
 
+// trackTaskStart adds taskID to the inflight set and pushes the new
+// gauge value to virtrigaud_provider_tasks_inflight{provider_type,
+// provider}. G7.3 / #129.
+//
+// Called by every task-creating RPC right after a non-nil Task field
+// is observed in the response. taskID = "" or c.tasks = nil are no-ops
+// so the helper is safe under both the empty-TaskRef edge case and the
+// &Client{...}-direct-construction test path.
+//
+// Re-adding an ID already in the set is a no-op for the gauge (set
+// semantics) — this defends against pathological provider-server
+// behaviour returning the same TaskRef from two RPCs.
+func (c *Client) trackTaskStart(taskID string) {
+	if c.tasks == nil || taskID == "" {
+		return
+	}
+	c.inflightTasksMu.Lock()
+	if c.inflightTasks == nil {
+		c.inflightTasks = make(map[string]struct{})
+	}
+	if _, already := c.inflightTasks[taskID]; already {
+		c.inflightTasksMu.Unlock()
+		return
+	}
+	c.inflightTasks[taskID] = struct{}{}
+	n := float64(len(c.inflightTasks))
+	c.inflightTasksMu.Unlock()
+	c.tasks.SetInflightTasks(n)
+}
+
+// trackTaskDone removes taskID from the inflight set and pushes the
+// new gauge value. G7.3 / #129.
+//
+// Idempotent on unknown IDs (no-op): handles two real cases observed
+// in production-style flows:
+//  1. The reconciler crashes between observing Done=true and clearing
+//     vm.Status.LastTaskRef — next reconcile polls again, gets Done=true
+//     again, calls trackTaskDone again. Without this guard the gauge
+//     would decrement to -1.
+//  2. A new manager instance (post-restart) polls TaskStatus for a
+//     vm.Status.LastTaskRef recorded by the previous instance. The new
+//     instance's inflightTasks map starts empty, so the ID is unknown,
+//     and the gauge stays at 0 — matching the documented semantic that
+//     this gauge measures "tasks THIS manager instance is tracking",
+//     not "tasks the provider believes are in-flight".
+func (c *Client) trackTaskDone(taskID string) {
+	if c.tasks == nil || taskID == "" {
+		return
+	}
+	c.inflightTasksMu.Lock()
+	if _, ok := c.inflightTasks[taskID]; !ok {
+		c.inflightTasksMu.Unlock()
+		return
+	}
+	delete(c.inflightTasks, taskID)
+	n := float64(len(c.inflightTasks))
+	c.inflightTasksMu.Unlock()
+	c.tasks.SetInflightTasks(n)
+}
+
 // Close closes the gRPC connection
 func (c *Client) Close() error {
 	return c.conn.Close()
@@ -358,6 +445,7 @@ func (c *Client) Create(ctx context.Context, req contracts.CreateRequest) (resul
 
 	if resp.Task != nil {
 		result.TaskRef = resp.Task.Id
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
 	}
 
 	return result, nil
@@ -379,6 +467,7 @@ func (c *Client) Delete(ctx context.Context, id string) (taskRef string, retErr 
 	}
 
 	if resp.Task != nil {
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
 		return resp.Task.Id, nil
 	}
 
@@ -416,6 +505,7 @@ func (c *Client) Power(ctx context.Context, id string, op contracts.PowerOp) (ta
 	}
 
 	if resp.Task != nil {
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
 		return resp.Task.Id, nil
 	}
 
@@ -447,6 +537,7 @@ func (c *Client) Reconfigure(ctx context.Context, id string, desired contracts.C
 	}
 
 	if resp.Task != nil {
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
 		return resp.Task.Id, nil
 	}
 
@@ -507,9 +598,15 @@ func (c *Client) IsTaskComplete(ctx context.Context, taskRef string) (done bool,
 	}
 
 	if resp.Error != "" {
+		// Terminal failure also counts as task-done — decrement the
+		// inflight gauge before returning (G7.3 / #129).
+		c.trackTaskDone(taskRef)
 		return true, fmt.Errorf("task failed: %s", resp.Error)
 	}
 
+	if resp.Done {
+		c.trackTaskDone(taskRef) // G7.3 (#129)
+	}
 	return resp.Done, nil
 }
 
@@ -523,6 +620,13 @@ func (c *Client) TaskStatus(ctx context.Context, taskRef string) (contracts.Task
 	})
 	if err != nil {
 		return contracts.TaskStatus{}, c.mapGRPCError("taskStatus", err)
+	}
+
+	// Both terminal-success (Done=true) and terminal-failure (Error != "")
+	// flip the task out of the inflight set (G7.3 / #129). Idempotent on
+	// unknown taskRef so double-poll / post-restart polls are safe.
+	if resp.Done || resp.Error != "" {
+		c.trackTaskDone(taskRef)
 	}
 
 	return contracts.TaskStatus{
@@ -558,6 +662,7 @@ func (c *Client) SnapshotCreate(ctx context.Context, req contracts.SnapshotCreat
 		result.Task = &contracts.TaskRef{
 			ID: resp.Task.Id,
 		}
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
 	}
 
 	return result, nil
@@ -579,6 +684,7 @@ func (c *Client) SnapshotDelete(ctx context.Context, vmId string, snapshotId str
 	}
 
 	if resp.Task != nil {
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
 		return resp.Task.Id, nil
 	}
 
@@ -601,6 +707,7 @@ func (c *Client) SnapshotRevert(ctx context.Context, vmId string, snapshotId str
 	}
 
 	if resp.Task != nil {
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
 		return resp.Task.Id, nil
 	}
 
@@ -635,6 +742,7 @@ func (c *Client) ExportDisk(ctx context.Context, req contracts.ExportDiskRequest
 
 	if resp.Task != nil {
 		result.TaskRef = resp.Task.Id
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
 	}
 
 	return result, nil
@@ -669,6 +777,7 @@ func (c *Client) ImportDisk(ctx context.Context, req contracts.ImportDiskRequest
 
 	if resp.Task != nil {
 		result.TaskRef = resp.Task.Id
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
 	}
 
 	return result, nil

--- a/internal/transport/grpc/client_tasks_inflight_test.go
+++ b/internal/transport/grpc/client_tasks_inflight_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// gaugeSample returns the current gauge value for the given metric
+// family matching the supplied labels. Returns 0 when no matching
+// sample exists (so before/after subtraction yields the delta).
+// Local to this file to avoid coupling with the resilience package's
+// own gaugeSample helper.
+func gaugeSample(t *testing.T, family string, want map[string]string) float64 {
+	t.Helper()
+	families, err := metrics.GetRegistry().Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != family {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if labelsMatchPairs(m.GetLabel(), want) {
+				if g := m.GetGauge(); g != nil {
+					return g.GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// _ keeps the dto import live for gaugeSample (which calls
+// m.GetGauge().GetValue() on *dto.Metric).
+var _ = (*dto.Histogram)(nil)
+
+// fakeTasksServer drives the G7.3 lifecycle tests. CreateTaskID is the
+// TaskRef ID returned from Create; DoneOnPoll determines whether the
+// next TaskStatus poll reports Done=true.
+type fakeTasksServer struct {
+	providerv1.UnimplementedProviderServer
+	CreateTaskID string
+	DoneOnPoll   bool
+}
+
+func (f *fakeTasksServer) Create(_ context.Context, _ *providerv1.CreateRequest) (*providerv1.CreateResponse, error) {
+	resp := &providerv1.CreateResponse{Id: "vm-test"}
+	if f.CreateTaskID != "" {
+		resp.Task = &providerv1.TaskRef{Id: f.CreateTaskID}
+	}
+	return resp, nil
+}
+
+func (f *fakeTasksServer) TaskStatus(_ context.Context, _ *providerv1.TaskStatusRequest) (*providerv1.TaskStatusResponse, error) {
+	return &providerv1.TaskStatusResponse{Done: f.DoneOnPoll}, nil
+}
+
+// newTestClientForTasks wires up an in-process gRPC client with the
+// G7.3 task tracker fully populated. Provider labels are caller-
+// supplied so each test pins its own metric sample.
+func newTestClientForTasks(t *testing.T, srv providerv1.ProviderServer, providerType, providerName string) *Client {
+	t.Helper()
+	dialer, cleanup := startBufconnServer(t, srv)
+	t.Cleanup(cleanup)
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return dialer(ctx, "") }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(providerRPCMetricsInterceptor(providerType)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	taskMetrics := metrics.NewTaskMetrics(providerType, providerName)
+	taskMetrics.SetInflightTasks(0) // seed the gauge so it appears in /metrics
+	return &Client{
+		conn:          conn,
+		client:        providerv1.NewProviderClient(conn),
+		vmOps:         metrics.NewVMOperationMetrics(providerType, providerName),
+		tasks:         taskMetrics,
+		inflightTasks: make(map[string]struct{}),
+	}
+}
+
+// TestTrackTask_NilTasksIsSafe pins the nil-safety contract on both
+// helpers. Test clients that construct &Client{...} directly may leave
+// the tasks field nil; neither helper should panic. G7.3 / #129.
+func TestTrackTask_NilTasksIsSafe(t *testing.T) {
+	c := &Client{} // tasks left nil on purpose
+	// Must not panic on any of these calls.
+	c.trackTaskStart("any-id")
+	c.trackTaskStart("")
+	c.trackTaskDone("any-id")
+	c.trackTaskDone("")
+}
+
+// TestTrackTask_StartAndDoneCycle pins the success path:
+//
+//	Start("a") → gauge = 1
+//	Start("b") → gauge = 2
+//	Done("a")  → gauge = 1
+//	Done("b")  → gauge = 0
+//
+// G7.3 / #129.
+func TestTrackTask_StartAndDoneCycle(t *testing.T) {
+	const providerType, provider = "g73-cycle", "g73-cycle-provider"
+	c := newClientWithTaskMetrics(providerType, provider)
+	labels := map[string]string{"provider_type": providerType, "provider": provider}
+
+	c.trackTaskStart("a")
+	assert.Equal(t, 1.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"gauge must be 1 after starting one task")
+
+	c.trackTaskStart("b")
+	assert.Equal(t, 2.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"gauge must be 2 after starting a second task")
+
+	c.trackTaskDone("a")
+	assert.Equal(t, 1.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"gauge must drop to 1 after first done")
+
+	c.trackTaskDone("b")
+	assert.Equal(t, 0.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"gauge must drop to 0 after all tasks done")
+}
+
+// TestTrackTask_DoubleDoneIsIdempotent pins the double-poll contract:
+// calling Done twice for the same taskID must decrement at most once.
+// This catches the reconciler-retry-between-observing-done-and-clearing-
+// status-ref class of regression. G7.3 / #129.
+func TestTrackTask_DoubleDoneIsIdempotent(t *testing.T) {
+	const providerType, provider = "g73-double", "g73-double-provider"
+	c := newClientWithTaskMetrics(providerType, provider)
+	labels := map[string]string{"provider_type": providerType, "provider": provider}
+
+	c.trackTaskStart("a")
+	require.Equal(t, 1.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels))
+
+	c.trackTaskDone("a")
+	c.trackTaskDone("a") // second done — must be no-op
+	c.trackTaskDone("a") // third done — still no-op
+
+	assert.Equal(t, 0.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"repeated Done calls for same taskID must not push gauge below 0")
+}
+
+// TestTrackTask_UnknownDoneIsNoop pins the post-restart contract: a
+// new manager instance polls TaskStatus for a vm.Status.LastTaskRef
+// recorded by a previous instance. The new instance's set is empty;
+// Done on an unknown ID must NOT push the gauge negative. G7.3 / #129.
+func TestTrackTask_UnknownDoneIsNoop(t *testing.T) {
+	const providerType, provider = "g73-unknown", "g73-unknown-provider"
+	c := newClientWithTaskMetrics(providerType, provider)
+	labels := map[string]string{"provider_type": providerType, "provider": provider}
+
+	require.Equal(t, 0.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"precondition: seeded gauge must be 0")
+
+	c.trackTaskDone("never-seen-this-id")
+	c.trackTaskDone("nor-this-one")
+
+	assert.Equal(t, 0.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"Done on unknown IDs must NOT push the gauge negative")
+}
+
+// TestTrackTask_StartIdempotentOnSameID pins the defensive
+// re-start-with-same-ID path: should not double-count, gauge stays
+// at +1 not +2. G7.3 / #129.
+func TestTrackTask_StartIdempotentOnSameID(t *testing.T) {
+	const providerType, provider = "g73-restart", "g73-restart-provider"
+	c := newClientWithTaskMetrics(providerType, provider)
+	labels := map[string]string{"provider_type": providerType, "provider": provider}
+
+	c.trackTaskStart("a")
+	c.trackTaskStart("a") // repeated — should not double-count
+	c.trackTaskStart("a") // still should not double-count
+
+	assert.Equal(t, 1.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"repeated Start with same ID must keep gauge at 1, not 3")
+}
+
+// TestTrackTask_ConcurrentStartDoneIsRaceFree pushes the mutex hard:
+// many goroutines start and complete tasks concurrently. End state
+// must be 0 with no panic and no race detection failure (run with
+// `go test -race`). G7.3 / #129.
+func TestTrackTask_ConcurrentStartDoneIsRaceFree(t *testing.T) {
+	const providerType, provider = "g73-concurrent", "g73-concurrent-provider"
+	c := newClientWithTaskMetrics(providerType, provider)
+	labels := map[string]string{"provider_type": providerType, "provider": provider}
+
+	const N = 100
+	var wg sync.WaitGroup
+	wg.Add(2 * N)
+	for i := 0; i < N; i++ {
+		id := "task-" + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26)) + string(rune('a'+(i/(26*26))%26))
+		go func(id string) {
+			defer wg.Done()
+			c.trackTaskStart(id)
+		}(id)
+		go func(id string) {
+			defer wg.Done()
+			c.trackTaskDone(id)
+		}(id)
+	}
+	wg.Wait()
+
+	// The Start/Done pairs interleave non-deterministically. After all
+	// goroutines settle, the gauge MAY be > 0 if some Done calls
+	// happened before their Start (no-op on unknown ID), so we drain by
+	// running Done again for each id sequentially.
+	for i := 0; i < N; i++ {
+		id := "task-" + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26)) + string(rune('a'+(i/(26*26))%26))
+		c.trackTaskDone(id)
+	}
+	assert.Equal(t, 0.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"after sequential drain, gauge must settle at 0")
+}
+
+// TestClient_TaskLifecycle_EndToEnd exercises the integration path:
+// Create returns Task → gauge goes to 1; IsTaskComplete returns Done=true
+// → gauge drops to 0. This is the canary that catches if either side of
+// the Inc/Dec wiring is dropped in a future refactor. G7.3 / #129.
+func TestClient_TaskLifecycle_EndToEnd(t *testing.T) {
+	const providerType, provider = "g73-e2e", "g73-e2e-provider"
+	labels := map[string]string{"provider_type": providerType, "provider": provider}
+
+	srv := &fakeTasksServer{CreateTaskID: "lifecycle-task-1", DoneOnPoll: false}
+	cli := newTestClientForTasks(t, srv, providerType, provider)
+	ctx := context.Background()
+
+	require.Equal(t, 0.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"precondition: seeded gauge must be 0")
+
+	// Create with Task → gauge increments to 1.
+	resp, err := cli.Create(ctx, contracts.CreateRequest{Name: "vm-test"})
+	require.NoError(t, err)
+	require.Equal(t, "lifecycle-task-1", resp.TaskRef, "fake server must echo the task id")
+	assert.Equal(t, 1.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"Create returning a Task must push gauge to 1")
+
+	// Poll: not done yet → gauge unchanged.
+	done, err := cli.IsTaskComplete(ctx, "lifecycle-task-1")
+	require.NoError(t, err)
+	require.False(t, done)
+	assert.Equal(t, 1.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"polling a not-yet-done task must leave gauge unchanged")
+
+	// Flip the server to Done; next poll terminates the task.
+	srv.DoneOnPoll = true
+	done, err = cli.IsTaskComplete(ctx, "lifecycle-task-1")
+	require.NoError(t, err)
+	require.True(t, done)
+	assert.Equal(t, 0.0, gaugeSample(t, "virtrigaud_provider_tasks_inflight", labels),
+		"poll observing Done=true must decrement gauge to 0")
+}
+
+// newClientWithTaskMetrics builds a minimal Client with only the
+// fields needed to exercise trackTaskStart / trackTaskDone (no real
+// gRPC connection — these tests pin the in-process state machine,
+// not the network path). Helper local to this file so the unit-level
+// tests stay loosely coupled from the integration-style helpers.
+func newClientWithTaskMetrics(providerType, provider string) *Client {
+	tm := metrics.NewTaskMetrics(providerType, provider)
+	tm.SetInflightTasks(0) // seed the gauge so gaugeSample finds the label set
+	return &Client{
+		tasks:         tm,
+		inflightTasks: make(map[string]struct{}),
+	}
+}


### PR DESCRIPTION
## Summary
- Closes **#129** (G7.3 sub-issue of umbrella **#123**).
- Third of 4 G7 sub-PRs. Wires `virtrigaud_provider_tasks_inflight` so the gauge reflects per-Provider async-task count in real time.
- **Same dead-code-paradox shape** as G7.1 / G7.2 / G6: family registered, helper present, zero production callsites.

## Why
"Is the libvirt provider drowning in concurrent migration tasks?" — pre-PR: no metric, operators had to read the manager logs. Post-PR: `virtrigaud_provider_tasks_inflight{provider_type="libvirt"} > 5` is a sensible alert threshold; `topk(5, virtrigaud_provider_tasks_inflight)` shows the busiest Providers.

## Implementation

**Stateful tracking in `Client`** (`internal/transport/grpc/client.go`):
- 3 new fields: `tasks *metrics.TaskMetrics`, `inflightTasksMu sync.Mutex`, `inflightTasks map[string]struct{}`. The map is the source of truth; gauge = `len(map)` after each change.
- 2 new helpers:
  - `trackTaskStart(id)` — adds, pushes gauge, idempotent on duplicate IDs
  - `trackTaskDone(id)` — removes, pushes gauge, idempotent on **unknown** IDs (the load-bearing post-restart safety)
- 9 task-creating methods now call `trackTaskStart(resp.Task.Id)` after `resp.Task != nil`:
  Create, Delete, Power, Reconfigure, SnapshotCreate, SnapshotDelete, SnapshotRevert, ExportDisk, ImportDisk
- 2 task-polling methods (`IsTaskComplete`, `TaskStatus`) call `trackTaskDone(taskRef)` on terminal completion (Done=true OR Error != "")
- `NewClient` seeds gauge to 0 so the family appears on `/metrics` from boot

## Critical semantic: per-instance counting

The gauge measures **"tasks THIS manager instance is tracking"**, not "tasks the provider believes are in-flight." When a manager restarts:
1. The new instance's `inflightTasks` map starts empty.
2. The reconciler reads `vm.Status.LastTaskRef` from etcd and polls `IsTaskComplete`.
3. The new instance's `trackTaskDone` sees an unknown ID → no-op.
4. Gauge stays at 0; self-corrects within seconds as those tasks complete and new ones start.

This is intentional and documented in helper GoDoc. The alternative (cross-instance state) would require an external store and add complexity disproportionate to the metric's purpose.

## Critical correctness: idempotency

Two real-world cases would silently push the gauge negative without the map-based gating:
1. **Double-poll**: reconciler crashes between observing `Done=true` and clearing `vm.Status.LastTaskRef`. Next reconcile polls again, gets Done=true again, calls `trackTaskDone` again. Without gating: gauge -= 1.
2. **Post-restart**: new manager polls a TaskRef recorded by previous instance. Without gating: gauge -= 1.

The map-based set fixes both — `trackTaskDone` only decrements when the ID is currently in the set, then removes it.

## Race-freedom

Mutex-guarded around the map. Controller-runtime defaults to **10 concurrent reconciles per controller** (`MaxConcurrentReconciles` in `SetupWithManager`), so multiple reconcilers can race on the same Client. Verified with `go test -race ./internal/transport/grpc/...` clean.

## Tests (`internal/transport/grpc/client_tasks_inflight_test.go`, new)

7 tests pinning every contract:
| Test | What it pins |
|---|---|
| `TestTrackTask_NilTasksIsSafe` | Nil-safety on both helpers |
| `TestTrackTask_StartAndDoneCycle` | Success path: 0 → 1 → 2 → 1 → 0 |
| `TestTrackTask_DoubleDoneIsIdempotent` | Double-poll contract |
| `TestTrackTask_UnknownDoneIsNoop` | Post-restart contract |
| `TestTrackTask_StartIdempotentOnSameID` | Duplicate-Start defensive |
| `TestTrackTask_ConcurrentStartDoneIsRaceFree` | 200 goroutines, race-detector clean |
| `TestClient_TaskLifecycle_EndToEnd` | Bufconn integration: Create→gauge=1, IsTaskComplete-Done→gauge=0 |

New `fakeTasksServer` (minimal `providerv1.ProviderServer` with toggles) + local `gaugeSample` helper (mirrors existing `counterSampleByLabels` pattern; kept package-local).

## Test plan
- [x] `make fmt` clean
- [x] `go vet ./...` clean
- [x] `make test` 12/12 packages, 0 FAIL
- [x] New tests 7/7 sub-cases green individually
- [x] `go test -race ./internal/transport/grpc/...` clean
- [x] `make build` clean; `./bin/manager --version` works
- [ ] **v0.3.6-rc1 smoke** (post-merge): trigger a VM create or migration on `vr1.lab.k8`; observe `virtrigaud_provider_tasks_inflight{provider_type="libvirt"}` increment to 1, then drop to 0 when the task completes

## Defaults / breakage
- **No breaking change.** No public API or signature changes.
- Metric emission is additive — operators see one new gauge family on `/metrics` post-deploy.

## What's next in G7
| # | Issue | What | Status |
|---|---|---|---|
| G7.1 | #124 | `vm_operations_total` | ✅ MERGED (PR #126) |
| G7.2 | #127 | `ip_discovery_duration_seconds` | ✅ MERGED (PR #128) |
| **G7.3** | **#129 ← this PR** | `provider_tasks_inflight` | v0.3.6 |
| G7.4 | (file when starting) | `queue_depth` | **closes G7 umbrella #123** |

After this lands: **10 of 12** expected `virtrigaud_*` families wired in code. Only G7.4 + the deploy-pending circuit_breaker pair remain.