### PR TITLE
chore(test): gate e2e suite behind //go:build e2e (supersedes #71)

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2025.
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2025.
 


### PR DESCRIPTION
## Summary
- **Supersedes draft #71** (which was 5 days out of date — base predated G-track, H1, Go-bump, and G7; rebase would have hit ~60-file conflicts).
- Add \`//go:build e2e\` build tags to \`test/e2e/e2e_suite_test.go\` and \`test/e2e/e2e_test.go\` so they're excluded from default \`go test ./...\` / \`go vet ./...\` runs.

## Why
\`test/e2e\` requires a running kind cluster + the manager image loaded. Without that, \`TestE2E\` fails in \`BeforeSuite\` (\`kind load docker-image example.com/virtrigaud:v0.0.1 --name kind\` errors with \"image not present locally\"). Today:

- **\`make test\`** works around it with an explicit \`grep -v /test/e2e\` exclude pattern (fine for the make target)
- **Raw \`go test ./...\`** has no such filter and fails — surfaced as a regular annoyance during pre-merge verification on the G7.x PRs
- **IDE 'run all tests'** buttons hit the same issue

The \`//go:build e2e\` tag is the idiomatic Go solution. Matches how other controller-runtime projects (cert-manager, capi, etc.) gate their e2e suites.

## Run the suite explicitly
\`\`\`bash
go test -tags=e2e ./test/e2e/...
\`\`\`

## Test plan
- [x] \`go test ./...\` runs 13 packages, 0 FAIL, **no TestE2E mention** (was the failing one before this PR)
- [x] \`go test -tags=e2e -run='^$' ./test/e2e/...\` builds cleanly (the \`-run='^$'\` filter avoids actually invoking BeforeSuite since we don't have a kind cluster in the local dev env — but the package compiles which is the contract this PR cares about)
- [x] \`make test\` still 12/12 packages with 0 FAIL — no regression to the existing exclude path
- [ ] CI green on this PR
- [ ] Post-merge: verify CI's Test job continues passing (it already excludes test/e2e via the \`make test\` target so should be unaffected)

## Defaults / breakage
- **No breaking change.** The e2e tests are still runnable; they just need the explicit tag flag.
- **CI is unaffected** — \`Test\` job uses \`make test\` which already excludes \`/test/e2e\`.

## What's superseded
Closing draft #71 with a comment pointing here. Same author identity (William Rizzo signoff); the original commit had a stray \`Co-authored-by: Cursor\` trailer which is dropped per the project rule (\"only attribution is the William Rizzo signoff\").