### PR TITLE
chore(ci): make Dependabot policy explicit + group non-major actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,28 @@
 ---
+# Dependabot configuration for VirtRigaud.
+#
+# Policy (per #134, 2026-05-25):
+#   - Major bumps ARE allowed. No `ignore` clause excludes any update
+#     type. Major version bumps for GitHub Actions are operationally
+#     significant (Node runtime changes, breaking API changes) and get
+#     reviewed individually; minor + patch bumps batch into a single PR
+#     per ecosystem to reduce review overhead.
+#   - The Node.js 20 deprecation in GitHub Actions has a 2026-09-16
+#     hard removal date. Actions still on Node 20 (per PROJECT_CONTEXT.md
+#     Risks-Watching) include: actions/setup-go (v5 → latest v6+),
+#     docker/login-action (v3 → v4+), docker/metadata-action (v5 → v6+),
+#     docker/setup-buildx-action (v3 → v4+). These have newer majors on
+#     Node 24; Dependabot should propose those bumps on its weekly run.
+#   - SHA-pinning caveat: our workflows use commit-SHA pinning with a
+#     trailing version comment (e.g. `actions/setup-go@<sha>  # v5`).
+#     Dependabot may be conservative about major bumps with SHA pins.
+#     If the weekly run does not propose v5→v6 (etc.), the fallback is
+#     a manual PR bumping the 4 outstanding actions to the latest SHA
+#     within the next major.
+#
+# Schedule: weekly Monday 09:00 America/Toronto — gives time during the
+# Monday business day to triage what landed before merging.
+
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -14,3 +38,21 @@ updates:
       - github-actions
     commit-message:
       prefix: "chore(deps)"
+
+    # Explicit allow block — documents intent that ALL update types
+    # (major + minor + patch) for ALL github-actions deps are eligible.
+    # Functionally equivalent to omitting the block, but makes the
+    # policy loud for future maintainers reading the config.
+    allow:
+      - dependency-type: all
+
+    # Group minor + patch bumps into one weekly PR per ecosystem; keep
+    # major bumps as individual PRs (so each major change gets its own
+    # review surface — matches what we did during the May 2026 Tier
+    # A/B/C batches where each action's major bump was a separate PR).
+    groups:
+      ci-actions-non-major:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Closes **#134** (modulo the rollout verification steps in that issue).
- Documents the Dependabot policy explicitly + adds \`groups:\` config to batch minor/patch bumps and keep major bumps individual (matches Tier A/B/C flow used for the May 22 batch).
- **Functionally close to a no-op**: the original config already allowed all update types via \`ignore\`-omission. The intent is to make the policy LOUD for future maintainers + improve the per-week review experience.

## Why now

Audit on 2026-05-25: 4 GitHub Actions are still on Node.js 20 with newer Node 24 majors available:
| Action | Pinned | Latest |
|---|---|---|
| \`actions/setup-go\` | v5 | **v6.4.0** |
| \`docker/login-action\` | v3 | **v4.2.0** |
| \`docker/metadata-action\` | v5 | **v6.1.0** |
| \`docker/setup-buildx-action\` | v3 | **v4.1.0** |

The May 22 Dependabot batch (PRs #74-#82) cleared 5 other outdated actions but missed these 4. Likely cause: SHA-pinning + \`# v5\` version-comment hints. **Hard deadline 2026-09-16** for Node 20 removal.

## What this PR does NOT do
- Does **not** manually bump the 4 outstanding actions (per maintainer call). The bet is that the explicit policy + the next Monday run picks them up. If not, the fallback (manual PR) is documented in #134.

## What changed in \`.github/dependabot.yml\`
| Addition | Effect |
|---|---|
| Top-of-file comment block (~25 lines) | Documents policy, Node 20 deadline, 4 outstanding actions, SHA-pinning caveat, fallback plan |
| \`allow: dependency-type: all\` | Explicit — was implicit before (no \`ignore\` clause). Loud-and-clear intent for future maintainers. |
| \`groups: ci-actions-non-major\` (\`update-types: [minor, patch]\`) | Batches minor + patch bumps into one weekly PR per ecosystem. Major bumps stay individual (per the Tier A/B/C convention). |

## Rollout plan (tracked in #134)
1. **This PR merges** → next weekly Dependabot run fires Monday 2026-06-01 09:00 America/Toronto = 13:00 UTC
2. **If Dependabot surfaces PRs for the 4 outstanding actions**: merge them with the same Tier-style coordinated process used May 22-24
3. **If no PRs after that run**: file a manual one-shot bump PR. Dependabot will maintain them within new majors going forward

## Test plan
- [x] YAML syntactically valid (Dependabot will reject malformed config; will see in the next run)
- [ ] CI green on this PR
- [ ] **Post-merge**: monitor 2026-06-01 Monday Dependabot run; verify PRs surface for the 4 outstanding actions (or trigger the fallback per #134)
- [ ] Verify that \`groups:\` actually batches future minor/patch bumps as expected (will show in the first weekly PR after merge)

## References
- Issue: **#134** (full plan + acceptance criteria)
- Predecessor batch: #74-#82 (May 22-24)
- GitHub Node 20 deprecation: 2025-09-19 announcement, 2026-09-16 removal