### PR TITLE
docs: v0.3.6 main-repo documentation alignment (Phase 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,47 +2,31 @@
 
 A Kubernetes operator for managing virtual machines across multiple hypervisors.
 
+**Version**: v0.3.6 — [CHANGELOG](CHANGELOG.md) | [Documentation](https://projectbeskar.github.io/virtrigaud)
+
 ## Overview
 
-Virtrigaud is a Kubernetes operator that enables declarative management of virtual machines across different hypervisor platforms. It provides a unified API for provisioning and managing VMs on vSphere, Libvirt/KVM, Proxmox VE, and other hypervisors through a clean provider interface.
+VirtRigaud is a Kubernetes operator that enables declarative management of virtual machines across different hypervisor platforms. It provides a unified API for provisioning and managing VMs on vSphere, Libvirt/KVM, and Proxmox VE through a remote gRPC provider architecture.
+
+The manager reconciles Kubernetes custom resources; each hypervisor runs as a separate provider pod. Manager and provider pods communicate over gRPC. Credentials are scoped to the Provider CR and never flow through the manager.
 
 ## Features
 
-- **Multi-Hypervisor Support**: Manage VMs across vSphere, Libvirt/KVM, and Proxmox VE simultaneously
-- **Cross-Provider VM Migration**: Migrate VMs between different hypervisor platforms using Kubernetes-native storage (currently tested: vSphere to Libvirt/KVM)
-- **Multi-VM Management**: Declarative management of VM sets with rolling updates and replica management
-- **Advanced Placement Policies**: Fine-grained VM placement rules with affinity, anti-affinity, and resource constraints
-- **Declarative API**: Define VM resources using Kubernetes CRDs with stable v1beta1 API
-- **Production-Ready Providers**: Full integration for vSphere (govmomi), Libvirt/KVM, and Proxmox VE
-- **Cloud-Init Support**: Initialize VMs with cloud-init configuration across all providers
-- **Network Management**: Configure VM networking with provider-specific settings
-- **Power Management**: Control VM power state (On/Off/Reboot) uniformly
-- **Async Task Support**: Handles long-running operations (vSphere) and synchronous operations (Libvirt)
-- **Resource Management**: CPU, memory, disk configuration across hypervisors
-- **Storage Management**: Provider-specific storage handling (datastores vs storage pools)
-- **Finalizer-based Cleanup**: Ensures proper cleanup of external resources
-
-## API Support
-
-**API Version**: v1beta1
-
-All resources use the v1beta1 API with comprehensive OpenAPI validation and type safety.
+- **Multi-Hypervisor Support**: vSphere, Libvirt/KVM, and Proxmox VE simultaneously
+- **Cross-Provider VM Migration**: Migrate VMs between hypervisors using PVC-backed storage (currently tested: vSphere to Libvirt/KVM only; other directions are roadmap)
+- **Multi-VM Management**: Declarative VM sets with rolling updates and replica management
+- **Advanced Placement Policies**: Affinity, anti-affinity, and resource constraints
+- **Declarative v1beta1 API**: Stable CRDs with OpenAPI validation
+- **Cloud-Init Support**: Cross-provider VM initialisation via cloud-init
+- **Power Management**: On/Off/Reboot/Graceful-Shutdown uniformly
+- **Async Task Tracking**: Long-running vSphere and Proxmox operations tracked via TaskStatus RPC
+- **Resource Reconfiguration**: CPU, memory, disk changes (online for vSphere/Proxmox; restart required for Libvirt)
+- **G6 Circuit Breaker**: One circuit breaker per Provider CR for automatic failure isolation (v0.3.6+)
+- **Observability**: 11 `virtrigaud_*` Prometheus metric families (1 deprecated in v0.3.6; removal in v0.4.0)
 
 ## Architecture
 
 VirtRigaud uses a **Remote Provider** architecture for optimal scalability and reliability:
-
-### Key Benefits
-
-- **Scalability**: Each provider runs as independent pods with dedicated resources
-- **Reliability**: Provider failures don't affect the manager or other providers
-- **Security**: Provider credentials are isolated to their respective pods
-- **Flexibility**: Scale providers independently based on workload demands
-- **Maintainability**: Update providers without affecting the core manager
-- **Multi-tenancy**: Different providers for different teams/environments
-- **Updates**: Rolling updates of providers without manager downtime
-
-### Architecture Overview Diagram
 
 ```mermaid
 graph TB
@@ -50,22 +34,28 @@ graph TB
     subgraph "Kubernetes Cluster"
 
         %% CRDs
-        subgraph "Custom Resources"
-            VM[VirtualMachine CRD]
-            VMC[VMClass CRD]
-            VMI[VMImage CRD]
-            PR[Provider CRD]
-            VMNA[VMNetworkAttachment CRD]
+        subgraph "Custom Resources (v1beta1)"
+            VM[VirtualMachine]
+            VMC[VMClass]
+            VMI[VMImage]
+            PR[Provider]
+            VMNA[VMNetworkAttachment]
+            VMSN[VMSnapshot]
+            VMSET[VMSet]
+            VMMig[VMMigration]
+            VMPP[VMPlacementPolicy]
+            VMCL[VMClone]
         end
 
         %% Controller
-        CTRL[VirtRigaud Controller<br/>Manager]
+        CTRL["VirtRigaud Manager
+        (controller + G6 CB interceptor)"]
 
         %% Remote Providers
         subgraph "Remote Providers (gRPC)"
-            VSP[vSphere Provider<br/>Pod]
-            LVP[Libvirt Provider<br/>Pod]
-            PXP[Proxmox Provider<br/>Pod]
+            VSP[vSphere Provider Pod]
+            LVP[Libvirt Provider Pod]
+            PXP[Proxmox Provider Pod]
         end
 
         %% Connections within cluster
@@ -75,36 +65,86 @@ graph TB
         PR -.-> CTRL
         VMNA -.-> CTRL
 
-        CTRL -->|gRPC/TLS| VSP
-        CTRL -->|gRPC/TLS| LVP
-        CTRL -->|gRPC/TLS| PXP
+        CTRL -->|"gRPC (G4 retry + G6 CB)"| VSP
+        CTRL -->|"gRPC (G4 retry + G6 CB)"| LVP
+        CTRL -->|"gRPC (G4 retry + G6 CB)"| PXP
     end
 
     %% External Infrastructure
     subgraph "External Infrastructure"
-        subgraph "vSphere Environment"
+        subgraph "vSphere"
             VCENTER[vCenter Server]
-            ESXI[ESXi Hosts]
         end
-
-        subgraph "KVM Environment"
-            LIBVIRT[Libvirt Hosts]
-            QEMU[QEMU/KVM VMs]
+        subgraph "KVM"
+            LIBVIRT[Libvirt Host]
         end
-
-        subgraph "Proxmox Environment"
-            PVE[Proxmox VE Cluster]
-            NODES[PVE Nodes]
+        subgraph "Proxmox VE"
+            PVE[Proxmox Cluster]
         end
     end
 
-    %% External connections
     VSP -->|govmomi API| VCENTER
-    LVP -->|libvirt API| LIBVIRT
+    LVP -->|libvirt+SSH| LIBVIRT
     PXP -->|REST API| PVE
 ```
 
+### Security status (v0.3.6)
+
+- **mTLS not yet default**: gRPC traffic between manager and provider pods is TLS-capable but mTLS is not wired through the provider `Resolver`; see issue [#147](https://github.com/projectbeskar/virtrigaud/issues/147).
+- **Provider gRPC servers do not enforce authentication**: provider pods accept any client; see issue [#148](https://github.com/projectbeskar/virtrigaud/issues/148).
+- **Libvirt SSH host-key verification skipped**: see issue [#149](https://github.com/projectbeskar/virtrigaud/issues/149).
+
+For a full security disclosure, see the [Security Operations Guide](https://projectbeskar.github.io/virtrigaud/operations/security/).
+
+## CRDs (10 total, all v1beta1)
+
+| CRD | Short name | Description |
+|-----|-----------|-------------|
+| VirtualMachine | vm | A virtual machine instance |
+| VMClass | vmc | Resource profile (CPU, memory, disk) |
+| VMImage | vmi | Base template or image reference |
+| VMNetworkAttachment | vmna | Network configuration |
+| Provider | prov | Hypervisor connection + runtime config |
+| VMMigration | vmmig | Cross-provider VM migration |
+| VMSet | vmset | Multi-VM replica set |
+| VMPlacementPolicy | — | Placement rules (affinity, resources) |
+| VMSnapshot | — | Snapshot lifecycle management |
+| VMClone | — | Cloning operations |
+
+Note: VMAdoption is a **controller** built into the manager, not a CRD.
+
+## Provider Feature Matrix
+
+Per the [canonical capabilities matrix](https://projectbeskar.github.io/virtrigaud/providers/providers-capabilities/), verified against provider `GetCapabilities` responses in v0.3.6:
+
+| Feature | vSphere | Libvirt | Proxmox | Notes |
+|---------|---------|---------|---------|-------|
+| **Core Operations** | ✅ | ✅ | ✅ | Create/Delete/Power/Describe |
+| **Reconfiguration** | ✅ | ⚠️ | ✅ | Libvirt requires VM restart |
+| **Disk Expansion** | ✅ | ⚠️ | ✅ | Libvirt: power-cycle required |
+| **Snapshots** | ✅ | ✅ | ✅ | Point-in-time captures |
+| **Memory Snapshots** | ❌ | ❌ | ✅ | RAM-inclusive snapshots (vSphere: no) |
+| **Cloning (full)** | ✅ | ✅ | ✅ | Independent copies |
+| **Linked Clones** | ✅ | ✅ | ✅ | COW-based (Libvirt: qcow2 backing) |
+| **Clone RPC** | ✅ | ⚠️ [#153] | ✅ | Libvirt Clone RPC is a stub in v0.3.6 |
+| **ImagePrepare RPC** | ✅ | ⚠️ [#154] | ✅ | Libvirt ImagePrepare is a stub in v0.3.6 |
+| **Task Tracking** | ✅ | N/A | ✅ | Async operation monitoring |
+| **Console URLs** | ✅ | ✅ | ⚠️ | Proxmox console URL: planned |
+| **Guest Agent** | ✅ | ✅ | ✅ | IP detection and guest info |
+| **Image Import** | ✅ | ✅ | ✅ | vSphere: OVA/content library |
+| **Multi-NIC** | ✅ | ✅ | ✅ | Multiple network interfaces |
+| **Circuit Breaker** | ✅ | ✅ | ✅ | One CB per Provider CR (v0.3.6) |
+
+[#153]: https://github.com/projectbeskar/virtrigaud/issues/153
+[#154]: https://github.com/projectbeskar/virtrigaud/issues/154
+
 ## Quick Start
+
+### Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.10+
+- Go 1.26+ (for source builds only)
 
 ### Installation via Helm (Recommended)
 
@@ -114,92 +154,80 @@ graph TB
    helm repo update
    ```
 
-2. **Install VirtRigaud** (Manager only - Providers are created via CRs):
+2. **Install VirtRigaud** (version 0.3.6):
    ```bash
-   # Install VirtRigaud manager (CRDs included automatically)
-   # Note: Providers are NOT enabled via Helm - they are created as Provider CRs
    helm install virtrigaud virtrigaud/virtrigaud \
-     -n virtrigaud-system --create-namespace \
-     --set providers.vsphere.enabled=false \
-     --set providers.libvirt.enabled=false \
-     --set providers.proxmox.enabled=false
+     --version 0.3.6 \
+     -n virtrigaud-system --create-namespace
+   ```
 
-   # Or simply install with default values (all providers disabled by default in future versions)
-   helm install virtrigaud virtrigaud/virtrigaud -n virtrigaud-system --create-namespace
-
-   # To disable automatic CRD upgrades:
+   CRDs are installed automatically via Helm hooks. To disable automatic CRD upgrades:
+   ```bash
    helm install virtrigaud virtrigaud/virtrigaud \
+     --version 0.3.6 \
      -n virtrigaud-system --create-namespace \
      --set crdUpgrade.enabled=false
    ```
 
-   > **Important**: Do not enable providers via Helm flags. Instead, create Provider CRs (see step 1 in "Using VirtRigaud" below) which automatically deploy provider pods with proper credential management.
+   > Providers are NOT enabled via Helm flags. Create Provider CRs (step 1 below) — the controller deploys provider pods automatically.
 
 3. **Verify the installation**:
    ```bash
-   # Check pods
    kubectl get pods -n virtrigaud-system
-
-   # Check CRDs
    kubectl get crd | grep virtrigaud
-
-   # Verify CRD upgrade job completed (if enabled)
-   kubectl get jobs -n virtrigaud-system -l app.kubernetes.io/component=crd-upgrade
    ```
 
-4. **Upgrade VirtRigaud** (CRDs are automatically upgraded):
+4. **Upgrade**:
    ```bash
-   # Standard upgrade - CRDs are automatically updated
-   helm upgrade virtrigaud virtrigaud/virtrigaud -n virtrigaud-system
-
-   # The chart uses Helm hooks to apply CRDs during upgrade
-   # No manual CRD management needed!
-
-   # To upgrade provider images, update the Provider CR's spec.runtime.image field:
-   kubectl patch provider <provider-name> -n <namespace> --type=merge \
-     -p '{"spec":{"runtime":{"image":"ghcr.io/projectbeskar/virtrigaud/provider-libvirt:v0.3.0"}}}'
+   helm upgrade virtrigaud virtrigaud/virtrigaud \
+     --version 0.3.6 \
+     -n virtrigaud-system
    ```
 
 ### Development Installation
 
-1. **Install the CRDs**:
-   ```bash
-   make install
-   ```
+```bash
+# Install CRDs
+make install
 
-2. **Run the controller**:
-   ```bash
-   make run
-   ```
+# Run the controller locally
+make run
+```
+
+Go 1.26+ is required for source builds.
 
 ### Using VirtRigaud
 
-1. **Create a Provider** (one-time setup per hypervisor):
-
-   First, create a credentials secret in the namespace where you'll create the Provider:
+1. **Create credentials secrets**:
 
    ```bash
-   # For Libvirt (SSH authentication)
-   kubectl create secret generic libvirt-creds -n default \
-     --from-literal=username=your-ssh-username \
-     --from-literal=password='your-ssh-password'
-
-   # Or with SSH key (recommended)
+   # Libvirt — SSH key (recommended)
    kubectl create secret generic libvirt-creds -n default \
      --from-literal=username=your-ssh-username \
      --from-file=ssh-privatekey=~/.ssh/id_rsa
 
-   # For vSphere
+   # Libvirt — password
+   kubectl create secret generic libvirt-creds -n default \
+     --from-literal=username=your-ssh-username \
+     --from-literal=password='your-ssh-password'
+
+   # vSphere
    kubectl create secret generic vsphere-creds -n default \
      --from-literal=username=administrator@vsphere.local \
      --from-literal=password='your-password'
+
+   # Proxmox VE — API token (recommended; keys: token_id, token_secret)
+   kubectl create secret generic proxmox-creds -n default \
+     --from-literal=token_id='virtrigaud@pve!vrtg-token' \
+     --from-literal=token_secret='xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx'
    ```
 
-   Then create the Provider CR that references the secret:
+   > The Proxmox provider reads credentials from files mounted at `/etc/virtrigaud/credentials/{token_id,token_secret,username,password}`. Do NOT use `envFrom: secretRef` for Proxmox credentials — that pattern is not implemented.
 
-   **Libvirt/KVM Provider Example:**
-   ```bash
-   kubectl apply -f - <<EOF
+2. **Create a Provider CR**:
+
+   ```yaml
+   # Libvirt/KVM
    apiVersion: infra.virtrigaud.io/v1beta1
    kind: Provider
    metadata:
@@ -209,18 +237,15 @@ graph TB
      type: libvirt
      endpoint: "qemu+ssh://192.168.1.10/system"
      credentialSecretRef:
-       name: libvirt-creds  # Secret in the same namespace (default)
+       name: libvirt-creds
      runtime:
-       mode: Remote
-       image: "ghcr.io/projectbeskar/virtrigaud/provider-libvirt:latest"
+       image: "ghcr.io/projectbeskar/virtrigaud/provider-libvirt:v0.3.6"
        service:
-         port: 9090
-   EOF
+         port: 9443
    ```
 
-   **vSphere Provider Example:**
-   ```bash
-   kubectl apply -f - <<EOF
+   ```yaml
+   # vSphere
    apiVersion: infra.virtrigaud.io/v1beta1
    kind: Provider
    metadata:
@@ -232,205 +257,29 @@ graph TB
      credentialSecretRef:
        name: vsphere-creds
      runtime:
-       mode: Remote
-       image: "virtrigaud/provider-vsphere:latest"
+       image: "ghcr.io/projectbeskar/virtrigaud/provider-vsphere:v0.3.6"
        service:
-         port: 9090
-   EOF
+         port: 9443
    ```
 
-   > **How it works**: When you create a Provider CR, the VirtRigaud Provider Controller:
-   > 1. Creates a dedicated Deployment in the same namespace as the Provider CR
-   > 2. Mounts the credentials secret specified in `credentialSecretRef`
-   > 3. Creates a Service for the provider pod
-   > 4. The provider pod connects to your hypervisor using the mounted credentials
-   >
-   > Each Provider CR gets its own isolated provider deployment with its own credentials. This is more secure than shared multi-tenant providers. See [Remote Provider Documentation](docs/REMOTE_PROVIDERS.md#configuration-flow-provider-resource--provider-pod) for details.
+   When you apply a Provider CR, the controller creates a dedicated Deployment and Service for the provider pod in the same namespace. Each Provider CR has isolated credentials.
 
-2. **Create VM resources using the Provider**:
+3. **Deploy a VM**:
+
    ```bash
-   # Apply VM definition that references the provider
-   kubectl apply -f examples/complete-example.yaml
-
-   # Proxmox VE example (v1beta1 API)
-   kubectl apply -f examples/proxmox-complete-example.yaml
-
-   # Only v1beta1 API is supported as of v0.2.1
-
-   # Multi-provider example (vSphere, Libvirt, and Proxmox)
-   kubectl apply -f examples/multi-provider-example.yaml
-
-   # Or step by step:
-   kubectl create secret generic vsphere-creds \
-     --from-literal=username=administrator@vsphere.local \
-     --from-literal=password=your-password
-   kubectl apply -f examples/provider-vsphere.yaml
-   kubectl apply -f examples/vmclass-small.yaml
-   kubectl apply -f examples/vmimage-ubuntu.yaml
-   kubectl apply -f examples/vmnetwork-app.yaml
    kubectl apply -f examples/vm-ubuntu-small.yaml
-   ```
-
-2. **Monitor VM creation**:
-   ```bash
    kubectl get virtualmachine -w
    ```
 
-For detailed instructions, see [Quick Start Guide](https://virtrigaud.io/getting-started/).
-
-## CRDs
-
-- **VirtualMachine**: Represents a virtual machine instance
-- **VMClass**: Defines resource allocation (CPU, memory, disk, etc.)
-- **VMImage**: References base templates/images
-- **VMNetworkAttachment**: Defines network configurations
-- **Provider**: Configures hypervisor connection details
-- **VMMigration**: Cross-provider VM migration resource
-- **VMSet**: Multi-VM management with rolling updates
-- **VMPlacementPolicy**: Advanced VM placement rules and constraints
-- **VMSnapshot**: VM snapshot lifecycle management
-- **VMClone**: VM cloning operations
-
-## Supported Providers
-
-### Production-Ready Providers
-
-- **vSphere** - **GA**
-  - VM creation from templates
-  - Power management (On/Off/ShutDown)
-  - Resource configuration (CPU/Memory/Disks)
-  - **Hot reconfiguration** (CPU/Memory/Disk resizing)
-  - **VM cloning** (full and linked clones)
-  - **Async task tracking** with TaskStatus RPC
-  - **Web console URLs** for direct VM access
-  - Cloud-init support via guestinfo
-  - Network configuration with portgroups
-  - Snapshot management with memory state
-
-- **Libvirt/KVM** - **Production Ready**
-  - VM creation from qcow2 images
-  - Power management (On/Off/Reboot)
-  - Resource configuration (CPU/Memory/Disks)
-  - **Reconfiguration** (CPU/Memory/Disk - requires VM restart)
-  - **VNC console URLs** for remote VM access
-  - Cloud-init support via nocloud ISO
-  - Network configuration with bridges/networks
-  - Storage pool and volume management
-  - Snapshot management (storage-dependent)
-  - QEMU guest agent integration
-
-- **Proxmox VE** - **Production Ready (Beta)**
-  - VM creation from templates or ISO
-  - Power management (On/Off/Reboot)
-  - **Hot-plug reconfiguration** (CPU/Memory/Disk)
-  - **Snapshot management** (with memory state)
-  - **Guest agent integration** for accurate IP detection
-  - **Multi-NIC networking** with VLAN support
-  - **Linked/Full cloning**
-  - **Image import** from URLs
-  - Cloud-init support with static IPs
-  - Async task monitoring with jittered backoff
-  - Complete CRD integration
-
-### Provider Feature Matrix
-
-| Feature | vSphere | Libvirt | Proxmox | Notes |
-|---------|---------|---------|---------|-------|
-| **Core Operations** | ✅ | ✅ | ✅ | Create/Delete/Power/Describe |
-| **Reconfiguration** | ✅ | ⚠️ | ✅ | CPU/Memory/Disk changes (Libvirt requires restart) |
-| **Disk Expansion** | ✅ | ✅ | ✅ | Online disk growth |
-| **Snapshots** | ✅ | ✅ | ✅ | VM state snapshots |
-| **Memory Snapshots** | ✅ | ❌ | ✅ | Include RAM in snapshots |
-| **Cloning** | ✅ | ✅ | ✅ | Full and linked clones |
-| **Linked Clones** | ✅ | ❌ | ✅ | COW-based fast clones |
-| **Task Tracking** | ✅ | N/A | ✅ | Async operation monitoring |
-| **Console URLs** | ✅ | ✅ | ⚠️ | vSphere web console, VNC (Proxmox planned) |
-| **Guest Agent** | ✅ | ✅ | ✅ | IP detection and guest info |
-| **Image Import** | ❌ | ✅ | ✅ | Import from URLs/files |
-| **Multi-NIC** | ✅ | ✅ | ✅ | Multiple network interfaces |
-| **VLAN Support** | ✅ | ✅ | ✅ | 802.1Q VLAN tagging |
-| **Static IPs** | ✅ | ✅ | ✅ | Cloud-init network config |
-| **Remote Deployment** | ✅ | ✅ | ✅ | gRPC-based providers |
-
-### Future Roadmap
-
-- **Firecracker**: Serverless microVM support
-- **Cloud-Hypervisor**: Serverless microVM support
-- **QEMU**: Direct QEMU integration
-
-
-## Troubleshooting
-
-### Missing CRDs
-
-If CRDs are missing after Helm install:
-
-1. **Check if CRDs were skipped**:
-   ```bash
-   helm get values virtrigaud -n virtrigaud-system | grep skip-crds
-   ```
-
-2. **Manually install CRDs**:
-   ```bash
-   kubectl apply -f charts/virtrigaud/crds/
-   ```
-
-3. **Re-install with CRDs**:
-   ```bash
-   helm uninstall virtrigaud -n virtrigaud-system
-   helm install virtrigaud virtrigaud/virtrigaud -n virtrigaud-system --create-namespace
-   ```
+   See `examples/` for more examples.
 
 ## VM Migration
 
-VirtRigaud supports VM migrations between different hypervisors using Kubernetes-native storage. **Note**: Currently only tested from vSphere to Libvirt/KVM. Other provider combinations are not yet fully tested.
+VirtRigaud supports VM migration between providers using PVC-backed storage.
 
-### Migration Storage Requirements
+**Currently tested**: vSphere → Libvirt/KVM only. Other directions (Libvirt → vSphere, any Proxmox path) are roadmap items and unverified.
 
-VM migrations require intermediate storage for transferring VM disk images. VirtRigaud uses **Kubernetes PersistentVolumeClaims (PVCs)** as the migration storage backend.
-
-#### Prerequisites
-
-1. **StorageClass with ReadWriteMany (RWX) Access**
-
-   You need a StorageClass that supports `ReadWriteMany` access mode, allowing multiple provider pods to access the migration storage simultaneously. Common options include:
-
-   - **NFS-based storage** (nfs-subdir-external-provisioner, NFS CSI driver)
-   - **CephFS** (Ceph storage cluster)
-   - **GlusterFS** (Gluster storage cluster)
-   - **Cloud provider file storage** (AWS EFS, Azure Files, GCP Filestore)
-
-2. **Create a StorageClass**
-
-   Example NFS StorageClass:
-
-   ```yaml
-   apiVersion: storage.k8s.io/v1
-   kind: StorageClass
-   metadata:
-     name: nfs-migration-storage
-   provisioner: nfs.csi.k8s.io  # Or your NFS provisioner
-   parameters:
-     server: nfs-server.example.com
-     share: /exports/virtrigaud-migrations
-   volumeBindingMode: Immediate
-   reclaimPolicy: Delete
-   ```
-
-   Apply the StorageClass:
-   ```bash
-   kubectl apply -f nfs-storageclass.yaml
-   ```
-
-3. **Verify StorageClass**
-
-   ```bash
-   kubectl get storageclass nfs-migration-storage
-   ```
-
-#### Migration Configuration
-
-When creating a `VMMigration` resource, configure the storage as follows:
+Migration requires a `ReadWriteMany` StorageClass (NFS, CephFS, or similar):
 
 ```yaml
 apiVersion: infra.virtrigaud.io/v1beta1
@@ -443,130 +292,85 @@ spec:
     vmRef:
       name: source-vm
   target:
+    name: target-vm
     providerRef:
       name: target-provider
-    vmRef:
-      name: target-vm
   storage:
-    type: pvc  # Required: must be 'pvc'
+    type: pvc       # Only "pvc" is supported — s3/http/nfs are not implemented
     pvc:
-      # Option 1: Auto-create PVC (recommended)
       storageClassName: nfs-migration-storage
       size: 100Gi
-      accessMode: ReadWriteMany  # Required for multi-provider access
-
-      # Option 2: Use existing PVC
-      # name: existing-migration-pvc
+      accessMode: ReadWriteMany
 ```
 
-#### How It Works
+For full migration documentation including provider restart behaviour, see the [Migration Guide](https://projectbeskar.github.io/virtrigaud/operations/vm-migration/).
 
-1. **PVC Creation**: VirtRigaud automatically creates a PVC with the specified StorageClass and size (or uses an existing one)
-2. **Provider Restart**: Provider pods automatically restart to mount the new PVC (5-15 second disruption)
-3. **Automatic Mounting**: Provider pods discover and mount migration PVCs during startup
-4. **Data Transfer**: Source provider exports VM disk to PVC, target provider imports from PVC
-5. **Automatic Cleanup**: PVC is deleted when the `VMMigration` resource is removed (if auto-created)
+## Observability
 
-**Important Notes:**
-- **Brief Service Disruption**: When a migration is created, both source and target provider pods will restart to mount the migration PVC. This causes a brief (5-15 second) disruption to VM operations managed by those providers.
-- **Graceful Termination**: Providers have a 30-second graceful termination period to complete in-flight operations before shutdown.
-- **Automatic Recovery**: After providers restart and become healthy, the migration proceeds automatically.
-- **Production Consideration**: Plan migrations during maintenance windows or ensure redundant providers if continuous availability is required.
+The manager exposes Prometheus metrics at `:8080/metrics` (HTTP by default; flip `--metrics-secure=true` for HTTPS).
 
-#### Storage Size Recommendations
+11 of 12 `virtrigaud_*` metric families are wired in v0.3.6. `virtrigaud_queue_depth` is deprecated (use `workqueue_depth{name}` instead); removal scheduled for v0.4.0.
 
-- Calculate required size: `source_vm_disk_size * 1.2` (20% overhead for conversion)
-- Minimum recommended: 50Gi
-- Large VMs: Match source disk size + 20GB overhead
+For the full metric catalog see [Observability](https://projectbeskar.github.io/virtrigaud/operations/observability/).
 
-#### Troubleshooting
+## Troubleshooting
 
-**Migration stuck in "Validating" phase:**
-- Verify StorageClass exists: `kubectl get storageclass`
-- Check PVC status: `kubectl get pvc -n <namespace>`
-- View PVC events: `kubectl describe pvc <pvc-name> -n <namespace>`
-- Check provider pods are restarting: `kubectl get pods -n <namespace> | grep provider`
-- View provider logs during restart: `kubectl logs -n <namespace> <provider-pod> --previous`
-
-**Migration fails with "PVC mount not writable":**
-- Verify PVC has `ReadWriteMany` access mode
-- Check provider pod can mount the PVC: `kubectl describe pod <provider-pod> -n <namespace>`
-- Verify NFS/storage backend is accessible from cluster nodes
-
-**Provider pod fails to start:**
-- Check provider logs: `kubectl logs <provider-pod> -n <namespace>`
-- Verify PVC is bound: `kubectl get pvc <pvc-name> -n <namespace>`
-
-## Development
-
-### Prerequisites
-
-- Go 1.22+
-- Docker
-- kubectl
-- A Kubernetes cluster
-
-### Local Testing
-
-Test GitHub Actions workflows locally before pushing to save costs and catch issues early:
+### Missing CRDs after Helm install
 
 ```bash
-# Setup local testing environment
-./hack/test-workflows-locally.sh setup
+# Check if CRDs were skipped
+helm get values virtrigaud -n virtrigaud-system | grep skip-crds
 
-# Quick lint check (run before every commit)
-./hack/test-lint-locally.sh
+# Manually install CRDs
+kubectl apply -f charts/virtrigaud/crds/
 
-# Comprehensive CI testing (run before PRs)
-./hack/test-ci-locally.sh
-
-# Test Helm charts with Kind cluster
-./hack/test-helm-locally.sh
-
-# Simulate release workflow
-./hack/test-release-locally.sh v0.2.0-test
+# Or reinstall
+helm uninstall virtrigaud -n virtrigaud-system
+helm install virtrigaud virtrigaud/virtrigaud --version 0.3.6 \
+  -n virtrigaud-system --create-namespace
 ```
 
-See [Testing Workflows Locally](docs/TESTING_WORKFLOWS_LOCALLY.md) for detailed instructions.
+## Development
 
 ### Building
 
 ```bash
-# Build the manager binary
-make build
-
-# Build the container image
-make docker-build
-
-# Run tests
-make test
-
-# Generate code and manifests
-make generate manifests
+make build          # Build the manager binary (requires Go 1.26+)
+make docker-build   # Build container image
+make test           # Run unit tests
+make generate manifests  # Regenerate CRDs and DeepCopy
 ```
 
-### Running locally
+### Local Testing
 
 ```bash
-# Install CRDs
-make install
+# Quick lint check (before every commit)
+./hack/test-lint-locally.sh
 
-# Run the controller
-make run
+# Comprehensive CI testing (before PRs)
+./hack/test-ci-locally.sh
+
+# Test Helm charts with Kind cluster
+./hack/test-helm-locally.sh
 ```
+
+See [Testing Workflows Locally](docs/TESTING_WORKFLOWS_LOCALLY.md) for detailed instructions.
 
 ## Documentation
 
-Please see our official documentation site [virtrigaud.io](https://virtrigaud.io)
+Primary documentation: **[https://projectbeskar.github.io/virtrigaud](https://projectbeskar.github.io/virtrigaud)**
 
-### Provider-Specific Documentation
-
-Provider specific [documentation](https://virtrigaud.io/guides/).
+In-tree design decisions: [`docs/adr/`](docs/adr/)
 
 ## Contributing
 
-Contributions are welcome! Please see our [contribution guidelines](CONTRIBUTING.md).
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Authors
+
+- **William Rizzo** ([@wrkode](https://github.com/wrkode)) — project maintainer
+- **Erick Bourgeois** ([@firestoned](https://github.com/firestoned)) — contributor
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+Apache License 2.0 — see [LICENSE](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# docs/
+
+VirtRigaud's primary documentation lives on the website:
+**[https://projectbeskar.github.io/virtrigaud](https://projectbeskar.github.io/virtrigaud)**
+
+This directory holds in-tree references that are most useful alongside the source code:
+
+| Path | Contents |
+|------|----------|
+| [`docs/adr/`](adr/) | Architecture Decision Records — design decisions that are binding on the codebase |
+
+For user guides, operator documentation, provider capabilities, and the API reference, see the website.

--- a/docs/adr/0001-transport-grpc-and-capi-integration.md
+++ b/docs/adr/0001-transport-grpc-and-capi-integration.md
@@ -1,0 +1,129 @@
+# ADR-0001: Transport choice (gRPC) and future CAPI integration layer
+
+> **Location**: `docs/adr/0001-transport-grpc-and-capi-integration.md`
+> Promoted from `fieldTesting/` on 2026-05-27. The gRPC transport decision has shipped through v0.3.6; the CAPI layering principle is settled.
+
+## Status
+
+**Accepted** — 2026-05-22 (promoted 2026-05-27)
+
+## Context
+
+Two questions get raised periodically about VirtRigaud's architecture:
+
+1. **Is gRPC the right manager↔provider transport on performance grounds?** A simpler-looking alternative (REST/JSON, or CRD-as-RPC) keeps being mentioned in design discussions, and "could we just use REST?" is a fair question for any synchronous RPC system.
+
+2. **Does the gRPC choice affect the future plan to build a Cluster API (CAPI) Infrastructure Provider for VirtRigaud?** There's a perception that the transport choice constrains what CAPI integration can look like.
+
+The point of this ADR is to close both questions definitively so they don't re-open every time a new contributor wonders.
+
+### Relevant facts
+
+- **RPC surface** is in `proto/provider/v1/provider.proto`: 17 coarse-grained verbs (Validate, Create, Delete, Power, Describe, Reconfigure, HardwareUpgrade, SnapshotCreate/Delete/Revert, Clone, ImagePrepare, ExportDisk, ImportDisk, TaskStatus, GetCapabilities, plus health/version).
+- **RPC profile**: 10–100 RPC/sec at peak per cluster, kilobyte payloads, long-running ops use the `TaskRef` + `TaskStatus` polling pattern (not streaming).
+- **Disk transfer** uses RWX PVCs as an out-of-band sidechannel — the actual disk bytes do NOT flow through the gRPC channel. `ExportDisk`/`ImportDisk` carry references to PVC paths, not contents.
+- **Provider impl scale**: vSphere (~3842 LOC), Libvirt (~2057 LOC), Proxmox (~1852 LOC), Mock (~744 LOC). Adding REST equivalents on the provider side would mean rewriting four servers + their conformance harness.
+- **Existing transport code**: `internal/transport/grpc/` (manager-side client), `sdk/provider/` (provider SDK with server, middleware, capabilities, errors). All wired; observability fully collected as of v0.3.6 (11 of 12 `virtrigaud_*` metric families, G6 circuit breaker per Provider CR).
+- **CAPI integration model**: Cluster API infrastructure providers (CAPV, CAPZ, CAPI-libvirt, CAPI-openstack) reconcile CAPI's `Machine`/`Cluster` CRDs and emit their own `InfrastructureMachine`/`InfrastructureCluster` CRDs that CAPI watches via OwnerReferences. **CAPI's contract with infra providers is CRDs, not wire RPC.**
+
+## Decision
+
+### Part 1: Keep gRPC as the manager↔provider transport.
+
+The performance argument is a non-question — VirtRigaud is nowhere near the scale where transport throughput matters. The real and load-bearing value of gRPC for this project is:
+
+1. **Proto3 + `buf` as a contract enforcement mechanism** across heterogeneous provider implementations. This is what keeps four provider impls (and any future ones — Firecracker, Cloud-Hypervisor, QEMU direct) honest with each other.
+2. **The `Unimplemented` + `GetCapabilities` pattern** for clean feature negotiation without silent no-ops. Only works cleanly with a typed IDL.
+3. **First-class deadlines, cancellation, mTLS readiness, and interceptor middleware** for cross-cutting concerns. The wiring exists; mTLS is not yet default-on (see open issues #147, #148).
+4. **Bidirectional streaming available** if disk transfer ever moves in-band. Not in the plan today, but it's a free option.
+
+### Part 2: A future CAPI Infrastructure Provider will sit on top of VirtRigaud's CRDs, not its gRPC contract.
+
+When `cluster-api-provider-virtrigaud` is built, its architecture will be:
+
+```
+┌─ Mgmt cluster ──────────────────────────────────────────────────┐
+│                                                                  │
+│  CAPI controllers                                                │
+│         │                                                        │
+│         │  watches Machine/Cluster CRDs via OwnerReferences      │
+│         ▼                                                        │
+│  cluster-api-provider-virtrigaud (NEW REPO)                     │
+│    reconciles: VirtRigaudMachine / VirtRigaudCluster CRDs       │
+│         │                                                        │
+│         │  emits: VirtualMachine + Provider CRDs                │
+│         ▼                                                        │
+│  VirtRigaud manager (EXISTING)                                  │
+│         │                                                        │
+│         │  gRPC/TLS (INTERNAL to VirtRigaud — invisible above)  │
+│         ▼                                                        │
+│  Provider pods (vSphere / Libvirt / Proxmox / ...)              │
+│         │                                                        │
+└─────────┼────────────────────────────────────────────────────────┘
+          ▼
+       Hypervisor
+```
+
+The gRPC layer is two levels below CAPI. **It is not in the CAPI provider's path, and CAPI never sees it.** This is the same layering used by every other CAPI provider.
+
+## Alternatives considered
+
+### Transport alternatives (rejected)
+
+| Option | Why not |
+|--------|---------|
+| **REST/JSON over HTTP** | No measurable perf change; loses codegen discipline; providers will drift on schema unless we reintroduce OpenAPI codegen. Cost of switching ≈ rewrite four provider servers + manager client + conformance harness. Gain: marginally easier debugging via `curl`. Not worth it. |
+| **CRD-as-RPC** (manager writes a `VMOperation` CR, provider watches it) | Every `Describe` becomes an etcd write. Providers need cluster credentials and watch quotas. Operational latency tied to apiserver QPS. Hard to do streaming. Trades complexity for a different kind of complexity, with worse scaling characteristics. |
+| **Async messaging (NATS, Redis Streams, Kafka)** | Strictly worse version of CRD-as-RPC for this workload. Adds infrastructure dependency without solving anything we have. |
+
+### CAPI integration alternatives (rejected)
+
+| Option | Why not |
+|--------|---------|
+| **CAPI provider talks gRPC directly to provider pods, bypassing VirtRigaud's CRDs** | Makes the gRPC contract a *public* API surface. Doubles blast radius on every proto change (CAPI users break, not just internal providers). Bypasses the per-Provider-CR multi-tenant boundary. |
+| **CAPI provider as an in-tree feature of VirtRigaud (no separate repo)** | Couples release cadences. Forces VirtRigaud users to take CAPI dependency they may not want. Not the established CAPI pattern. |
+| **CAPI provider links VirtRigaud's controllers as a library** | Rare in CAPI ecosystem. Inherits lifecycle pain from both projects. No clear advantage over the CRD-translation pattern. |
+
+## Consequences
+
+### Positive
+
+- The transport question is settled. Future contributors won't relitigate gRPC vs REST without first reading this ADR.
+- The CAPI integration shape is settled. When the CAPI provider is built, the team knows it's a CRD translator and doesn't go down the gRPC-exposure path.
+- The proto contract (`proto/provider/v1/provider.proto`) can continue to evolve as the internal contract it is, without worrying about external CAPI consumers.
+
+### Negative
+
+- **Provider authors face a steeper onboarding curve** than a REST API would impose: they need to consume protobuf-generated bindings, understand the `Unimplemented` + capabilities pattern, and use `buf` for proto codegen. Mitigated by `sdk/provider/` which abstracts most of it, and by the conformance harness in `internal/conformance/`.
+- **Debugging is harder** for operators looking at the wire (no `curl -X POST` on `/Validate`). Mitigated by gRPC reflection (if enabled) and `grpcurl`.
+
+### Neutral
+
+- mTLS posture between manager and providers is not yet default-on (issues [#147](https://github.com/projectbeskar/virtrigaud/issues/147), [#148](https://github.com/projectbeskar/virtrigaud/issues/148)). gRPC makes mTLS easy when we decide to enforce it; this ADR doesn't change that.
+
+## Follow-ups
+
+| ID | Item | Owner | Priority | Status |
+|----|------|-------|----------|--------|
+| F1 | ~~Promote ADR from `fieldTesting/`~~ | tech-writer | low | Done (v0.3.6) |
+| F2 | **Add a comment block to `proto/provider/v1/provider.proto`** near `ExportDisk`/`ImportDisk` explicitly declaring disk transfer as out-of-band (PVC-mediated). | golang-engineer | low | Open |
+| F3 | **Interceptor coverage audit**: verify `sdk/provider/middleware/` interceptors emit per-RPC latency, error counters, and tracing spans. v0.3.6 wired 11 of 12 metric families; confirm the interceptor loop is closed end-to-end. | staff-engineer | medium | Partially done (v0.3.6) |
+| F4 | **ADR-0002 "CAPI provider sits on top of VirtRigaud CRDs"** — when CAPI work actually starts. Captures the layering decision more formally with `VirtRigaudMachine`/`VirtRigaudCluster` schema sketch. | staff-architect | deferred | Open |
+| F5 | **Provider-author onboarding guide** covering `sdk/provider/`, the `buf` codegen flow, capability declaration, and conformance harness. | tech-writer | low | Open |
+
+## Open questions
+
+1. **Should mTLS be default-on in v0.4?** Separate ADR needed; the answer affects how strongly we lean on "gRPC has good security ergonomics" as a justification here. See #147.
+2. **Is `VirtRigaudCluster` going to need a control-plane endpoint (LB / kube-vip / VIP)?** This is the biggest design call in a future CAPI provider. Decision affects timing of F4.
+3. **Does `VMSet` overlap awkwardly with CAPI's `MachineDeployment`/`MachineSet`?** Worth deciding whether the CAPI provider creates individual `VirtualMachine` CRDs or composes via `VMSet`. Decision belongs in F4.
+
+## References
+
+- Related PR: [#83](https://github.com/projectbeskar/virtrigaud/issues/83) (metrics-registry fix)
+- Related PR: [#112](https://github.com/projectbeskar/virtrigaud/issues/112) (G6 CircuitBreaker per Provider CR)
+- Security issues: [#147](https://github.com/projectbeskar/virtrigaud/issues/147) mTLS, [#148](https://github.com/projectbeskar/virtrigaud/issues/148) provider auth
+- Code touchpoints:
+  - `proto/provider/v1/provider.proto`
+  - `internal/transport/grpc/`
+  - `sdk/provider/` (server, client, middleware, capabilities, errors)
+  - `internal/providers/{vsphere,libvirt,proxmox,mock}/server.go`

--- a/docs/adr/0002-build-path-consolidation.md
+++ b/docs/adr/0002-build-path-consolidation.md
@@ -1,0 +1,126 @@
+# ADR-0002: Consolidate the two parallel manager build paths
+
+> **Location**: `docs/adr/0002-build-path-consolidation.md`
+> Promoted from `fieldTesting/` on 2026-05-27.
+> **H1 PRs 1–4 shipped in v0.3.6. PR-5 (HTTPS-by-default metrics) is deferred to v0.4.0.**
+
+## Status
+
+**Accepted** — 2026-05-24 (promoted 2026-05-27)
+
+**Author**: William Rizzo ([@wrkode](https://github.com/wrkode))
+
+**Related issue**: [#92](https://github.com/projectbeskar/virtrigaud/issues/92)
+
+## Context
+
+VirtRigaud's manager binary had **two coexisting build paths** that compiled slightly different programs from slightly different Dockerfiles. Both paths were exercised by current Makefile targets; neither path was dead.
+
+### The two paths (pre-v0.3.6)
+
+| Aspect | Canonical (release) | Local-dev |
+|---|---|---|
+| Entrypoint | `cmd/manager/main.go` | `cmd/main.go` |
+| Dockerfile | `build/Dockerfile.manager` | `Dockerfile` (repo root) |
+| Invoked by | Release workflow | `make docker-build`, `make build`, `make run` |
+| Built into | `ghcr.io/projectbeskar/virtrigaud/manager:<tag>` | Local dev images |
+
+### What actually broke (v0.3.3-rc4 incident)
+
+During the v0.3.3-rc4 hotfix, `virtrigaud_build_info{version="dev"}` appeared on `/metrics`. Diagnosis cost ~30 minutes because two Dockerfiles were visible in the tree. The first instinct was `rm cmd/main.go Dockerfile` — which would have **broken `make docker-build` and `make docker-buildx`**, two daily-driver developer commands.
+
+### Functional gaps (audit as of 2026-05-24)
+
+**Local-dev path lacked** (vs. canonical):
+- No `metrics.SetupMetrics()` call — local-dev binary did not emit `virtrigaud_build_info`.
+- VMSnapshot controller not registered.
+- VMMigration controller not registered.
+- No client-side QPS/burst tuning.
+
+**Canonical path lacked** (vs. local-dev):
+- `--version` CLI flag.
+- `certwatcher` integration for hot cert rotation.
+- `metrics/filters.WithAuthenticationAndAuthorization`.
+- `ARG BUILDER_IMAGE` / `ARG BASE_IMAGE` / `GOPROXY` / CA-cert passthrough in Dockerfile (required for corporate/banking environments that cannot pull from `docker.io` directly).
+
+## Decision
+
+**Option A — Consolidate to the canonical path, port the missing features, retire the local-dev orphan.**
+
+The release flow was already established on `cmd/manager/main.go` + `build/Dockerfile.manager`. The local-dev path was the one to retire — after the small handful of genuinely useful features it carried had been ported across.
+
+## Roadmap (PR-sized chunks)
+
+### PR-1: Port `cmd/manager/main.go` parity gains (v0.3.6) ✅ Done
+
+Added `--version` flag, `certwatcher` integration, and `metrics/filters.WithAuthenticationAndAuthorization` to the canonical entrypoint. All additions are gated on flags that default to off/empty; existing operators see no behaviour change.
+
+**Shipped**: v0.3.6 (#115).
+
+### PR-2: Add Dockerfile parametrization to `build/Dockerfile.manager` (v0.3.6) ✅ Done
+
+Added `ARG BUILDER_IMAGE`, `ARG BASE_IMAGE`, `ARG GOPROXY` / `GOINSECURE` / `GOPRIVATE` / `GOSUMDB`, and CA-cert bundle injection. Enables corporate forks to point at internal mirrors without patching Dockerfiles.
+
+**Shipped**: v0.3.6 (#117).
+
+### PR-3: Point `make docker-build` / `make docker-buildx` at the canonical Dockerfile (v0.3.6) ✅ Done
+
+Changed `make docker-build`, `make docker-buildx`, `make build`, and `make run` to use `cmd/manager/main.go` + `build/Dockerfile.manager`. Silent fix for latent bug #113: `make docker-build` now produces a complete manager binary (emits `virtrigaud_build_info`, registers VMSnapshot + VMMigration controllers).
+
+**Shipped**: v0.3.6 (#119).
+
+### PR-4: Delete the orphaned local-dev path (v0.3.6) ✅ Done
+
+Removed `cmd/main.go` and root `Dockerfile`. All Makefile targets that previously used these files were rewired in PR-3.
+
+**Shipped**: v0.3.6 (#121).
+
+### PR-5: Flip metrics-secure default to `true` (v0.4.0) — deferred
+
+Changes `--metrics-secure` default from `false` to `true`. Breaking: operators with HTTP-scrape Prometheus configurations will stop receiving metrics on upgrade unless they update their scrape config or explicitly set `--metrics-secure=false`. Held for v0.4.0 with loud release-note callout.
+
+**Target**: v0.4.0. Must NOT ship in a v0.3.x point release.
+
+## Security implications
+
+| Item | Status |
+|---|---|
+| **HTTPS-by-default metrics (PR-5)** | Deferred to v0.4.0. Removes a plaintext channel that exposes operator internals to anonymous scrapers. Paired with cert-manager guidance and a Helm values escape hatch. |
+| **`certwatcher` integration (PR-1)** | Shipped v0.3.6. Enables cert rotation without pod restart — critical for cert-manager 90-day renewals. |
+| **`metrics/filters.WithAuthenticationAndAuthorization` (PR-1)** | Shipped v0.3.6. Activates when `--metrics-secure=true`. Requires Prometheus ServiceAccount to have RBAC on `/metrics`. |
+| **`BUILDER_IMAGE`/`BASE_IMAGE` parametrization (PR-2)** | Shipped v0.3.6. Banking customers categorically cannot pull from `docker.io` or `gcr.io` in production build pipelines; this unblocks them without requiring Dockerfile forks. |
+
+## Consequences
+
+### Positive
+
+- **One build path, one entrypoint.** Future contributors don't have to ask "which Dockerfile?" The v0.3.3-rc4 diagnosis cost doesn't recur.
+- **VMSnapshot and VMMigration controllers are no longer silently missing from local-dev builds.** Anyone who ran `make docker-build` for local testing and then said "why isn't snapshot working?" was tripping over this.
+- **Banking-deployment posture strengthens**: BUILDER/BASE parametrization, CA cert handling, certwatcher, and metrics RBAC are now in the canonical path.
+
+### Negative
+
+- **PR-5 is breaking and operator-visible.** Even with release notes, some operators will discover the HTTP→HTTPS change the hard way when their Prometheus stops scraping.
+- **PR-3 silently activated VMSnapshot/VMMigration controllers for local-dev users.** Correct behaviour, but a behaviour change. Called out explicitly in the v0.3.6 CHANGELOG.
+
+## Follow-ups
+
+| ID | Item | Owner | Priority | Status |
+|----|------|-------|----------|--------|
+| F1 | ~~Promote ADR from `fieldTesting/`~~ | tech-writer | low | Done (v0.3.6) |
+| F2 | ~~Implement PR-1 through PR-4~~ | staff-engineer + golang-engineer | medium | Done (v0.3.6) |
+| F3 | **Implement PR-5** with explicit release-note callout and Helm values escape hatch | staff-engineer + security-architect | low | Open (v0.4.0) |
+| F4 | **Operator-facing doc** in `docs/operators/build-customization.md` covering `BUILDER_IMAGE` / `BASE_IMAGE` / `GOPROXY` for corporate environments | tech-writer | low | Open |
+| F5 | ~~Audit `hack/dev-deploy.sh` for Dockerfile path assumptions~~ | golang-engineer | low | Done (PR-3) |
+| F6 | **Consider renaming `build/Dockerfile.manager` → `cmd/manager/Dockerfile`** for layout consistency with provider Dockerfiles | staff-architect | low | Open (optional, post-v0.3.6) |
+
+## References
+
+- Issue: [#92](https://github.com/projectbeskar/virtrigaud/issues/92) — chore: remove orphan cmd/main.go and root Dockerfile
+- PR [#115](https://github.com/projectbeskar/virtrigaud/pull/115) — PR-1 (cmd/manager parity)
+- PR [#117](https://github.com/projectbeskar/virtrigaud/pull/117) — PR-2 (Dockerfile parametrization)
+- PR [#119](https://github.com/projectbeskar/virtrigaud/pull/119) — PR-3 (Makefile redirect; fixes #113)
+- PR [#121](https://github.com/projectbeskar/virtrigaud/pull/121) — PR-4 (remove orphans)
+- PR [#85](https://github.com/projectbeskar/virtrigaud/pull/85) — `internal/version` populated; prerequisite for `--version` flag port
+- PR [#112](https://github.com/projectbeskar/virtrigaud/pull/112) — G6 per-Provider CircuitBreaker; exposed the dual-path porting tax
+- Companion: [ADR-0001](./0001-transport-grpc-and-capi-integration.md) — gRPC transport choice

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for VirtRigaud. ADRs record significant design decisions that are binding on the codebase and should not be re-litigated without reading the relevant ADR first.
+
+## Format
+
+```
+# ADR-NNNN: Title
+## Status: Proposed | Accepted | Deprecated | Superseded by ADR-XXXX
+## Context
+## Decision
+## Consequences
+```
+
+## Index
+
+| # | Title | Status | Date | Summary |
+|---|-------|--------|------|---------|
+| [0001](./0001-transport-grpc-and-capi-integration.md) | Transport choice (gRPC) and CAPI integration layer | Accepted | 2026-05-22 | Settles gRPC as the manager↔provider transport and establishes that a future CAPI provider sits on top of VirtRigaud's CRDs (not gRPC). |
+| [0002](./0002-build-path-consolidation.md) | Consolidate two parallel manager build paths | Accepted | 2026-05-24 | H1 decision: retire the local-dev `cmd/main.go` + root `Dockerfile`; port missing features to the canonical path; shipped PRs 1–4 in v0.3.6; PR-5 (HTTPS-by-default metrics) deferred to v0.4.0. |
+
+## Contributing an ADR
+
+1. Copy the format from an existing ADR.
+2. Number it sequentially (NNNN).
+3. Set Status to **Proposed** until accepted.
+4. Open a PR; move to **Accepted** when merged to `main`.
+5. For superseded ADRs, update the old ADR's Status line and link to the new one.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,188 +1,123 @@
 # VirtRigaud Examples
 
-This directory contains comprehensive examples for VirtRigaud v0.2.3+, showcasing all features and capabilities.
+Verified against v0.3.6 on 2026-05-27.
+
+All examples use `apiVersion: infra.virtrigaud.io/v1beta1` and the 10 CRDs that exist in v0.3.6.
+
+## Known limitations (v0.3.6)
+
+Before applying any example, read these constraints:
+
+- **mTLS not default-on**: gRPC between manager and provider pods is TLS-capable but mTLS is not wired end-to-end. See [#147](https://github.com/projectbeskar/virtrigaud/issues/147), [#148](https://github.com/projectbeskar/virtrigaud/issues/148).
+- **Libvirt Clone RPC is a stub**: the Clone gRPC is declared but not implemented for Libvirt in v0.3.6. See [#153](https://github.com/projectbeskar/virtrigaud/issues/153).
+- **Libvirt ImagePrepare RPC is a stub**: see [#154](https://github.com/projectbeskar/virtrigaud/issues/154).
+- **Only vSphere → Libvirt/KVM migration is tested**: other migration directions are roadmap. See `migration/README.md`.
+- **Migration storage**: only `type: pvc` is supported. `s3`, `http`, and `nfs` URI types do not exist in the API.
+- **Proxmox credentials**: read from files at `/etc/virtrigaud/credentials/`; do NOT use `envFrom: secretRef`.
+
+For full documentation see [https://projectbeskar.github.io/virtrigaud](https://projectbeskar.github.io/virtrigaud).
+
+---
 
 ## Quick Start Examples
 
-### Basic Examples
-- **[complete-example.yaml](complete-example.yaml)** - Complete end-to-end example with v0.2.1 features
-- **[vm-ubuntu-small.yaml](vm-ubuntu-small.yaml)** - Simple Ubuntu VM with graceful shutdown
-- **[vmclass-small.yaml](vmclass-small.yaml)** - Basic VMClass with hardware version support
+| File | Description |
+|------|-------------|
+| [complete-example.yaml](complete-example.yaml) | Complete end-to-end: Provider + VMClass + VMImage + VMNetworkAttachment + VirtualMachine |
+| [vm-ubuntu-small.yaml](vm-ubuntu-small.yaml) | Simple Ubuntu VM |
+| [vmclass-small.yaml](vmclass-small.yaml) | VMClass resource profile |
+| [vmimage-ubuntu.yaml](vmimage-ubuntu.yaml) | VMImage configuration |
+| [vmnetwork-app.yaml](vmnetwork-app.yaml) | VMNetworkAttachment configuration |
 
-### Provider Examples
-- **[provider-vsphere.yaml](provider-vsphere.yaml)** - Basic vSphere provider configuration
-- **[provider-libvirt.yaml](provider-libvirt.yaml)** - Basic LibVirt provider configuration
+## Provider Examples
 
-### Resource Examples
-- **[vmimage-ubuntu.yaml](vmimage-ubuntu.yaml)** - VM image configuration
-- **[vmnetwork-app.yaml](vmnetwork-app.yaml)** - Network attachment configuration
-- **[vm-adoption-example.yaml](vm-adoption-example.yaml)** - VM adoption with filters
+| File | Description |
+|------|-------------|
+| [provider-vsphere.yaml](provider-vsphere.yaml) | vSphere provider configuration |
+| [provider-libvirt.yaml](provider-libvirt.yaml) | Libvirt/KVM provider configuration |
+| [vm-adoption-example.yaml](vm-adoption-example.yaml) | Provider CRs with VMAdoption annotation |
 
-## v0.2.1 Feature Examples
+## Provider-Specific Examples
 
-### New in v0.2.1
-- **[v021-feature-showcase.yaml](v021-feature-showcase.yaml)** - **🌟 COMPREHENSIVE DEMO** - All v0.2.1 features in one example
-- **[graceful-shutdown-examples.yaml](graceful-shutdown-examples.yaml)** - OffGraceful shutdown configurations
-- **[vsphere-hardware-versions.yaml](vsphere-hardware-versions.yaml)** - Hardware version management
-- **[disk-sizing-examples.yaml](disk-sizing-examples.yaml)** - Disk size configuration tests
+| File | Description |
+|------|-------------|
+| [vsphere-advanced-example.yaml](vsphere-advanced-example.yaml) | Advanced vSphere VM configuration |
+| [vsphere-hardware-versions.yaml](vsphere-hardware-versions.yaml) | vSphere hardware version management |
+| [libvirt-complete-example.yaml](libvirt-complete-example.yaml) | Complete Libvirt/KVM deployment |
+| [libvirt-advanced-example.yaml](libvirt-advanced-example.yaml) | Advanced Libvirt configuration |
+| [proxmox-complete-example.yaml](proxmox-complete-example.yaml) | Complete Proxmox VE setup |
+| [multi-provider-example.yaml](multi-provider-example.yaml) | vSphere + Libvirt + Proxmox in one cluster |
 
-### Advanced Provider Examples
-- **[vsphere-advanced-example.yaml](vsphere-advanced-example.yaml)** - Advanced vSphere with v0.2.1 features
-- **[libvirt-advanced-example.yaml](libvirt-advanced-example.yaml)** - Advanced LibVirt configuration
-- **[proxmox-complete-example.yaml](proxmox-complete-example.yaml)** - Complete Proxmox setup
+## Feature-Specific Examples
 
-### Multi-Provider Examples
-- **[multi-provider-example.yaml](multi-provider-example.yaml)** - Multiple providers in one cluster
-- **[libvirt-complete-example.yaml](libvirt-complete-example.yaml)** - Complete LibVirt deployment
+| File | Description |
+|------|-------------|
+| [graceful-shutdown-examples.yaml](graceful-shutdown-examples.yaml) | OffGraceful power state |
+| [disk-sizing-examples.yaml](disk-sizing-examples.yaml) | Disk size configuration |
+| [nested-virtualization.yaml](nested-virtualization.yaml) | Nested virtualisation (vSphere) |
+| [cloud-init-with-metadata.yaml](cloud-init-with-metadata.yaml) | Cloud-init with metadata |
+| [vm-scsi-controllers.yaml](vm-scsi-controllers.yaml) | SCSI controller configuration (vSphere only) |
 
-## v0.2.3 Feature Summary
+## v0.2.x Showcase (historical reference)
 
-### 🔧 VM Reconfiguration (vSphere, Libvirt, Proxmox)
-```yaml
-# Online resource changes (vSphere, Proxmox)
-# Offline changes (Libvirt - requires restart)
-spec:
-  vmClassRef: medium  # Change from small to medium
-  powerState: "On"
-```
+| File | Description |
+|------|-------------|
+| [v021-feature-showcase.yaml](v021-feature-showcase.yaml) | v0.2.1 features comprehensive demo (historical; some fields may be superseded by v0.3.x schema changes) |
 
-### 📋 Async Task Tracking (vSphere, Proxmox)
-```yaml
-# Automatic tracking of long-running operations
-# Real-time progress and error reporting
-```
+## Migration Examples
 
-### 🖥️ Console Access (vSphere, Libvirt)
-```yaml
-# Web console URLs automatically generated
-status:
-  consoleURL: "https://vcenter.example.com/ui/app/vm..."  # vSphere
-  # or
-  consoleURL: "vnc://libvirt-host:5900"  # Libvirt VNC
-```
+See [`migration/`](migration/) for cross-provider migration examples. All migration examples use `storage.type: pvc`.
 
-### 🌐 Guest Agent Integration (Proxmox)
-```yaml
-# Accurate IP detection via QEMU guest agent
-status:
-  ipAddresses:
-    - 192.168.1.100
-    - fd00::1234:5678:9abc:def0
-```
+## Secrets Examples
 
-### 📦 VM Cloning (vSphere)
-```yaml
-# Full and linked clones with automatic snapshot handling
-spec:
-  vmImageRef: source-vm
-  cloneType: linked  # or "full"
-```
+See [`secrets/`](secrets/) for credential Secret examples per provider:
+- `vsphere-creds.yaml` — `username` + `password`
+- `libvirt-creds.yaml` — `username` + `ssh-privatekey` (or `password`)
+- `proxmox-creds.yaml` — `token_id` + `token_secret` (or `username` + `password`)
 
-### 🔄 Previous Features (v0.2.1)
+## Advanced Examples
 
-- **Graceful Shutdown**: OffGraceful power state with VMware Tools
-- **Hardware Version Management**: vSphere hardware version control
-- **Proper Disk Sizing**: Correct disk allocation across providers
-- **Enhanced Lifecycle Management**: postStart/preStop hooks
+See [`advanced/`](advanced/) for snapshot lifecycle, console access, task tracking, and VM cloning scenarios.
 
-## Usage Patterns
+## Security Examples
 
-### Testing v0.2.3 Features
-
-1. **Test VM reconfiguration**:
-   ```bash
-   # Change VM class to trigger reconfiguration
-   kubectl patch virtualmachine my-vm --type='merge' \
-     -p='{"spec":{"vmClassRef":"medium"}}'
-   
-   # Watch the reconfiguration process
-   kubectl get vm my-vm -w
-   ```
-
-2. **Access VM console**:
-   ```bash
-   # Get console URL from VM status
-   kubectl get vm my-vm -o jsonpath='{.status.consoleURL}'
-   
-   # For VNC (Libvirt): Use any VNC client
-   vncviewer $(kubectl get vm my-vm -o jsonpath='{.status.consoleURL}' | sed 's/vnc:\/\///')
-   ```
-
-3. **Monitor async tasks** (vSphere, Proxmox):
-   ```bash
-   # Watch task progress in provider logs
-   kubectl logs -f deployment/virtrigaud-provider-vsphere
-   ```
-
-4. **Verify guest agent** (Proxmox):
-   ```bash
-   # Check IP addresses from guest agent
-   kubectl get vm my-vm -o jsonpath='{.status.ipAddresses}'
-   ```
-
-5. **Test VM cloning** (vSphere):
-   ```bash
-   # Create a clone of existing VM
-   kubectl apply -f - <<EOF
-   apiVersion: infra.virtrigaud.io/v1beta1
-   kind: VirtualMachine
-   metadata:
-     name: web-server-clone
-   spec:
-     vmClassRef: small
-     vmImageRef: web-server-01
-     cloneType: linked
-   EOF
-   ```
-
-### Development Workflow
-
-1. **Choose base example** based on your use case
-2. **Customize** provider, class, and VM specifications
-3. **Test locally** with your infrastructure
-4. **Iterate** based on your requirements
-
-### Production Deployment
-
-1. **Start with complete-example.yaml**
-2. **Add security configurations** from security/ subdirectory
-3. **Configure secrets** from secrets/ subdirectory  
-4. **Apply advanced patterns** from advanced/ subdirectory
+See [`security/`](security/) for NetworkPolicy, RBAC, and ExternalSecrets patterns.
 
 ## File Organization
 
 ```
-docs/examples/
-├── README.md                          # This file
-├── complete-example.yaml             # Complete setup guide
-├── v021-feature-showcase.yaml        # 🌟 v0.2.1 comprehensive demo
-├── vm-ubuntu-small.yaml             # Simple VM example
-├── vmclass-small.yaml               # Basic VMClass
-├── provider-*.yaml                  # Provider configurations
-├── graceful-shutdown-examples.yaml  # OffGraceful demos
-├── vsphere-hardware-versions.yaml   # Hardware version examples
-├── disk-sizing-examples.yaml        # Disk sizing tests
-├── advanced/                        # Complex scenarios
-├── secrets/                         # Secret management
-└── security/                        # Security configurations
+examples/
+├── README.md                    # This file
+├── complete-example.yaml        # Full end-to-end
+├── vm-ubuntu-small.yaml
+├── vmclass-small.yaml
+├── vmimage-ubuntu.yaml
+├── vmnetwork-app.yaml
+├── provider-vsphere.yaml
+├── provider-libvirt.yaml
+├── vm-adoption-example.yaml
+├── vsphere-advanced-example.yaml
+├── vsphere-hardware-versions.yaml
+├── libvirt-complete-example.yaml
+├── libvirt-advanced-example.yaml
+├── proxmox-complete-example.yaml
+├── multi-provider-example.yaml
+├── vmmigration-basic.yaml       # PVC-only storage
+├── vmmigration-advanced.yaml    # PVC-only, all options
+├── vmmigration-nfs.yaml         # NFS-backed StorageClass
+├── vmmigration-s3.yaml          # Renamed from s3 — now PVC-based
+├── disk-sizing-examples.yaml
+├── graceful-shutdown-examples.yaml
+├── cloud-init-with-metadata.yaml
+├── nested-virtualization.yaml
+├── vm-scsi-controllers.yaml
+├── v021-feature-showcase.yaml
+├── advanced/                    # Snapshots, consoles, cloning, task tracking
+├── migration/                   # Cross-provider migration examples
+├── secrets/                     # Per-provider Secret templates
+└── security/                    # NetworkPolicy, RBAC, ExternalSecrets
 ```
 
-## Version Compatibility
+## Version compatibility
 
-- **v0.2.3+**: All examples with v0.2.3 features (Reconfigure, Clone, TaskStatus, ConsoleURL, Guest Agent)
-- **v0.2.2**: Nested virtualization, TPM support, snapshot management
-- **v0.2.1**: Graceful shutdown, hardware version, disk sizing fixes
-- **v0.2.0**: Initial production-ready providers
-- **v0.1.x**: Legacy examples in git history
-
-## Need Help?
-
-- 📖 **Documentation**: [../README.md](../README.md)
-- 🚀 **Quick Start**: [../getting-started/quickstart.md](../getting-started/quickstart.md)
-- 🔧 **CLI Tools**: [../CLI.md](../CLI.md)
-- 📋 **Upgrade Guide**: [../UPGRADE.md](../UPGRADE.md)
-- 🏗️ **Contributing**: [../../CONTRIBUTING.md](../../CONTRIBUTING.md)
-
----
-
-**Pro Tip**: Start with `v021-feature-showcase.yaml` to see all v0.2.1 capabilities in action! 🚀
+These examples target **v0.3.6**. For earlier versions, check git history.

--- a/examples/migration/README.md
+++ b/examples/migration/README.md
@@ -1,235 +1,71 @@
 # VM Migration Examples
 
-This directory contains practical examples for migrating VMs between different hypervisor platforms using VirtRigaud.
+This directory contains examples for migrating VMs between hypervisor platforms using VirtRigaud.
+
+## v0.3.6 migration constraints
+
+Before using these examples, read the constraints:
+
+- **Only PVC storage is supported.** `storage.type` is enum-constrained to `"pvc"` in the API. The s3, http, and nfs URI storage types documented in older resources do not exist in v0.3.6.
+- **Only vSphere → Libvirt/KVM is tested.** Other migration directions are roadmap items and are marked with a WARNING in the respective example files.
+- **Requires a ReadWriteMany StorageClass.** NFS, CephFS, AWS EFS, and Azure Files are common options.
 
 ## Examples
 
-### Basic Cross-Platform Migrations
+| File | Direction | Status |
+|------|-----------|--------|
+| [libvirt-to-vsphere.yaml](./libvirt-to-vsphere.yaml) | Libvirt/KVM → vSphere | Untested (roadmap) |
+| [vsphere-to-proxmox.yaml](./vsphere-to-proxmox.yaml) | vSphere → Proxmox VE | Untested (roadmap) |
+| [proxmox-to-libvirt.yaml](./proxmox-to-libvirt.yaml) | Proxmox VE → Libvirt/KVM | Untested (roadmap) |
 
-1. **[libvirt-to-vsphere.yaml](./libvirt-to-vsphere.yaml)**
-   - Migrate Linux VM from Libvirt/KVM to VMware vSphere
-   - Uses S3 for intermediate storage
-   - Demonstrates qcow2 → VMDK conversion
-   - Production-ready example with retry policy
+For the tested vSphere → Libvirt/KVM path, see `examples/vmmigration-basic.yaml` in the parent directory.
 
-2. **[vsphere-to-proxmox.yaml](./vsphere-to-proxmox.yaml)**
-   - Migrate Windows Server from vSphere to Proxmox VE
-   - Uses NFS for intermediate storage
-   - Demonstrates VMDK → qcow2 conversion
-   - Includes resource and network configuration
+## Quick start
 
-3. **[proxmox-to-libvirt.yaml](./proxmox-to-libvirt.yaml)**
-   - Migrate database server from Proxmox to Libvirt/KVM
-   - Uses HTTP server for intermediate storage
-   - Best practices for database migration
-   - Conservative cleanup policy
+1. Create a ReadWriteMany StorageClass (example using NFS CSI driver):
 
-## Quick Start
+   ```yaml
+   apiVersion: storage.k8s.io/v1
+   kind: StorageClass
+   metadata:
+     name: nfs-migration-storage
+   provisioner: nfs.csi.k8s.io
+   parameters:
+     server: nfs-server.example.com
+     share: /exports/virtrigaud-migrations
+   volumeBindingMode: Immediate
+   reclaimPolicy: Delete
+   ```
 
-### 1. Choose an Example
+2. Customise the example YAML for your environment:
 
-Select the example that matches your migration scenario:
+   ```yaml
+   spec:
+     source:
+       vmRef:
+         name: your-source-vm
+     target:
+       name: your-target-vm
+       providerRef:
+         name: your-target-provider
+     storage:
+       type: pvc
+       pvc:
+         storageClassName: nfs-migration-storage
+         size: 200Gi
+         accessMode: ReadWriteMany
+   ```
 
-```bash
-# Libvirt to vSphere
-kubectl apply -f libvirt-to-vsphere.yaml
+3. Apply and monitor:
 
-# vSphere to Proxmox
-kubectl apply -f vsphere-to-proxmox.yaml
+   ```bash
+   kubectl apply -f your-migration.yaml
+   kubectl get vmmigration your-migration-name -w
+   kubectl describe vmmigration your-migration-name
+   ```
 
-# Proxmox to Libvirt
-kubectl apply -f proxmox-to-libvirt.yaml
-```
+## Reference
 
-### 2. Customize for Your Environment
-
-Edit the YAML file to match your environment:
-
-```yaml
-spec:
-  sourceName: your-vm-name              # Your source VM
-  sourceNamespace: your-namespace
-  
-  targetProviderRef:
-    name: your-provider                 # Your target provider
-  targetName: your-new-vm-name
-  
-  storage:
-    type: s3                            # or http, nfs
-    bucket: your-bucket
-    credentialsSecretRef:
-      name: your-credentials
-```
-
-### 3. Update Credentials
-
-Create appropriate credentials secret:
-
-```bash
-# For S3
-kubectl create secret generic aws-s3-creds \
-  --from-literal=accessKey=YOUR_ACCESS_KEY \
-  --from-literal=secretKey=YOUR_SECRET_KEY
-
-# For HTTP
-kubectl create secret generic http-creds \
-  --from-literal=token=Bearer_YOUR_TOKEN
-
-# NFS typically doesn't need credentials
-```
-
-### 4. Monitor Migration
-
-```bash
-# Watch migration status
-kubectl get vmmigration your-migration-name -w
-
-# View detailed status
-kubectl describe vmmigration your-migration-name
-
-# Check events
-kubectl get events --field-selector involvedObject.name=your-migration-name
-```
-
-## Example Scenarios
-
-### Development → Production
-
-Promote a VM from dev to production environment:
-
-```yaml
-sourceName: app-server-dev
-sourceNamespace: development
-targetName: app-server-prod
-targetNamespace: production
-```
-
-### Cross-Region Migration
-
-Migrate VM to different region/datacenter:
-
-```yaml
-storage:
-  type: s3
-  bucket: migrations-us-west
-  region: us-west-2
-```
-
-### Test Migration
-
-Test migration without deleting source:
-
-```yaml
-cleanupPolicy:
-  deleteSource: false               # Keep source
-targetName: test-migration-vm       # Different name
-```
-
-## Storage Backend Selection
-
-| Backend | Best For | Speed | Cost |
-|---------|----------|-------|------|
-| **S3** | Cross-region, large VMs | Medium | Low |
-| **HTTP** | Custom workflows | Fast | Varies |
-| **NFS** | Same datacenter | Fastest | Low |
-
-### When to Use Each
-
-- **S3**: Different data centers, cloud storage, large migrations
-- **HTTP**: When you have existing file storage infrastructure
-- **NFS**: Same data center, fastest performance, local network
-
-## Best Practices
-
-### Before Migration
-
-1. ✅ Test migration in non-production first
-2. ✅ Take application-level backup
-3. ✅ Document current VM configuration
-4. ✅ Plan downtime window (if needed)
-5. ✅ Verify network connectivity to storage
-6. ✅ Check disk space on all systems
-
-### During Migration
-
-1. 👁️ Monitor migration progress
-2. 👁️ Watch for errors or warnings
-3. 👁️ Check provider logs if issues occur
-4. 👁️ Verify network/storage performance
-
-### After Migration
-
-1. ✅ Validate target VM boots correctly
-2. ✅ Test application functionality
-3. ✅ Verify data integrity
-4. ✅ Update DNS/load balancers
-5. ✅ Monitor for 24-48 hours
-6. ✅ Document any issues/changes
-
-### Safety
-
-- **Always keep source VM** until target is validated
-- **Never set deleteSource: true** on first migration
-- **Test rollback procedures** before prod migration
-- **Have backup plan** in case migration fails
-
-## Troubleshooting
-
-### Migration Stuck
-
-```bash
-# Check phase
-kubectl get vmmigration my-migration -o jsonpath='{.status.phase}'
-
-# Check conditions
-kubectl get vmmigration my-migration -o jsonpath='{.status.conditions}'
-
-# Check provider logs
-kubectl logs -n virtrigaud-system deployment/provider-libvirt
-```
-
-### Storage Errors
-
-```bash
-# Verify credentials exist
-kubectl get secret aws-s3-creds
-
-# Test storage access manually
-aws s3 ls s3://my-bucket  # For S3
-curl -H "Authorization: Bearer TOKEN" https://storage/  # For HTTP
-ls /mnt/migrations  # For NFS
-```
-
-### Format Conversion Failed
-
-```bash
-# Check qemu-img is installed
-# On provider host:
-qemu-img --version
-
-# Check disk space
-df -h /tmp
-```
-
-## Additional Resources
-
-- [User Guide](../../docs/migration/user-guide.md) - Complete migration guide
-- [API Reference](../../docs/migration/api-reference.md) - Full API documentation
-- [Implementation Status](../../MIGRATION_IMPLEMENTATION_STATUS.md) - Technical details
-
-## Support
-
-For issues and questions:
-- GitHub Issues: https://github.com/projectbeskar/virtrigaud/issues
-- Documentation: https://virtrigaud.io/docs
-
-## Contributing
-
-Have a useful migration example? Please contribute!
-
-1. Create example YAML file
-2. Add clear comments explaining the scenario
-3. Include prerequisites and expected behavior
-4. Test the example
-5. Submit a pull request
-
+- [VMMigration CRD source](../../api/infra.virtrigaud.io/v1beta1/vmmigration_types.go)
+- [Migration Guide](https://projectbeskar.github.io/virtrigaud/operations/vm-migration/)
+- Open issues: [#147 mTLS](https://github.com/projectbeskar/virtrigaud/issues/147), [#148 provider auth](https://github.com/projectbeskar/virtrigaud/issues/148), [#153 Libvirt Clone stub](https://github.com/projectbeskar/virtrigaud/issues/153), [#154 Libvirt ImagePrepare stub](https://github.com/projectbeskar/virtrigaud/issues/154)

--- a/examples/migration/libvirt-to-vsphere.yaml
+++ b/examples/migration/libvirt-to-vsphere.yaml
@@ -1,29 +1,19 @@
 # Example: Migrate a VM from Libvirt/KVM to VMware vSphere
 #
-# This example demonstrates migrating a Linux VM from a Libvirt host
-# to a vSphere cluster using S3 for intermediate storage.
+# WARNING: This migration direction (Libvirt → vSphere) is NOT currently tested.
+# Only vSphere → Libvirt/KVM is tested in v0.3.6. Use this example with caution
+# and validate in a non-production environment first.
+#
+# This example previously showed S3 storage, which is NOT supported.
+# storage.type is constrained to "pvc" only. All credential-based storage
+# (s3, http, nfs URI) has been removed; use a RWX StorageClass instead.
 #
 # Prerequisites:
 # - Source VM "ubuntu-server" running on Libvirt provider
 # - Target vSphere provider configured
-# - S3 bucket "vm-migrations" accessible
-# - AWS credentials in secret "aws-s3-creds"
+# - A ReadWriteMany StorageClass (e.g. nfs-migration-storage)
 
 ---
-# S3 Credentials Secret
-apiVersion: v1
-kind: Secret
-metadata:
-  name: aws-s3-creds
-  namespace: default
-type: Opaque
-stringData:
-  accessKey: AKIAIOSFODNN7EXAMPLE
-  secretKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-  region: us-east-1
-
----
-# VMMigration Resource
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
 metadata:
@@ -33,52 +23,45 @@ metadata:
     app: ubuntu-server
     migration-type: platform-upgrade
 spec:
-  # Source: Libvirt VM
-  sourceName: ubuntu-server
-  sourceNamespace: default
-  
-  # Target: vSphere
-  targetProviderRef:
-    name: vsphere-prod
-    namespace: default
-  targetName: ubuntu-server-vsphere
-  targetStorageHint: datastore1           # vSphere datastore
-  
-  # Intermediate Storage: S3
-  storage:
-    type: s3
-    bucket: vm-migrations
-    region: us-east-1
-    credentialsSecretRef:
-      name: aws-s3-creds
-      namespace: default
-  
-  # Cleanup: Keep source VM for rollback
-  cleanupPolicy:
-    deleteIntermediate: true              # Clean up S3 after migration
-    deleteSnapshot: true                  # Remove snapshot after success
-    deleteSource: false                   # Keep source VM (recommended)
-  
-  # Retry: Automatic retry on failure
-  retryPolicy:
-    maxAttempts: 3
-    backoffDuration: 5m
-    maxBackoffDuration: 30m
+  source:
+    vmRef:
+      name: ubuntu-server
+    createSnapshot: true
+    deleteAfterMigration: false   # Keep source VM for rollback
 
-# What happens:
-# 1. Controller validates ubuntu-server exists on Libvirt
-# 2. Creates snapshot of ubuntu-server
-# 3. Libvirt provider exports disk (qcow2 format)
-# 4. Converts qcow2 → vmdk using qemu-img
-# 5. Uploads vmdk to s3://vm-migrations/
-# 6. vSphere provider downloads vmdk from S3
-# 7. Uploads vmdk to datastore1
-# 8. Creates new VM "ubuntu-server-vsphere" in vSphere
-# 9. Validates target VM creation
-# 10. Cleans up S3 and snapshot
-# 11. Sets status.phase = "Ready"
+  target:
+    name: ubuntu-server-vsphere
+    providerRef:
+      name: vsphere-prod
+      namespace: default
+    classRef:
+      name: standard-vm
+
+  # PVC-backed storage — only supported storage type in v0.3.6.
+  # Requires a StorageClass with ReadWriteMany access mode.
+  storage:
+    type: pvc
+    pvc:
+      storageClassName: nfs-migration-storage
+      size: 100Gi
+      accessMode: ReadWriteMany
+
+  options:
+    diskFormat: vmdk
+    compress: false
+    verifyChecksums: true
+    timeout: "4h"
+    retryPolicy:
+      maxRetries: 3
+      retryDelay: "5m"
+      backoffMultiplier: 2
+    cleanupPolicy: OnSuccess
+
+  metadata:
+    purpose: "provider-change"
+    environment: "prod"
+    createdBy: "platform-team"
 
 # Monitor progress:
 #   kubectl get vmmigration ubuntu-libvirt-to-vsphere -w
 #   kubectl describe vmmigration ubuntu-libvirt-to-vsphere
-

--- a/examples/migration/proxmox-to-libvirt.yaml
+++ b/examples/migration/proxmox-to-libvirt.yaml
@@ -1,30 +1,17 @@
 # Example: Migrate a VM from Proxmox VE to Libvirt/KVM
 #
-# This example demonstrates migrating a database server from Proxmox
-# to a standalone KVM host using HTTP storage.
+# WARNING: This migration direction (Proxmox → Libvirt) is NOT currently tested.
+# Only vSphere → Libvirt/KVM is tested in v0.3.6. Use this example with caution.
+#
+# This example previously showed HTTP storage, which is NOT supported.
+# storage.type is constrained to "pvc" only. Use a RWX StorageClass instead.
 #
 # Prerequisites:
 # - Source VM "postgres-db" running on Proxmox
 # - Target Libvirt provider configured
-# - HTTP server accessible for file storage
-# - HTTP credentials in secret
+# - A ReadWriteMany StorageClass
 
 ---
-# HTTP Storage Credentials Secret
-apiVersion: v1
-kind: Secret
-metadata:
-  name: fileserver-credentials
-  namespace: databases
-type: Opaque
-stringData:
-  token: Bearer_your-secure-api-token-here
-  # Or use username/password:
-  # username: admin
-  # password: secret123
-
----
-# VMMigration Resource
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
 metadata:
@@ -35,87 +22,46 @@ metadata:
     tier: database
     migration-type: infrastructure-change
 spec:
-  # Source: Proxmox VM
-  sourceName: postgres-db
-  sourceNamespace: databases
-  
-  # Target: Libvirt/KVM
-  targetProviderRef:
-    name: kvm-host1
-    namespace: default
-  targetName: postgres-db-kvm
-  targetNamespace: databases
-  targetStorageHint: default              # Libvirt storage pool
-  targetDiskFormat: qcow2                 # Explicit format
-  
-  # Resource allocation
-  targetResourceHints:
-    cpu: 8
-    memory: 32768                         # 32GB RAM
-    disk: 500                             # 500GB disk
-  
-  # Network configuration
-  targetNetworkHints:
-    - name: eth0
-      bridge: virbr0                      # Libvirt bridge
-  
-  # Intermediate Storage: HTTP Server
+  source:
+    vmRef:
+      name: postgres-db
+    createSnapshot: true
+    powerOffBeforeMigration: true   # Stop writes before migration
+    deleteAfterMigration: false     # Keep source DB until validated
+
+  target:
+    name: postgres-db-kvm
+    namespace: databases
+    providerRef:
+      name: kvm-host1
+      namespace: default
+    classRef:
+      name: database-8cpu-32gb
+
+  # PVC-backed storage — only supported storage type in v0.3.6.
   storage:
-    type: http
-    endpoint: https://fileserver.example.com/vm-exports
-    credentialsSecretRef:
-      name: fileserver-credentials
-      namespace: databases
-  
-  # Cleanup: Keep source for safety
-  cleanupPolicy:
-    deleteIntermediate: true              # Clean up HTTP storage
-    deleteSnapshot: true                  # Remove snapshot
-    deleteSource: false                   # Keep source DB
-  
-  # Retry: Important for database migration
-  retryPolicy:
-    maxAttempts: 5
-    backoffDuration: 10m
-    maxBackoffDuration: 1h
+    type: pvc
+    pvc:
+      storageClassName: nfs-migration-storage
+      size: 600Gi
+      accessMode: ReadWriteMany
 
-# What happens:
-# 1. Controller validates postgres-db on Proxmox
-# 2. Creates snapshot of postgres-db (stops writes temporarily)
-# 3. Proxmox provider exports disk (qcow2 format)
-# 4. Uploads qcow2 to HTTP server
-# 5. Libvirt provider downloads qcow2 from HTTP
-# 6. Copies to /var/lib/libvirt/images/
-# 7. Creates new VM "postgres-db-kvm" in Libvirt
-# 8. Configures CPU, memory, and network
-# 9. Validates target VM creation
-# 10. Cleans up HTTP storage and snapshot
-# 11. Sets status.phase = "Ready"
+  options:
+    diskFormat: qcow2
+    compress: false
+    verifyChecksums: true
+    timeout: "6h"
+    retryPolicy:
+      maxRetries: 5
+      retryDelay: "10m"
+      backoffMultiplier: 2
+    cleanupPolicy: OnSuccess
 
-# Important notes for database migration:
-# 1. Stop database writes before migration (if possible)
-# 2. Take application-level backup before migration
-# 3. Verify data integrity after migration
-# 4. Update application connection strings
-# 5. Monitor target VM performance
+  metadata:
+    purpose: "provider-change"
+    environment: "prod"
+    createdBy: "platform-team"
 
 # Monitor progress:
 #   kubectl get vmmigration postgres-proxmox-to-kvm -w
-#
-# After migration:
-#   1. Start target VM:
-#      virsh start postgres-db-kvm
-#   
-#   2. Verify PostgreSQL starts:
-#      virsh console postgres-db-kvm
-#      systemctl status postgresql
-#   
-#   3. Test database connectivity:
-#      psql -h postgres-db-kvm -U postgres -c "SELECT version();"
-#   
-#   4. Run data integrity checks
-#   
-#   5. Update DNS/load balancer to point to new VM
-#   
-#   6. Monitor for 24-48 hours before removing source
-
+#   kubectl describe vmmigration postgres-proxmox-to-kvm

--- a/examples/migration/vsphere-to-proxmox.yaml
+++ b/examples/migration/vsphere-to-proxmox.yaml
@@ -1,16 +1,17 @@
 # Example: Migrate a VM from VMware vSphere to Proxmox VE
 #
-# This example demonstrates migrating a Windows Server VM from vSphere
-# to Proxmox using NFS for intermediate storage.
+# WARNING: This migration direction (vSphere → Proxmox) is NOT currently tested.
+# Only vSphere → Libvirt/KVM is tested in v0.3.6. Use this example with caution.
+#
+# This example previously showed NFS URI storage, which is NOT supported.
+# storage.type is constrained to "pvc" only. Use an NFS-backed StorageClass instead.
 #
 # Prerequisites:
 # - Source VM "windows-server-2022" running on vSphere
 # - Target Proxmox provider configured
-# - NFS share mounted at /mnt/migrations on both providers
-# - Sufficient space on NFS for VM disk
+# - A ReadWriteMany StorageClass (NFS, CephFS, etc.)
 
 ---
-# VMMigration Resource
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
 metadata:
@@ -24,70 +25,49 @@ metadata:
     migration.virtrigaud.io/requestor: ops-team@example.com
     migration.virtrigaud.io/reason: "Migrating to Proxmox cluster"
 spec:
-  # Source: vSphere VM
-  sourceName: windows-server-2022
-  sourceNamespace: production
-  
-  # Target: Proxmox
-  targetProviderRef:
-    name: proxmox-cluster
-    namespace: default
-  targetName: windows-server-2022-pve
-  targetNamespace: production
-  targetStorageHint: local-lvm            # Proxmox storage
-  
-  # Resource hints for target VM
-  targetResourceHints:
-    cpu: 4
-    memory: 8192                          # 8GB RAM
-  
-  # Network configuration
-  targetNetworkHints:
-    - name: eth0
-      bridge: vmbr0                       # Proxmox bridge
-  
-  # Intermediate Storage: NFS
-  storage:
-    type: nfs
-    path: /mnt/migrations
-    endpoint: nfs.example.com
-  
-  # Cleanup: Conservative approach
-  cleanupPolicy:
-    deleteIntermediate: true              # Clean up NFS after migration
-    deleteSnapshot: true                  # Remove snapshot
-    deleteSource: false                   # Keep source (important!)
-  
-  # Retry: Aggressive retry for reliability
-  retryPolicy:
-    maxAttempts: 5
-    backoffDuration: 10m
-    maxBackoffDuration: 1h
+  source:
+    vmRef:
+      name: windows-server-2022
+    createSnapshot: true
+    powerOffBeforeMigration: false
+    deleteAfterMigration: false     # Keep source until target is validated
 
-# What happens:
-# 1. Controller validates windows-server-2022 on vSphere
-# 2. Creates snapshot of windows-server-2022
-# 3. vSphere provider downloads VMDK from datastore
-# 4. Converts vmdk → qcow2 using qemu-img
-# 5. Copies qcow2 to /mnt/migrations (NFS)
-# 6. Proxmox provider reads qcow2 from /mnt/migrations
-# 7. Uploads to Proxmox local-lvm storage
-# 8. Creates new VM "windows-server-2022-pve" in Proxmox
-# 9. Configures CPU, memory, and network
-# 10. Validates target VM creation
-# 11. Cleans up NFS and snapshot
-# 12. Sets status.phase = "Ready"
+  target:
+    name: windows-server-2022-pve
+    namespace: production
+    providerRef:
+      name: proxmox-cluster
+      namespace: default
+    classRef:
+      name: windows-4cpu-8gb
+
+  # PVC-backed storage — only supported storage type in v0.3.6.
+  # Using an NFS-backed StorageClass achieves the same result as a direct NFS mount.
+  storage:
+    type: pvc
+    pvc:
+      storageClassName: nfs-migration-storage
+      size: 100Gi
+      accessMode: ReadWriteMany
+
+  options:
+    diskFormat: qcow2
+    compress: false
+    verifyChecksums: true
+    timeout: "4h"
+    retryPolicy:
+      maxRetries: 5
+      retryDelay: "10m"
+      backoffMultiplier: 2
+    cleanupPolicy: OnSuccess
+
+  metadata:
+    purpose: "provider-change"
+    environment: "prod"
+    createdBy: "ops-team"
 
 # Monitor progress:
 #   kubectl get vmmigration windows-vsphere-to-proxmox -w
 #
-# Validate target VM:
-#   # Log into Proxmox web UI
-#   # Start windows-server-2022-pve
-#   # Verify Windows boots correctly
-#   # Test network connectivity
-#
-# After validation, optionally delete source:
-#   # Only after confirming target works!
-#   # kubectl delete vm windows-server-2022 -n production
-
+# Validate target VM before removing source:
+#   Log into Proxmox web UI, start windows-server-2022-pve, verify Windows boots

--- a/examples/secrets/libvirt-creds.yaml
+++ b/examples/secrets/libvirt-creds.yaml
@@ -1,3 +1,13 @@
+# Libvirt credentials secret for VirtRigaud
+#
+# The Libvirt provider reads credentials from the mounted secret.
+# Supported keys:
+#   ssh-privatekey  — private key for SSH transport (recommended)
+#   username        — SSH username (required with ssh-privatekey or password)
+#   password        — SSH password (less secure than key-based auth)
+
+---
+# SSH key authentication (recommended):
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,15 +15,21 @@ metadata:
   namespace: default
 type: Opaque
 stringData:
-  # For SASL authentication (if required)
+  username: "virtrigaud"
+  # ssh-privatekey must be the raw PEM-encoded private key (not base64-encoded again)
+  ssh-privatekey: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    REDACTED
+    -----END OPENSSH PRIVATE KEY-----
+
+---
+# Password authentication (less secure):
+apiVersion: v1
+kind: Secret
+metadata:
+  name: libvirt-creds-password
+  namespace: default
+type: Opaque
+stringData:
   username: "virtrigaud"
   password: "REDACTED"
-  # For TLS client certificates (if required)
-  # tls.crt: |
-  #   -----BEGIN CERTIFICATE-----
-  #   ...
-  #   -----END CERTIFICATE-----
-  # tls.key: |
-  #   -----BEGIN PRIVATE KEY-----
-  #   ...
-  #   -----END PRIVATE KEY-----

--- a/examples/secrets/proxmox-creds.yaml
+++ b/examples/secrets/proxmox-creds.yaml
@@ -1,0 +1,34 @@
+# Proxmox VE credentials secret for VirtRigaud
+#
+# The Proxmox provider reads credentials from files mounted at:
+#   /etc/virtrigaud/credentials/token_id
+#   /etc/virtrigaud/credentials/token_secret
+#   /etc/virtrigaud/credentials/username
+#   /etc/virtrigaud/credentials/password
+#
+# Do NOT use envFrom: secretRef for Proxmox credentials.
+# That pattern is not implemented; the provider only reads from the file paths above.
+#
+# API token authentication (recommended):
+apiVersion: v1
+kind: Secret
+metadata:
+  name: proxmox-creds
+  namespace: default
+type: Opaque
+stringData:
+  # API token: USER@REALM!TOKENID format
+  token_id: "virtrigaud@pve!vrtg-token"
+  token_secret: "xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx"
+
+---
+# Username/password authentication (less secure):
+apiVersion: v1
+kind: Secret
+metadata:
+  name: proxmox-creds-userpass
+  namespace: default
+type: Opaque
+stringData:
+  username: "virtrigaud@pve"
+  password: "REDACTED"

--- a/examples/vm-adoption-example.yaml
+++ b/examples/vm-adoption-example.yaml
@@ -1,9 +1,15 @@
----
-# Example: VM Adoption with Filters
-# This example demonstrates how to enable VM adoption on a Provider
-# with various filter configurations.
+# VM Adoption Examples
+#
+# VMAdoption is a CONTROLLER built into the manager, not a CRD.
+# Adoption is triggered by annotations on the Provider CR.
+# The Provider spec uses the v1beta1 schema: type, endpoint,
+# credentialSecretRef, and runtime — NOT nested provider-specific blocks.
+#
+# The old spec fields (remote: true, vsphere.server, libvirt.uri,
+# proxmox.server, credentials.secretRef) do NOT exist in v0.3.6.
 
-# Example 1: Basic VM Adoption (adopt all unmanaged VMs)
+---
+# Example 1: vSphere Provider with VM Adoption enabled
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: Provider
 metadata:
@@ -13,16 +19,22 @@ metadata:
     virtrigaud.io/adopt-vms: "true"
 spec:
   type: vsphere
-  remote: true
-  vsphere:
-    server: vcenter.example.com
+  endpoint: "https://vcenter.example.com:443"
+  credentialSecretRef:
+    name: vsphere-prod-credentials
+    namespace: default
+  runtime:
+    image: "ghcr.io/projectbeskar/virtrigaud/provider-vsphere:v0.3.6"
+    service:
+      port: 9443
+  defaults:
     datacenter: Production
-    credentials:
-      secretRef:
-        name: vsphere-prod-credentials
-        namespace: default
+    datastore: datastore1
+    cluster: cluster1
+
 ---
-# Example 2: Adopt Only Production VMs (name pattern filter)
+# Example 2: vSphere Provider — adopt only VMs matching a name pattern
+# The annotation value is passed to the VMAdoption controller as a filter hint.
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: Provider
 metadata:
@@ -33,76 +45,17 @@ metadata:
     virtrigaud.io/adopt-filter: '{"namePattern": "^prod-.*"}'
 spec:
   type: vsphere
-  remote: true
-  vsphere:
-    server: vcenter.example.com
-    datacenter: Production
-    credentials:
-      secretRef:
-        name: vsphere-prod-credentials
-        namespace: default
+  endpoint: "https://vcenter.example.com:443"
+  credentialSecretRef:
+    name: vsphere-prod-credentials
+    namespace: default
+  runtime:
+    image: "ghcr.io/projectbeskar/virtrigaud/provider-vsphere:v0.3.6"
+    service:
+      port: 9443
+
 ---
-# Example 3: Adopt Only Powered-On VMs
-apiVersion: infra.virtrigaud.io/v1beta1
-kind: Provider
-metadata:
-  name: vsphere-prod-online
-  namespace: default
-  annotations:
-    virtrigaud.io/adopt-vms: "true"
-    virtrigaud.io/adopt-filter: '{"powerState": "on"}'
-spec:
-  type: vsphere
-  remote: true
-  vsphere:
-    server: vcenter.example.com
-    datacenter: Production
-    credentials:
-      secretRef:
-        name: vsphere-prod-credentials
-        namespace: default
----
-# Example 4: Adopt VMs with Resource Requirements
-apiVersion: infra.virtrigaud.io/v1beta1
-kind: Provider
-metadata:
-  name: vsphere-prod-large
-  namespace: default
-  annotations:
-    virtrigaud.io/adopt-vms: "true"
-    virtrigaud.io/adopt-filter: '{"minCPU": 4, "minMemoryMiB": 8192}'
-spec:
-  type: vsphere
-  remote: true
-  vsphere:
-    server: vcenter.example.com
-    datacenter: Production
-    credentials:
-      secretRef:
-        name: vsphere-prod-credentials
-        namespace: default
----
-# Example 5: Complex Filter (production VMs, powered on, 2-8 CPUs)
-apiVersion: infra.virtrigaud.io/v1beta1
-kind: Provider
-metadata:
-  name: vsphere-prod-complex
-  namespace: default
-  annotations:
-    virtrigaud.io/adopt-vms: "true"
-    virtrigaud.io/adopt-filter: '{"namePattern": "^prod-.*", "powerState": "on", "minCPU": 2, "maxCPU": 8}'
-spec:
-  type: vsphere
-  remote: true
-  vsphere:
-    server: vcenter.example.com
-    datacenter: Production
-    credentials:
-      secretRef:
-        name: vsphere-prod-credentials
-        namespace: default
----
-# Example 6: Libvirt Provider with Filter
+# Example 3: Libvirt Provider with VM Adoption enabled
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: Provider
 metadata:
@@ -110,14 +63,20 @@ metadata:
   namespace: default
   annotations:
     virtrigaud.io/adopt-vms: "true"
-    virtrigaud.io/adopt-filter: '{"namePattern": "^app-.*", "powerState": "on"}'
+    virtrigaud.io/adopt-filter: '{"namePattern": "^app-.*"}'
 spec:
   type: libvirt
-  remote: true
-  libvirt:
-    uri: qemu:///system
+  endpoint: "qemu+ssh://kvm-host.example.com/system"
+  credentialSecretRef:
+    name: libvirt-prod-credentials
+    namespace: default
+  runtime:
+    image: "ghcr.io/projectbeskar/virtrigaud/provider-libvirt:v0.3.6"
+    service:
+      port: 9443
+
 ---
-# Example 7: Proxmox Provider with Filter
+# Example 4: Proxmox Provider with VM Adoption enabled
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: Provider
 metadata:
@@ -125,14 +84,13 @@ metadata:
   namespace: default
   annotations:
     virtrigaud.io/adopt-vms: "true"
-    virtrigaud.io/adopt-filter: '{"minCPU": 2, "minMemoryMiB": 4096}'
 spec:
   type: proxmox
-  remote: true
-  proxmox:
-    server: proxmox.example.com
-    credentials:
-      secretRef:
-        name: proxmox-prod-credentials
-        namespace: default
-
+  endpoint: "https://proxmox.example.com:8006"
+  credentialSecretRef:
+    name: proxmox-prod-credentials
+    namespace: default
+  runtime:
+    image: "ghcr.io/projectbeskar/virtrigaud/provider-proxmox:v0.3.6"
+    service:
+      port: 9443

--- a/examples/vmmigration-advanced.yaml
+++ b/examples/vmmigration-advanced.yaml
@@ -1,5 +1,11 @@
 # Advanced VM Migration Example
-# Demonstrates all available configuration options
+# Demonstrates available VMMigration configuration options for v0.3.6.
+#
+# IMPORTANT CONSTRAINTS:
+# - storage.type only accepts "pvc" (enum-constrained). s3/http/nfs are not implemented.
+# - Only vSphere → Libvirt/KVM migration is tested. Other paths are roadmap.
+# - Fields that don't exist on the CRD (options.type, options.storage.*,
+#   options.performance.*, source.providerRef) have been removed.
 
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
@@ -7,133 +13,65 @@ metadata:
   name: advanced-migration
   namespace: production
   labels:
-    migration-batch: "2025-q1"
+    migration-batch: "2026-q2"
     priority: "high"
     team: "platform"
   annotations:
     migration.virtrigaud.io/requester: "ops-team@company.com"
     migration.virtrigaud.io/ticket: "INFRA-1234"
-    migration.virtrigaud.io/estimated-duration: "2h"
 spec:
-  # Advanced source configuration
   source:
     vmRef:
       name: critical-app-vm
-      namespace: production
-    
-    # Explicit provider reference (auto-detected if omitted)
-    providerRef:
-      name: vsphere-datacenter-1
-      namespace: infrastructure
-    
-    # Use existing snapshot for migration
     snapshotRef:
-      name: daily-backup-20250116
+      name: daily-backup-20260116
     createSnapshot: false
-    
-    # Power off VM before migration for data consistency
     powerOffBeforeMigration: true
-    
-    # Delete source VM after successful migration
-    deleteAfterMigration: true
-  
-  # Advanced target configuration
+    deleteAfterMigration: false   # Keep source until target is validated
+
   target:
     name: critical-app-vm-migrated
     namespace: production
-    
     providerRef:
-      name: proxmox-cluster-prod
+      name: libvirt-host-prod
       namespace: infrastructure
-    
-    # VM specifications
     classRef:
       name: high-performance-8cpu-16gb
-    
-    # Multiple network attachments
     networks:
       - name: production-frontend
-        ipam:
-          staticIP: "10.0.1.100"
-      - name: production-backend
-        ipam:
-          staticIP: "10.0.2.100"
       - name: management
-    
-    # Specific disks configuration
-    disks:
-      - name: root
-        size: 100Gi
-        storageClass: fast-ssd
-      - name: data
-        size: 500Gi
-        storageClass: standard-hdd
-    
-    # Placement on specific host/cluster
     placementRef:
-      name: proxmox-node-prod-3
-    
-    # Labels and annotations for target VM
+      name: kvm-node-prod-3
     labels:
       app: critical-app
       environment: production
-      tier: frontend
-      managed-by: virtrigaud
       migrated-from: vsphere
-    
     annotations:
       backup.schedule: "0 2 * * *"
-      monitoring.enabled: "true"
-      compliance.level: "high"
-  
-  # Storage configuration with S3
+
+  # storage.type must be "pvc". Use a ReadWriteMany StorageClass.
   storage:
-    type: s3
-    bucket: enterprise-vm-migrations
-    region: us-west-2
-    endpoint: https://s3.us-west-2.amazonaws.com
-    credentialsSecretRef:
-      name: aws-migration-credentials
-  
-  # Comprehensive migration options
+    type: pvc
+    pvc:
+      storageClassName: cephfs-migration
+      size: 600Gi
+      accessMode: ReadWriteMany
+
   options:
-    # Migration type (Cold is default, Warm for future)
-    type: Cold
-    
-    # Disk format
     diskFormat: qcow2
-    
-    # Transfer options
     compress: true
     verifyChecksums: true
-    
-    # Timeouts
-    timeout: 8h  # For very large VMs
-    
-    # Retry policy with exponential backoff
+    timeout: "8h"
     retryPolicy:
       maxRetries: 5
-      retryDelay: 5m
+      retryDelay: "5m"
       backoffMultiplier: 2
-    
-    # Storage options
-    storage:
-      chunkSize: 64Mi
-      parallelUploads: 4
-      encryption: true
-    
-    # Performance tuning
-    performance:
-      networkBandwidthLimit: 1Gbps
-      diskIOLimit: 500MBps
-      compressionLevel: 6
-  
-  # Migration metadata
-  metadata:
-    purpose: "Datacenter consolidation and modernization"
-    project: "Project Phoenix 2025"
-    environment: "production"
-    owner: "platform-engineering@company.com"
-    costCenter: "IT-INFRA-001"
-    scheduledWindow: "2025-01-20T02:00:00Z - 2025-01-20T06:00:00Z"
+    cleanupPolicy: OnSuccess
 
+  metadata:
+    # Valid: disaster-recovery, cloud-migration, provider-change, testing, maintenance
+    purpose: "provider-change"
+    project: "migration-2026"
+    # Valid: dev, staging, prod, test, qa, uat
+    environment: "prod"
+    createdBy: "platform-engineering"

--- a/examples/vmmigration-basic.yaml
+++ b/examples/vmmigration-basic.yaml
@@ -1,5 +1,8 @@
 # Basic VM Migration Example
-# Migrates a VM from one provider to another with minimal configuration
+# Migrates a VM from one provider to another with minimal configuration.
+#
+# storage.type is enum-constrained to "pvc" only (v0.3.6).
+# Only vSphere → Libvirt/KVM is currently tested.
 
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
@@ -11,8 +14,8 @@ spec:
   source:
     vmRef:
       name: my-source-vm
-    createSnapshot: true  # Create snapshot before migration
-  
+    createSnapshot: true
+
   # Target configuration
   target:
     name: my-target-vm
@@ -23,12 +26,16 @@ spec:
       name: standard-vm
     networks:
       - name: default
-  
-  # Storage for intermediate disk transfer
+
+  # PVC-backed intermediate storage (only supported type in v0.3.6).
+  # Requires a ReadWriteMany StorageClass (NFS, CephFS, etc.).
   storage:
-    type: nfs
-    endpoint: /mnt/nfs-migrations
-  
+    type: pvc
+    pvc:
+      storageClassName: nfs-migration-storage
+      size: 100Gi
+      accessMode: ReadWriteMany
+
   # Migration options with sensible defaults
   options:
     diskFormat: qcow2

--- a/examples/vmmigration-nfs.yaml
+++ b/examples/vmmigration-nfs.yaml
@@ -1,39 +1,26 @@
-# VM Migration with NFS Storage
-# Uses NFS shared storage for on-premises migrations
+# VM Migration using PVC-backed storage (NFS StorageClass)
+#
+# NOTE: VirtRigaud v0.3.6 only supports "pvc" as the migration storage type.
+# The previously-documented "nfs" type is not a valid MigrationStorage.Type value.
+# Use an NFS-backed StorageClass to achieve NFS storage for migrations.
+#
+# Currently tested migration path: vSphere → Libvirt/KVM only.
+# The Libvirt → Proxmox path shown here is roadmap and unverified.
 
-# PersistentVolume for NFS storage
-apiVersion: v1
-kind: PersistentVolume
+# NFS StorageClass — create once per cluster
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: nfs-migration-storage
-spec:
-  capacity:
-    storage: 1Ti
-  accessModes:
-    - ReadWriteMany
-  nfs:
-    server: nfs-server.company.local
-    path: /export/vm-migrations
-  mountOptions:
-    - hard
-    - nfsvers=4.1
-    - rsize=1048576
-    - wsize=1048576
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: nfs-server.company.local
+  share: /export/vm-migrations
+volumeBindingMode: Immediate
+reclaimPolicy: Delete
+
 ---
-# PersistentVolumeClaim
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: nfs-migration-storage
-  namespace: virtrigaud-system
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 1Ti
----
-# VM Migration using NFS
+# VMMigration using the NFS-backed StorageClass
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
 metadata:
@@ -44,9 +31,8 @@ spec:
     vmRef:
       name: legacy-app-libvirt
     createSnapshot: true
-    # Power off VM before migration for consistency
     powerOffBeforeMigration: true
-  
+
   target:
     name: legacy-app-proxmox
     providerRef:
@@ -58,20 +44,21 @@ spec:
       - name: vlan-100-production
     placementRef:
       name: proxmox-node-2
-  
-  # NFS storage - must be mounted at same path on all provider pods
+
+  # storage.type must be "pvc" — the only accepted value in v0.3.6.
   storage:
-    type: nfs
-    endpoint: /mnt/nfs-migrations  # Mount point on provider pods
-  
+    type: pvc
+    pvc:
+      storageClassName: nfs-migration-storage
+      size: 200Gi
+      accessMode: ReadWriteMany
+
   options:
     diskFormat: qcow2
-    compress: false  # NFS is fast, no need for compression
+    compress: false
     verifyChecksums: true
-    timeout: 4h
-    
+    timeout: "4h"
     retryPolicy:
       maxRetries: 3
-      retryDelay: 3m
+      retryDelay: "3m"
       backoffMultiplier: 2
-

--- a/examples/vmmigration-s3.yaml
+++ b/examples/vmmigration-s3.yaml
@@ -1,20 +1,12 @@
-# VM Migration with S3 Storage
-# Uses AWS S3 for intermediate disk storage during migration
+# NOTE: This file was formerly an S3 migration example.
+# S3 storage backend is NOT implemented in VirtRigaud v0.3.6.
+# MigrationStorage.Type is enum-constrained to "pvc" only.
+# This file has been replaced with an equivalent PVC-based example.
 
-apiVersion: v1
-kind: Secret
-metadata:
-  name: s3-migration-credentials
-  namespace: default
-type: Opaque
-stringData:
-  accessKey: "AKIAIOSFODNN7EXAMPLE"
-  secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
----
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
 metadata:
-  name: migration-with-s3
+  name: migration-pvc-example
   namespace: default
   labels:
     app: my-app
@@ -23,18 +15,16 @@ spec:
   source:
     vmRef:
       name: prod-app-server
-    # Use existing snapshot instead of creating new one
     snapshotRef:
       name: pre-migration-snapshot
     createSnapshot: false
-    # Optionally delete source VM after successful migration
     deleteAfterMigration: false
-  
+
   target:
     name: prod-app-server-migrated
     providerRef:
-      name: proxmox-production
-      namespace: infra
+      name: target-provider
+      namespace: default
     classRef:
       name: high-performance
     networks:
@@ -45,33 +35,30 @@ spec:
       environment: production
       migrated: "true"
     annotations:
-      description: "Migrated from vSphere to Proxmox"
-  
-  # S3 storage configuration
+      description: "Migrated to new provider"
+
+  # Storage: only "pvc" type is supported in v0.3.6.
+  # The previously-documented s3/http/nfs types do not exist.
+  # Use a ReadWriteMany StorageClass (NFS, CephFS, AWS EFS, etc.).
   storage:
-    type: s3
-    bucket: company-vm-migrations
-    region: us-east-1
-    endpoint: https://s3.amazonaws.com
-    credentialsSecretRef:
-      name: s3-migration-credentials
-  
-  # Advanced options
+    type: pvc
+    pvc:
+      storageClassName: nfs-migration-storage
+      size: 200Gi
+      accessMode: ReadWriteMany
+
   options:
     diskFormat: qcow2
-    compress: true  # Compress for transfer
+    compress: false
     verifyChecksums: true
-    timeout: 6h
-    
-    # Retry configuration
+    timeout: "6h"
     retryPolicy:
       maxRetries: 3
-      retryDelay: 5m
+      retryDelay: "5m"
       backoffMultiplier: 2
-  
-  # Migration metadata
-  metadata:
-    purpose: "Infrastructure consolidation"
-    project: "cloud-migration-2025"
-    owner: "platform-team"
 
+  metadata:
+    # Valid values: disaster-recovery, cloud-migration, provider-change, testing, maintenance
+    purpose: "provider-change"
+    project: "cloud-migration-2026"
+    createdBy: "platform-team"


### PR DESCRIPTION
## Summary

Phase 9 (final) of the v0.3.6 documentation alignment. Phases 1–8 landed on the website repo (`projectbeskar/virtrigaud-website`). This PR brings the main repo's user-facing docs, examples, and ADRs into alignment with v0.3.6 reality and with the website.

- **README.md** — complete audit and rewrite to v0.3.6 accuracy
- **examples/** — 10 files fixed (invented fields, wrong storage types, wrong CRD schema)
- **docs/adr/** — two ADRs promoted from gitignored `fieldTesting/` into the tree

## Per-area delta

### README.md
- Provider Feature Matrix corrected: vSphere memory snapshots `❌` (was `✅`); Libvirt linked clones `✅` (was `❌`); stub warnings added for Libvirt Clone/ImagePrepare (#153, #154)
- Security section added disclosing #147 (mTLS), #148 (provider auth), #149 (Libvirt SSH host-key), cross-linked to website security guide
- Helm install command: added `--version 0.3.6`
- CRD list: 10 CRDs; VMAdoption removed (it is a controller, not a CRD)
- Proxmox credentials note: `/etc/virtrigaud/credentials/` file path (not `envFrom: secretRef`)
- Migration section: only `type: pvc` is supported; only vSphere → Libvirt tested
- Go floor: 1.26.0
- Fictional `docs/REMOTE_PROVIDERS.md` link removed; link to website instead
- Architecture diagram updated: all 10 CRDs listed; G4+G6 interceptor chain noted

### examples/ (10 files fixed, 1 file added)
- `vmmigration-basic.yaml`, `vmmigration-advanced.yaml`, `vmmigration-nfs.yaml`, `vmmigration-s3.yaml`: `storage.type` changed from `nfs`/`s3` to `pvc` (enum-constrained to `pvc` in the API)
- `migration/libvirt-to-vsphere.yaml`, `proxmox-to-libvirt.yaml`, `vsphere-to-proxmox.yaml`: same fix; untested-direction warnings added; all invented `sourceName`/`targetProviderRef` flat fields replaced with correct `source.vmRef` + `target.providerRef` nested schema
- `vm-adoption-example.yaml`: completely rewritten from invented Provider spec (`remote: true`, `vsphere.server`, `libvirt.uri`) to actual v1beta1 Provider schema
- `secrets/libvirt-creds.yaml`: corrected to `ssh-privatekey` / `username` / `password` keys
- `secrets/proxmox-creds.yaml`: **new file** — `token_id` + `token_secret` keys matching what the provider reads from `/etc/virtrigaud/credentials/`
- `examples/README.md`, `migration/README.md`: updated to v0.3.6; known-limitations sections added

### docs/adr/ (new directory)
- `docs/adr/0001-transport-grpc-and-capi-integration.md`: promoted from gitignored `fieldTesting/`; Status: Accepted (gRPC transport shipped through v0.3.6; CAPI layering principle settled)
- `docs/adr/0002-build-path-consolidation.md`: promoted from gitignored `fieldTesting/`; Status: Accepted; PR-1 through PR-4 marked Done (v0.3.6); PR-5 (HTTPS-by-default metrics) marked deferred to v0.4.0
- `docs/adr/README.md`: ADR index
- `docs/README.md`: top-level pointer to website + ADR directory

## Fictional content removed (audit pattern)

| File | What was removed/fixed |
|------|----------------------|
| README.md | Invented `docs/REMOTE_PROVIDERS.md` link; wrong `--version` (absent); VMAdoption listed as CRD; vSphere memory snapshots `✅`; Libvirt linked clones `❌`; missing security gaps |
| vmmigration-*.yaml (7 files) | `storage.type: s3`/`nfs` (not in the API enum); flat spec fields (`sourceName`, `targetProviderRef`, `cleanupPolicy.deleteSource`, etc.) that don't exist on the CRD |
| vm-adoption-example.yaml | Entire Provider spec was invented (`remote: true`, `vsphere.server`, `credentials.secretRef`) |
| secrets/libvirt-creds.yaml | `tls.crt`/`tls.key` keys that libvirt provider doesn't read; missing `ssh-privatekey` |

## Test plan

- [ ] `kubectl apply --dry-run=client -f examples/` passes on a cluster with v0.3.6 CRDs installed
- [ ] `kubectl apply --dry-run=client -f examples/migration/` passes
- [ ] No broken intra-repo links (README links verified manually)
- [ ] ADR files render correctly on GitHub

## Follow-up issues (flagged, not filed — tech-writer role cannot file)

- Libvirt Clone stub (#153) and ImagePrepare stub (#154) — already filed per Phase 8
- PR-5 (flip metrics-secure default to true) — tracked in ADR-0002; target v0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)