### PR TITLE
feat(security): libvirt SSH host-key verification on by default (closes #149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-29 04:40] - v0.3.7: Libvirt SSH host-key verification on by default (closes #149)
+**Author:** @wrkode (William Rizzo)
+
+### Security
+- `internal/providers/libvirt/sshhostkey.go`: **new centralized host-key policy** — the single source of truth for the libvirt provider's SSH/scp host-key verification. `resolveHostKeyPolicy()` reads the new escape-hatch env var `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION` once (honoured only for the literal word `"true"`, case-insensitive/trimmed — mirrors ADR-0003's `isInsecureOptedIn`); `sshHostKeyOptions()`/`sshConfigStanza()`/`applyURIHostKeyOptions()` render the `-o StrictHostKeyChecking=…`/`UserKnownHostsFile=…` flags and `~/.ssh/config`/URI options; `verifyKnownHostsPresent()` is the loud hard-fail gate; `logVerificationMode()` emits the structured `slog` audit line. Trust material is read from `known_hosts` in the existing credentials Secret mount (`/etc/virtrigaud/credentials/known_hosts`) — zero controller/CRD change.
+- `internal/providers/libvirt/virsh.go`: closed three of the five bypass paths — removed unconditional `no_verify=1` on the `qemu+ssh://` URI (now gated by the policy), and replaced `StrictHostKeyChecking=accept-new` + ephemeral `UserKnownHostsFile=/tmp/known_hosts` on both the `sshpass`-direct (`!`) and the standard virsh-over-ssh argv builders with the centralized policy options. `createSSHConfig` now writes a verifying `~/.ssh/config` instead of `accept-new`. `setupConnection` resolves the policy once into `VirshProvider.hostKey`, emits the one-line verification-mode audit log, and hard-fails (no TOFU) when verification is on but no usable `known_hosts` is present.
+- `internal/providers/libvirt/server.go`: closed the remaining two bypass paths — the `scp` disk-image copy (`copyDiskToRemote`, both `sshpass`-password and key-based fallback) now consumes the same centralized host-key options, re-emits the verification-mode audit line, and re-runs the hard-fail gate before transfer.
+
+### Fixed
+- Libvirt SSH/scp no longer disables host-key verification on any code path. Pre-#149 every path used `no_verify=1` / `accept-new` against an emptyDir-backed `/tmp/known_hosts` that re-TOFU'd on every pod restart — strictly worse than classic TOFU and the exact MITM window #149 calls out. Verification is now on by default with a single, named, audit-visible escape hatch.
+
+### Added
+- `internal/providers/libvirt/sshhostkey_test.go`: table-driven coverage of the env-var parsing (`unset`/`""`/`false`/`1`/`yes`/`true`/`TRUE`/`  true  `), the secure and insecure option/config/URI output across all three transports (URI/key, password, scp), the actionable hard-fail error (asserts it names the host, the path, the `ssh-keyscan` recipe, and the env var), and the WARN/INFO `slog` audit lines via a captured handler.
+- `docs/adr/0004-libvirt-ssh-host-key-verification.md`: promoted ADR-0004 from the gitignored `fieldTesting/` draft into the tracked ADR directory; flipped Status to **Accepted (2026-05-27)**, converted Open Questions into a "Decisions resolved" table, and added an "Implementation status — as shipped" note (centralized helper, scp re-emit, `slog` audit, empty-file hard-fail, I1 interaction).
+- `docs/adr/README.md`: added the ADR-0004 index row (Accepted, 2026-05-27).
+
+### Why
+#149 is the last HIGH-severity item from the v0.3.6 security audit: the libvirt provider (a virsh-CLI-over-SSH provider) connected to remote hypervisors with SSH host-key verification disabled on every path, exposing the manager→hypervisor channel to MITM (SSH credential leak + injected `virsh`/disk-image tampering) — below the project's regulated-banking compliance posture. This makes verification secure-by-default and coherent with ADR-0003's manager→provider mTLS, closing both transport-trust boundaries in v0.3.7.
+
+### Impact
+- [x] Breaking change
+- [x] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
+> **Breaking change for v0.3.7 release notes.** Existing v0.3.6 libvirt Providers that connect over SSH and relied on the implicit `no_verify=1` will **stop connecting** after upgrade until the operator either (a) adds a `known_hosts` key to the credentials Secret referenced by `credentialSecretRef` (seed it from a trusted bastion: `ssh-keyscan -H <host> >> known_hosts`), OR (b) sets `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true` in the Provider's `spec.runtime.env` (audit-flagged WARN on every connection). This is intentional and the same breaking-change callout class as ADR-0003's nil-TLS-block loud failure.
+
+### Usage
+```yaml
+# Secure (default): seed the host key in the existing credentials Secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: libvirt-credentials
+  namespace: virtrigaud-system
+stringData:
+  ssh-privatekey: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    ...
+  known_hosts: |
+    # output of: ssh-keyscan -H <libvirt-host> >> known_hosts
+    |1|...= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+---
+# Escape hatch (lab/migration only — audit-flagged): per-Provider env var.
+apiVersion: infra.virtrigaud.io/v1beta1
+kind: Provider
+spec:
+  runtime:
+    env:
+      - name: LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION
+        value: "true"
+```
+
+---
+
 ## [2026-05-28 11:05] - v0.3.7 PR-4: Promote ADR-0003 (mTLS + provider gRPC auth) to docs/adr/
 **Author:** @wrkode (William Rizzo)
 

--- a/docs/adr/0004-libvirt-ssh-host-key-verification.md
+++ b/docs/adr/0004-libvirt-ssh-host-key-verification.md
@@ -1,0 +1,494 @@
+# ADR-0004: Libvirt SSH host-key verification
+
+## Status
+
+**Accepted (2026-05-27)** — maintainer sign-off received; targeted at v0.3.7.
+
+**Implementation**: code-complete on `v0.3.7/149-libvirt-ssh-hostkey`. The single
+PR closes [#149](https://github.com/projectbeskar/virtrigaud/issues/149), lands the
+fix + tests + CHANGELOG, and promotes this document to `docs/adr/0004-...`. The
+operator-facing runbook and website security-page updates are intentionally
+deferred to the **v0.3.7 release doc-sync** (the website documents released reality,
+and v0.3.7 is unreleased at promotion time), mirroring ADR-0003.
+
+**Author**: William Rizzo ([@wrkode](https://github.com/wrkode))
+
+**Related issues**:
+- [#149](https://github.com/projectbeskar/virtrigaud/issues/149) — libvirt SSH skips host-key verification (`no_verify=1`)
+- `I1` (PROJECT_CONTEXT, no GitHub issue) — libvirt SSH connectivity to `172.16.56.8` on `vr1.lab.k8` fails with `kex_exchange_identification: Connection closed by remote host`. **Related but distinct** — I1 is the cluster-specific data-plane symptom; #149 is the codebase-level host-key-verification fix. Their interaction is covered in "Interaction with I1" below.
+
+**Companion ADRs**: [ADR-0001](./0001-transport-grpc-and-capi-integration.md) (gRPC transport), [ADR-0003](./0003-mtls-and-provider-grpc-auth.md) (mTLS + provider gRPC auth). ADR-0004 is the **provider→hypervisor** transport-trust sibling of ADR-0003's **manager→provider** transport-trust decision; it deliberately reuses ADR-0003's patterns (secure-by-default + named escape hatch, trust material co-located in the provider's existing Secret, loud-failure-on-missing-material).
+
+### Decisions resolved 2026-05-27
+
+The maintainer accepted every recommendation in this ADR. The Open Questions
+section (preserved at the end) is superseded by this table.
+
+| # | Question | Decision | Reflected in |
+|---|---|---|---|
+| (a) | Backwards-compat option | **Option C** — verify-by-default + named env escape hatch. Existing libvirt SSH Providers break on upgrade unless they supply `known_hosts` or set the escape hatch (intentional; v0.3.7 breaking-change callout). | "Decision" / "Backwards-compat — Option C" |
+| (b) | Escape-hatch mechanism + name | **Env var `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION`** (value `"true"`), settable per-Provider via the existing `spec.runtime.env`. **No CRD change.** | "CRD surface — no schema change" |
+| (c) | `known_hosts` Secret-key name + format | **Key `known_hosts`** (standard OpenSSH line format) in the **existing `credentialSecretRef` Secret**; mounts read-only at `/etc/virtrigaud/credentials/known_hosts` with zero controller change. | "Trust material source" |
+| (d) | First-connect policy | **Hard-fail** with an actionable error on missing/unknown/mismatched host key. **No TOFU.** | "`known_hosts` absent + verification on = loud hard failure" |
+| (e) | Release-note treatment | **Breaking-change callout** in the v0.3.7 release notes, same class as ADR-0003's nil-TLS-block loud failure. | "Consequences (Negative)" |
+
+### Implementation status — as shipped (2026-05-27)
+
+The "Implementation plan" section below preserves the **original design intent**.
+A few details were sharpened during coding; this table is authoritative where it
+conflicts with the per-section "Files touched" notes:
+
+| Area | As planned (below) | As shipped |
+|---|---|---|
+| Where the policy lives | "centralize the on/off decision in `setupConnection`" | A dedicated file `internal/providers/libvirt/sshhostkey.go` holds a `hostKeyPolicy` value (`resolveHostKeyPolicy()`), with `sshHostKeyOptions()` / `sshConfigStanza()` / `applyURIHostKeyOptions()` / `verifyKnownHostsPresent()` / `logVerificationMode()`. `setupConnection` resolves it once into `VirshProvider.hostKey`; **all five** SSH/scp call sites consume that one value. This is stronger than the plan's "one branch in setupConnection" — there is exactly one host-key literal of each kind in the tree, in this file. |
+| Verification-mode log + hard-fail re-emission | logged/checked once at startup in `setupConnection` | `setupConnection` logs + hard-fails for the virsh paths; the scp disk-copy path (`server.go copyDiskToRemote`) **re-emits** the verification-mode audit line and **re-runs** the hard-fail gate before transfer, because scp can be reached independently of the initial connection. |
+| Logging backend | "the libvirt provider uses `slog` — check and match" | The host-key audit log uses `slog` (structured `provider`/`host`/`env_var`/`known_hosts` fields) on an injectable `VirshProvider.logger` (defaults to `slog.Default()`), so the WARN can be asserted via a captured handler in tests. The surrounding legacy `virsh.go`/`server.go` lines still use stdlib `log`; only the audit line was moved to `slog`, to keep the diff focused (no broad logging refactor — out of scope). |
+| Empty `known_hosts` | hard-fail on absent | hard-fail on absent **or empty** (`os.Stat` size == 0): an empty file is no trust material and would silently fall through to ssh's default behaviour otherwise. |
+
+**Interaction with I1 (decision (e), as-shipped):** the hard-fail error and a code
+comment in `sshhostkey.go` (`verifyKnownHostsPresent`) both record that, post-#149,
+an operator hitting I1 with a stale/missing `known_hosts` will now see
+`Host key verification failed` (or the pre-flight error naming the path) instead of
+the old `kex_exchange_identification: Connection closed`. The two failure modes stay
+distinguishable by error string; this is the control working as designed, not a
+regression.
+
+No divergence from the accepted decisions themselves — no CRD change, env-var name
+and Secret-key name as specified, hard-fail (no TOFU), Option C.
+
+---
+
+## Context
+
+VirtRigaud is documented as **deployable in regulated banking environments**. The
+libvirt provider reaches remote libvirt hosts over **SSH** (it is a virsh-CLI-over-SSH
+provider, not a libvirt-go binding — confirmed below). Today that SSH connection is
+made with **host-key verification disabled on every code path**. An attacker who can
+intercept the manager→libvirt-host network (compromised intermediate hop, ARP
+poisoning on the management VLAN, BGP hijack) can present their own SSH host key, and
+the provider connects without warning — leaking the SSH credential and accepting
+injected `virsh` commands against the hypervisor. This is below the bar the project's
+compliance posture claims (NIST 800-53 SC-8 / IA-3 routinely require SSH host-key
+verification in the secure-remote-management baseline).
+
+Unlike ADR-0003 (a *wiring* gap — the machinery existed and just needed connecting),
+#149 is a **default-posture** gap: the code actively and unconditionally opts out of a
+security control. The fix is to flip the default and supply the trust material.
+
+### Transport mechanism — virsh-CLI-over-SSH (this determines everything)
+
+The libvirt provider is **not** libvirt-go with an SSH transport. It shells out to
+`virsh` and `scp`. There are **two distinct execution paths**, and *both* disable
+host-key verification:
+
+1. **Key-based path** — `virsh` is invoked with `LIBVIRT_DEFAULT_URI` set to a
+   `qemu+ssh://...` URI. libvirt's own ssh transport then execs the system `ssh`
+   binary; the `no_verify=1` query parameter in the URI tells it to skip host-key
+   checking. Set at `internal/providers/libvirt/virsh.go:176-177` (URI exported as
+   env) and `:167` (the `no_verify=1`).
+
+2. **Password path** — when a password credential is present, the URI is bypassed
+   entirely. The provider builds explicit `sshpass -e ssh -o ...` argv (for `virsh`)
+   and `sshpass -e scp -o ...` argv (for disk copy), pinning
+   `StrictHostKeyChecking=accept-new` and `UserKnownHostsFile=/tmp/known_hosts` — a
+   trust-on-first-use against an ephemeral, never-persisted file. See
+   `internal/providers/libvirt/virsh.go:255-258, 287-290`,
+   `internal/providers/libvirt/virsh.go:488-492` (the SSH config file), and
+   `internal/providers/libvirt/server.go:694-695, 703-704` (scp).
+
+A complete fix for #149 must therefore close **both** paths. The issue body cites only
+`virsh.go:167`; the password path's `accept-new` + `/tmp/known_hosts` is an equivalent
+gap that the issue does not mention.
+
+### What's broken — evidence table (file:line)
+
+| # | Location | What it does | Why it's a gap |
+|---|---|---|---|
+| 1 | `internal/providers/libvirt/virsh.go:167` | `query.Set("no_verify", "1")` appended unconditionally to every `qemu+ssh://` URI | Key-based path: libvirt's ssh transport skips host-key verification entirely. No `known_hosts` consulted. |
+| 2 | `internal/providers/libvirt/virsh.go:255-258` | direct-command (`!`-prefixed) ssh: `-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known_hosts` | Password path: TOFU against an ephemeral file inside the (read-only-root, `tmp`-emptyDir) pod — first connection always trusts whatever key is presented; file is lost on restart so it is TOFU forever. |
+| 3 | `internal/providers/libvirt/virsh.go:287-290` | virsh-over-ssh: same `accept-new` + `/tmp/known_hosts` | Same as #2, for the primary virsh command path. |
+| 4 | `internal/providers/libvirt/virsh.go:488-492` | `createSSHConfig` writes `StrictHostKeyChecking accept-new` + `UserKnownHostsFile /tmp/known_hosts` into `~/.ssh/config` | Belt-and-suspenders TOFU for any ssh invocation that reads the config. |
+| 5 | `internal/providers/libvirt/server.go:694-695, 703-704` | `scp` for disk-to-remote copy: `accept-new` + `/tmp/known_hosts` | Disk image transfer to the hypervisor over an unverified channel — same MITM exposure, plus tampering of the transferred image. |
+
+### How the SSH key is consumed today (so we know where to add trust material)
+
+- The libvirt credentials Secret is referenced by `Provider.spec.credentialSecretRef`
+  (`api/infra.virtrigaud.io/v1beta1/provider_types.go:221-222`) and mounted by the
+  controller as a read-only volume at **`/etc/virtrigaud/credentials`**
+  (`internal/controller/provider_controller.go:751-755`, volume defined at `:869-875`).
+- The provider reads the SSH private key from the env var
+  `LIBVIRT_SSH_PRIVATE_KEY`, falling back to the mounted file
+  **`/etc/virtrigaud/credentials/ssh-privatekey`** (`internal/providers/libvirt/virsh.go:128-133`).
+  The Secret-key name `ssh-privatekey` was confirmed during the v0.3.6 doc audit and
+  matches Kubernetes' `kubernetes.io/ssh-auth` convention.
+- The same mount also carries `username` and `password`
+  (`internal/providers/libvirt/virsh.go:115-126`).
+
+So a `known_hosts` entry placed in the **same credentials Secret** would mount,
+read-only, at `/etc/virtrigaud/credentials/known_hosts` with **zero controller
+changes** — the whole Secret is already projected into that directory. This is the
+ADR-0003 "trust material co-located in the provider's Secret" pattern applied to SSH.
+
+### Current CRD surface — there is *no* SSH/host-key field today
+
+`Provider.spec` (`provider_types.go`) has `endpoint`, `credentialSecretRef`,
+`runtime` (image/service/env/etc.), `defaults`, `healthCheck`. The only TLS-ish field
+is `runtime.service.tls` (`ProviderTLSSpec`, `:64-78`) — that governs the
+**manager→provider gRPC** channel (ADR-0003), *not* the provider→hypervisor SSH
+channel. There is **no** libvirt-specific block, no `Spec.Libvirt`, no SSH struct.
+Everything libvirt-connection-related is credential-Secret-driven or env-driven today.
+
+This matters for the CRD-surface decision below: adding `Spec.Libvirt.SSH.*` (as the
+issue body sketches) would be a **net-new CRD subtree**, triggering the `crd-update`
+skill and a v1beta1 schema commitment. The env/Secret-driven alternative needs none.
+
+### The escape-hatch precedent (ADR-0003 as-shipped)
+
+ADR-0003 shipped its plaintext escape hatch as an **env var**, not a CRD field:
+`VIRTRIGAUD_PROVIDER_INSECURE` (`sdk/provider/server/tlsconfig.go:61`, mirrored by the
+controller constant `envProviderInsecure` at `provider_controller.go:105`). The
+controller sets it only after `evaluateTLSPosture` confirms an *explicit* opt-out, so
+an undecided Provider can never be silently downgraded
+(`provider_controller.go:670-687`). #149's escape hatch should follow the same shape.
+
+---
+
+## Decision
+
+**Make SSH host-key verification on by default for the libvirt provider, with an
+explicit, audit-flagged, env-driven escape hatch — and no CRD schema change.** Trust
+material (`known_hosts`) is supplied as a new key in the **existing libvirt
+credentials Secret**. Missing trust material with verification on is a **loud,
+actionable hard failure** at provider startup — not TOFU.
+
+This ships in v0.3.7, alongside ADR-0003, because #149 is a documented HIGH-severity
+compliance failure and we should not ship another release with a security control
+actively disabled.
+
+### Backwards-compat — **Option C: verify-by-default with an explicit escape hatch**
+
+Existing v0.3.6 libvirt Providers connect with `no_verify=1` / `accept-new` today.
+Turning verification on is a breaking change for them. The three options (mirroring
+ADR-0003):
+
+| Option | Behaviour for an existing libvirt Provider on upgrade | Trade-off |
+|---|---|---|
+| **(A)** Hard breaking — always verify, no escape | Provider refuses to connect until operator supplies `known_hosts`; no fallback | Loud and correct, but every libvirt upgrade requires operator action *before* the provider can do anything, including mid-migration |
+| **(B)** Opt-in — verify only when `known_hosts` supplied; default stays `no_verify=1` | Silent upgrade, existing Providers keep working unchanged | The compliance gap simply persists; an operator who never supplies `known_hosts` is silently insecure forever — the exact "silent failure mode" #149 calls out |
+| **(C)** Verify-by-default + named escape hatch | Provider refuses to connect unless `known_hosts` is present **or** the operator sets an explicit `*_INSECURE_SKIP_HOST_KEY_VERIFICATION` env opt-out (audit-flagged WARN) | Loud but reversible — operators *can* fall back for lab/migration, but only by typing the word "insecure", leaving an audit trail in logs |
+
+**Option C wins**, and the reasoning is stronger here than the generic banking
+argument:
+
+1. **Consistency with ADR-0003.** Manager→provider (ADR-0003) and provider→hypervisor
+   (#149) are the two transport-trust boundaries in the system. Having one default-on
+   and the other default-off would be incoherent for an auditor.
+2. **The I1 reality argues *for* the escape hatch, not against secure-default.** On
+   `vr1.lab.k8` the libvirt data plane is currently broken (I1). An operator
+   mid-migration, or debugging I1, genuinely needs a way to connect without first
+   nailing down `known_hosts` — Option A would make I1 strictly harder to diagnose by
+   adding a second failure mode on top of the connectivity failure. The escape hatch
+   gives them that, *loudly*, instead of the current *silent* `no_verify=1`.
+3. **Option B keeps the gap.** It is the status quo with extra steps; rejected.
+
+### `known_hosts` absent + verification on = loud hard failure (not TOFU)
+
+When the libvirt provider starts with verification on (the new default) and finds **no**
+`known_hosts` material and **no** explicit insecure opt-out, it **refuses to operate**
+and emits an actionable error — mirroring ADR-0003's `TLSNotConfigured` loud failure:
+
+> `libvirt SSH host-key verification is on (default) but no known_hosts was found at /etc/virtrigaud/credentials/known_hosts. Add a 'known_hosts' key to the credentials Secret (see runbook: ssh-keyscan), or set LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true to connect without verification (audit-flagged, NOT recommended for production).`
+
+**TOFU is rejected.** Trust-on-first-use accepts whatever key the host presents on the
+first connection — which is *exactly* the MITM window #149 is about, just narrowed to
+the first connect. In a hostile network the first connection is precisely when the
+attacker strikes. TOFU also can't be audited (no operator decision is recorded). The
+current `/tmp/known_hosts` behaviour is in fact *worse* than classic TOFU: because
+`/tmp` is an emptyDir that is wiped on pod restart (`provider_controller.go:773-776`,
+`server.go` mounts `tmp`), every restart re-TOFUs. We are removing this.
+
+### Verification-mode startup log line (audit signal)
+
+On startup the provider logs exactly one of:
+
+- `libvirt SSH host-key verification: enabled (known_hosts: /etc/virtrigaud/credentials/known_hosts)`
+- `libvirt SSH host-key verification: DISABLED via LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION` — at WARN level, mirroring ADR-0003's `InsecureSkipVerify` WARN.
+
+Banking auditors grep for this line, same as they grep `TLSConfigured` for ADR-0003.
+
+### How the SSH client is pointed at `known_hosts` (both paths)
+
+Tied to the two transport paths found in the code:
+
+- **Key-based path (URI):** stop appending `no_verify=1`. libvirt's ssh transport
+  reads the standard ssh config / `known_hosts`. Point it explicitly by adding
+  `-o UserKnownHostsFile=/etc/virtrigaud/credentials/known_hosts -o StrictHostKeyChecking=yes`
+  via the ssh-config the provider already writes (`createSSHConfig`,
+  `virsh.go:469-503`) — repurpose that function to write *verifying* config instead of
+  `accept-new`.
+- **Password path (explicit argv):** replace `StrictHostKeyChecking=accept-new` with
+  `StrictHostKeyChecking=yes` and `UserKnownHostsFile=/tmp/known_hosts` with
+  `UserKnownHostsFile=/etc/virtrigaud/credentials/known_hosts` in all four argv
+  builders (`virsh.go:255-260`, `:287-292`, `server.go:693-697`, `:702-707`).
+- **Escape hatch:** when `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true`, restore the
+  *old* behaviour (`no_verify=1` on the URI; `StrictHostKeyChecking=accept-new` on the
+  argv) plus the WARN log. One branch, set once in `setupConnection`.
+
+### Trust material source — new key in the existing credentials Secret
+
+| Option | Verdict | Reason |
+|---|---|---|
+| **New key `known_hosts` in the existing `credentialSecretRef` Secret** | **Chosen** | Already mounted read-only at `/etc/virtrigaud/credentials`; zero controller change; co-located with the SSH key it secures (ADR-0003 pattern). Standard OpenSSH `known_hosts` line format. |
+| Separate ConfigMap (`KnownHostsConfigMapRef`) | Rejected for v0.3.7 | A host *public* key is not secret, so a ConfigMap is defensible — but it needs a *new CRD field* to reference, a second volume/mount in the controller, and splits libvirt trust material across two objects. Not worth the surface for v0.3.7. Can be a follow-up if operators ask. |
+| `Provider` CRD field carrying the host key inline | Rejected | Puts operational trust material in the CR spec (drifts from the Secret-driven credential model), and inline-string host keys are a poor UX vs. `ssh-keyscan` output. Also a v1beta1 schema commitment. |
+
+**Secret-key name:** `known_hosts`. **Format:** standard OpenSSH `known_hosts` lines,
+one host per line:
+
+```
+172.16.56.8 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+vr1.lab.k8,172.16.56.8 ecdsa-sha2-nistp256 AAAAE2VjZHNh...
+```
+
+Multiple lines / multiple key types per host are fine (it is just the standard file).
+The Secret may be `kubernetes.io/ssh-auth` (already used for `ssh-privatekey`) or
+`Opaque` — both project the key into the mount identically.
+
+### CRD surface — **no schema change** (strong preference honoured)
+
+The issue body sketches `Spec.Libvirt.SSH.{SkipHostKeyVerification,KnownHostsSecretRef,KnownHostsConfigMapRef}`.
+This ADR **rejects the new CRD subtree** for v0.3.7, because the same outcome is
+reachable with mechanisms that already exist:
+
+- **Trust material** → new `known_hosts` key in the Secret that
+  `credentialSecretRef` *already* points at. No new ref field needed.
+- **Escape hatch** → env var `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION`, settable
+  per-Provider via the **existing** `spec.runtime.env` field
+  (`provider_types.go:148-151`), exactly the way ADR-0003 surfaces
+  `VIRTRIGAUD_PROVIDER_INSECURE`. The operator writes
+  `runtime.env: [{name: LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION, value: "true"}]`.
+
+This mirrors how ADR-0003 mostly avoided CRD changes. If maintainer review concludes a
+typed CRD field is genuinely required (e.g. to surface a Condition or to validate the
+value), **that is a bigger commitment** — it triggers the `crd-update` skill, a
+`zz_generated.deepcopy.go` regen, Helm CRD sync, and a v1beta1 schema-stability review.
+Flagged loudly as Open Question (b). The ADR's recommendation is to stay
+env/Secret-driven.
+
+> Note: the manager could *optionally* set the env var itself when it detects the
+> known_hosts key is absent and the operator has annotated the Provider — but that
+> reintroduces controller logic. The simplest v0.3.7 shape is: operator sets the env
+> var explicitly via `runtime.env`, provider honours it. No controller change at all.
+
+---
+
+## Bootstrap / first-connect UX
+
+There is no automatic bootstrap. The operator obtains the host key out-of-band and
+seeds the Secret. The runbook shape (pointer-quality, like ADR-0003's openssl recipe):
+
+**1. Scan the libvirt host's key from a trusted bastion / jump host** (NOT from the
+pod — the whole point is an out-of-band trust anchor):
+
+```bash
+ssh-keyscan -t ed25519,ecdsa,rsa 172.16.56.8 > known_hosts
+# Verify the fingerprint against what the libvirt host's admin reports:
+ssh-keygen -lf known_hosts
+```
+
+**2. Put it in the existing credentials Secret** (alongside `ssh-privatekey`):
+
+```bash
+kubectl create secret generic libvirt-creds \
+  --namespace virtrigaud-system \
+  --from-file=ssh-privatekey=./id_ed25519 \
+  --from-file=known_hosts=./known_hosts \
+  --from-literal=username=virtrigaud \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+(Or `kubectl patch`/`kubectl edit` an existing Secret to add the `known_hosts` key.)
+
+**3. Verify** the provider picked it up:
+
+```bash
+kubectl logs deploy/provider-libvirt-... | grep 'host-key verification'
+# expect: libvirt SSH host-key verification: enabled (known_hosts: /etc/virtrigaud/credentials/known_hosts)
+```
+
+Secret-to-pod sync (~60s) re-projects the file without a pod restart, so rotating a
+host key (e.g. after a hypervisor rebuild) is `kubectl apply` + wait — no rollout.
+
+---
+
+## Interaction with I1
+
+This is a **diagnostic note for whoever debugs I1 after #149 lands**, not a fix for I1.
+
+I1 today surfaces as `kex_exchange_identification: Connection closed by remote host` —
+a failure *before* the SSH key exchange completes (host-side sshd config, fail2ban
+rate-limiting, firewall). Host-key verification happens *after* key exchange, so #149
+**does not change the I1 signature** in the I1-as-currently-observed case: a host that
+closes the connection at `kex` never gets far enough to present a host key.
+
+What *will* change: once I1's connectivity is fixed and the host responds normally, an
+operator with a **stale or missing** `known_hosts` entry will now see
+`Host key verification failed` (a clean, post-kex error) instead of the old silent
+`no_verify=1` success. Document this in the I1 ticket so the debugger isn't confused by
+a *new* error appearing after the connectivity fix — it is the security control working
+as designed, not a regression. The two failure modes are orthogonal and distinguishable
+by the error string (`kex_exchange_identification` = connectivity/host-side;
+`Host key verification failed` = trust material mismatch).
+
+This also retroactively validates #149's "operational observation": with verification
+on, the I1-class failure would have been *more* diagnosable (a trust error names the
+problem) rather than masked behind `no_verify=1`.
+
+---
+
+## Implementation plan — single PR
+
+#149 is narrower than ADR-0003 (which needed 4 sequential PRs to wire two ends, an
+auth interceptor, and hot-reload). The host-key change is confined to the libvirt
+provider package plus its docs. **One focused PR.**
+
+**Files touched:**
+- `internal/providers/libvirt/virsh.go` — the crux:
+  - `:167` — gate `no_verify=1` behind the insecure opt-out (default: omit it).
+  - `:255-260`, `:287-292` — `StrictHostKeyChecking=yes` +
+    `UserKnownHostsFile=/etc/virtrigaud/credentials/known_hosts` (insecure path keeps
+    `accept-new` + `/tmp/known_hosts`).
+  - `:469-503` (`createSSHConfig`) — write verifying config; point at the mounted
+    `known_hosts`.
+  - `setupConnection` (`:142-197`) — read the opt-out env var once; emit the
+    verification-mode log line; loud-fail if verification on and `known_hosts` absent.
+- `internal/providers/libvirt/server.go` — `:693-697`, `:702-707` (scp): same argv
+  swap as the virsh path.
+- **No controller change** (the Secret is already mounted; the escape-hatch env var
+  rides the existing `runtime.env` path). No CRD change. No Helm change.
+
+**Tests required** (mirroring ADR-0003's test shape):
+- verification-on + matching `known_hosts` present → URI/argv contain
+  `StrictHostKeyChecking=yes`, point at the mounted file, **no** `no_verify`/`accept-new`.
+- verification-on + `known_hosts` absent + no opt-out → `setupConnection` returns the
+  loud actionable error (assert the message names the path and the env var).
+- escape-hatch env set → URI keeps `no_verify=1` / argv keeps `accept-new`, and a WARN
+  log is emitted (mirror the mTLS `InsecureSkipVerify` WARN test).
+- argv builders for both the `virsh` path and the `scp` path are covered (the issue
+  body misses scp — the test must not).
+- table-test the `setupConnection` env-var parsing (`unset`/`"false"`/`"true"`/`"TRUE"`).
+
+**CHANGELOG shape** (per the strict project format): a `### Security` entry under a
+`## [YYYY-MM-DD HH:MM] - Libvirt SSH host-key verification on by default` header,
+`**Author:** @williamrizzo (William Rizzo)`, `### Why` citing #149 / MITM / banking
+posture, and `### Impact` checking **Breaking change** and **Requires cluster rollout**
+(operators relying on implicit `no_verify=1` must add `known_hosts` or the opt-out env
+before the libvirt provider will connect).
+
+**Rollback:** revert the single PR; libvirt SSH goes back to `no_verify=1` /
+`accept-new` everywhere (v0.3.6 behaviour). No state migration, no CRD rollback.
+
+**Why not >1 PR:** the change is one provider package + tests + docs. There is no
+cross-package contract to sequence (unlike ADR-0003's resolver↔controller↔SDK chain).
+If review decides a typed CRD field *is* required after all, that splits into (1) the
+CRD-field PR (with `crd-update`) and (2) the wiring PR — but the recommendation is to
+avoid that and stay single-PR.
+
+---
+
+## Out of scope
+
+- **The I1 data-plane investigation itself.** I1 is host-side sshd/fail2ban/firewall on
+  `172.16.56.8`, not VirtRigaud code. Tracked separately in PROJECT_CONTEXT. #149 only
+  notes how its failure signature changes post-fix (above).
+- **mTLS / provider-gRPC-auth** (#147/#148, ADR-0003, done) — a different transport
+  boundary (manager→provider, not provider→hypervisor).
+- **Any non-libvirt provider.** vSphere and Proxmox use their own API transports
+  (already TLS-bearing); they have no SSH host-key surface.
+- **A typed CRD `Spec.Libvirt.SSH` block** — explicitly deferred unless maintainer
+  review reverses Open Question (b). The env/Secret mechanism covers v0.3.7.
+- **ConfigMap-based `known_hosts` distribution** — defensible (host public keys aren't
+  secret) but needs a new ref field; deferred to a follow-up if demanded.
+- **Migrating libvirt off virsh-CLI-over-SSH onto a native libvirt-go transport** — a
+  much larger refactor; orthogonal to host-key trust.
+
+---
+
+## Consequences
+
+### Positive
+- **v0.3.7 closes the last disclosed transport-trust gap.** Both the manager→provider
+  (ADR-0003) and provider→hypervisor (#149) channels are secure-by-default, coherent
+  for an auditor.
+- **No CRD schema change.** v1beta1 stays put; no `crd-update` churn; trust material
+  rides the existing credential Secret.
+- **No controller change.** The Secret is already mounted; the escape hatch rides
+  `runtime.env`. The blast radius is one provider package.
+- **Loud, auditable posture.** Startup log line + hard-fail-on-missing-material; an
+  auditor greps one log line, exactly like ADR-0003's `TLSConfigured`.
+- **Removes the worse-than-TOFU `/tmp/known_hosts` re-trust-on-every-restart behaviour.**
+
+### Negative — release-note callout required for v0.3.7
+- **Existing v0.3.6 libvirt Providers that rely on the implicit `no_verify=1` will stop
+  connecting after upgrade until the operator either (a) adds a `known_hosts` key to the
+  credentials Secret OR (b) sets `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true` in
+  `runtime.env`.** This is intentional. **The v0.3.7 release notes must call this out in
+  the same breaking-change callout class as ADR-0003's nil-TLS-block loud failure.**
+- **Two failure modes now exist on the libvirt SSH path** (connectivity vs. host-key
+  mismatch). Mitigated by distinct, greppable error strings (documented under
+  "Interaction with I1").
+- **Operator friction:** seeding `known_hosts` is a manual `ssh-keyscan` + Secret edit.
+  Conscious trade-off; mitigated by the runbook recipe. Same friction class as
+  ADR-0003's manual cert provisioning.
+
+## Security implications summary
+
+| Item | Status after v0.3.7 |
+|---|---|
+| Libvirt SSH host-key verification | **On by default.** Per-Provider opt-out via `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true` (audit-flagged WARN). |
+| Trust material source | New `known_hosts` key in the existing `credentialSecretRef` Secret, mounted read-only at `/etc/virtrigaud/credentials/known_hosts`. |
+| First-connect behaviour | **Hard fail** on missing/mismatched host key. No TOFU. |
+| MITM on the manager→libvirt SSH path | Blocked when verification on (both key-based and password/scp paths). |
+| Disk-image transfer (scp) | Verified host key on the same trust material — closes the gap the issue body omits. |
+| Audit visibility | One startup log line: `libvirt SSH host-key verification: enabled\|DISABLED via ...`. |
+| CRD impact | **None.** No v1beta1 schema change. |
+| Ephemeral `/tmp/known_hosts` re-TOFU on restart | Removed. |
+
+---
+
+## Open Questions (resolved 2026-05-27 — see "Decisions resolved" table at top)
+
+> **Superseded.** All five questions below were resolved by the maintainer on
+> 2026-05-27; the recommendations were accepted verbatim. This section is retained
+> for the design-record trail. See the "Decisions resolved 2026-05-27" table at the
+> top for the binding outcomes.
+
+1. **(a) Backwards-compat option — confirm C.** The ADR recommends Option C
+   (verify-by-default + named env escape hatch), for consistency with ADR-0003 and
+   because the I1 reality argues for a reversible hatch rather than a hard break (A).
+   Confirm, or pick A/B with rationale.
+
+2. **(b) Escape-hatch mechanism + exact name.** The ADR recommends an env var,
+   `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION`, set per-Provider via the existing
+   `spec.runtime.env` — **no CRD change**, mirroring ADR-0003's
+   `VIRTRIGAUD_PROVIDER_INSECURE`. Confirm the name, and confirm we are NOT adding a
+   typed `Spec.Libvirt.SSH.SkipHostKeyVerification` CRD field (which would trigger
+   `crd-update` and a v1beta1 commitment). If you want the typed field, say so — it
+   re-shapes the implementation into two PRs.
+
+3. **(c) `known_hosts` Secret-key name + format.** The ADR recommends key name
+   `known_hosts`, standard OpenSSH `known_hosts` line format, in the existing
+   `credentialSecretRef` Secret (mounts at `/etc/virtrigaud/credentials/known_hosts`).
+   Confirm the key name and that we are reusing the existing Secret (vs. the issue
+   body's `KnownHostsSecretRef`/`KnownHostsConfigMapRef` separate-object approach).
+
+4. **(d) First-connect policy — confirm hard-fail over TOFU.** The ADR rejects TOFU
+   (it preserves the MITM window #149 is about and can't be audited) in favour of a
+   loud hard failure with an actionable message. Confirm, or accept TOFU with rationale.
+
+5. **(e) Release-note treatment — breaking change requiring operator action?** The ADR
+   treats this as the same callout class as ADR-0003's nil-TLS-block loud failure:
+   existing libvirt operators must add `known_hosts` or the opt-out env before upgrade,
+   or the provider stops connecting. Confirm this lands in the v0.3.7 release notes as a
+   loud breaking-change callout (and whether it warrants a pre-upgrade check in the
+   release runbook).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ This directory contains Architecture Decision Records (ADRs) for VirtRigaud. ADR
 | [0001](./0001-transport-grpc-and-capi-integration.md) | Transport choice (gRPC) and CAPI integration layer | Accepted | 2026-05-22 | Settles gRPC as the manager↔provider transport and establishes that a future CAPI provider sits on top of VirtRigaud's CRDs (not gRPC). |
 | [0002](./0002-build-path-consolidation.md) | Consolidate two parallel manager build paths | Accepted | 2026-05-24 | H1 decision: retire the local-dev `cmd/main.go` + root `Dockerfile`; port missing features to the canonical path; shipped PRs 1–4 in v0.3.6; PR-5 (HTTPS-by-default metrics) deferred to v0.4.0. |
 | [0003](./0003-mtls-and-provider-grpc-auth.md) | Wire mTLS and provider gRPC authentication | Accepted | 2026-05-27 | Wire mTLS manager↔provider on the existing CRD surface, TLS-on-by-default (Option C) with per-Provider `tls.enabled=false` escape hatch; `validateTLSPeer` SAN allow-list (permissive empty); manual cert provisioning (no cert-manager template). Code-complete on `main` (PRs #157/#158/#159); targeted at v0.3.7. |
+| [0004](./0004-libvirt-ssh-host-key-verification.md) | Libvirt SSH host-key verification | Accepted | 2026-05-27 | Provider→hypervisor sibling of ADR-0003: libvirt SSH host-key verification on-by-default (Option C), env escape hatch `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true`; `known_hosts` co-located in the existing credentials Secret; hard-fail (no TOFU) on missing trust material; no CRD change. Closes #149; targeted at v0.3.7. |
 
 ## Contributing an ADR
 

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -634,9 +634,9 @@ func (s *Server) ListVMs(ctx context.Context, req *providerv1.ListVMsRequest) (*
 		var protoNetworks []*providerv1.NetworkInfo
 		for _, net := range vmInfo.Networks {
 			protoNetworks = append(protoNetworks, &providerv1.NetworkInfo{
-				Name:       net.Name,
-				Mac:        net.MAC,
-				IpAddress:  net.IPAddress,
+				Name:      net.Name,
+				Mac:       net.MAC,
+				IpAddress: net.IPAddress,
 			})
 		}
 
@@ -685,27 +685,34 @@ func (s *Server) copyDiskToRemote(ctx context.Context, virshProvider *VirshProvi
 
 	// Copy disk file using scp (run locally from the pod, not through SSH)
 	log.Printf("INFO Copying disk file (%s) to remote host via scp...", localPath)
-	
+
+	// Host-key options come from the same centralized policy as the virsh
+	// paths (#149/ADR-0004) so the disk-image transfer is verified against the
+	// same trust material. Re-emit the verification-mode audit line for the scp
+	// connection and hard-fail before transfer if verification is on but no
+	// usable known_hosts is present (no TOFU).
+	virshProvider.hostKey.logVerificationMode(virshProvider.logger, host)
+	if err := virshProvider.hostKey.verifyKnownHostsPresent(host); err != nil {
+		return "", fmt.Errorf("libvirt scp host-key verification pre-flight failed: %w", err)
+	}
+	hostKeyOpts := virshProvider.hostKey.sshHostKeyOptions()
+
 	// Run scp LOCALLY on the pod to copy to remote host
 	var cmd *exec.Cmd
 	if virshProvider.credentials.Password != "" {
 		// Use sshpass with scp for password authentication
-		cmd = exec.CommandContext(ctx, "sshpass", "-e", "scp",
-			"-o", "StrictHostKeyChecking=accept-new",
-			"-o", "UserKnownHostsFile=/tmp/known_hosts",
-			localPath,
-			fmt.Sprintf("%s:%s", sshTarget, remotePath))
+		scpArgs := append([]string{"-e", "scp"}, hostKeyOpts...)
+		scpArgs = append(scpArgs, localPath, fmt.Sprintf("%s:%s", sshTarget, remotePath))
+		cmd = exec.CommandContext(ctx, "sshpass", scpArgs...)
 		// Set password via environment variable for sshpass
 		cmd.Env = append(os.Environ(), fmt.Sprintf("SSHPASS=%s", virshProvider.credentials.Password))
 	} else {
 		// Fallback to scp without sshpass (for key-based auth)
-		cmd = exec.CommandContext(ctx, "scp",
-			"-o", "StrictHostKeyChecking=accept-new",
-			"-o", "UserKnownHostsFile=/tmp/known_hosts",
-			localPath,
-			fmt.Sprintf("%s:%s", sshTarget, remotePath))
+		scpArgs := append([]string{}, hostKeyOpts...)
+		scpArgs = append(scpArgs, localPath, fmt.Sprintf("%s:%s", sshTarget, remotePath))
+		cmd = exec.CommandContext(ctx, "scp", scpArgs...)
 	}
-	
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("scp failed: %w, output: %s", err, string(output))

--- a/internal/providers/libvirt/sshhostkey.go
+++ b/internal/providers/libvirt/sshhostkey.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SSH host-key verification policy for the libvirt provider (ADR-0004, #149).
+//
+// VirtRigaud's libvirt provider is a virsh-CLI-over-SSH provider: it shells out
+// to `ssh`/`scp` (directly via sshpass for the password path, or implicitly via
+// libvirt's own qemu+ssh:// transport for the key-based path). Historically every
+// one of those code paths disabled SSH host-key verification — `no_verify=1` on
+// the URI, `StrictHostKeyChecking=accept-new` + an ephemeral `/tmp/known_hosts`
+// on the argv paths — leaving the manager→hypervisor channel open to MITM.
+//
+// This file is the SINGLE source of truth for the host-key policy. Every SSH/scp
+// call site MUST route its host-key options through this helper so the on/off
+// decision and the known_hosts location live in exactly one place (per the
+// project rule: global constants for repeated literals, no duplicated ssh option
+// strings). Five independently-maintained host-key policies is how #149 happened
+// in the first place.
+const (
+	// EnvInsecureSkipHostKeyVerification is the explicit, audit-flagged escape
+	// hatch. When set to "true" (case-insensitive, whitespace-trimmed) the
+	// provider connects with host-key verification DISABLED and emits a loud
+	// WARN log on every connection. It is settable per-Provider via the
+	// existing spec.runtime.env field, mirroring ADR-0003's
+	// VIRTRIGAUD_PROVIDER_INSECURE. Any other value (unset, "false", "1",
+	// "yes") keeps verification ON. We deliberately require the literal word
+	// "true" so the operator's intent is unambiguous and greppable in audit
+	// logs.
+	EnvInsecureSkipHostKeyVerification = "LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION"
+
+	// KnownHostsFile is the in-pod path at which the verifying host-key
+	// material is read. It lives inside the existing credentials Secret mount
+	// (CredentialsPath, /etc/virtrigaud/credentials), so an operator who adds a
+	// `known_hosts` key to the Provider's credentialSecretRef Secret gets it
+	// projected here read-only with ZERO controller/mount changes (ADR-0004,
+	// "trust material co-located in the provider's Secret").
+	KnownHostsFile = CredentialsPath + "/known_hosts"
+
+	// insecureKnownHostsFile is the ephemeral, never-persisted known_hosts file
+	// used only on the insecure (escape-hatch) path. It is an emptyDir-backed
+	// path that is wiped on pod restart; that re-trust-on-every-restart
+	// behaviour is exactly why it MUST NOT be used on the verifying path.
+	insecureKnownHostsFile = "/tmp/known_hosts"
+
+	// strictYes / strictAcceptNew are the two StrictHostKeyChecking values the
+	// helper selects between.
+	strictYes       = "yes"
+	strictAcceptNew = "accept-new"
+)
+
+// hostKeyPolicy captures the resolved SSH host-key verification posture for a
+// single provider process. It is computed once (resolveHostKeyPolicy) and then
+// consulted by every SSH/scp call site so the decision is taken in exactly one
+// place.
+type hostKeyPolicy struct {
+	// insecure is true when EnvInsecureSkipHostKeyVerification=true; host-key
+	// verification is disabled and a WARN is logged on every connection.
+	insecure bool
+}
+
+// resolveHostKeyPolicy reads the escape-hatch env var once and returns the
+// effective host-key policy. Verification is ON unless the operator has
+// explicitly opted out with EnvInsecureSkipHostKeyVerification=true.
+//
+// The "true"-only check mirrors ADR-0003's isInsecureOptedIn: we match the exact
+// word "true" (case-insensitive, trimmed) rather than any truthy value, so the
+// operator's opt-out is deliberate and auditable.
+func resolveHostKeyPolicy() hostKeyPolicy {
+	return hostKeyPolicy{
+		insecure: strings.EqualFold(strings.TrimSpace(os.Getenv(EnvInsecureSkipHostKeyVerification)), "true"),
+	}
+}
+
+// strictHostKeyChecking returns the StrictHostKeyChecking value for the policy:
+// "yes" when verifying, "accept-new" (legacy TOFU) on the insecure path.
+func (p hostKeyPolicy) strictHostKeyChecking() string {
+	if p.insecure {
+		return strictAcceptNew
+	}
+	return strictYes
+}
+
+// knownHostsFile returns the UserKnownHostsFile path for the policy: the
+// credentials-mounted, operator-supplied file when verifying; the ephemeral
+// /tmp file on the insecure path.
+func (p hostKeyPolicy) knownHostsFile() string {
+	if p.insecure {
+		return insecureKnownHostsFile
+	}
+	return KnownHostsFile
+}
+
+// sshHostKeyOptions returns the `ssh`/`scp` `-o key=value` flag pairs that
+// enforce the policy. The slice is laid out as alternating ["-o", "k=v", ...]
+// so it can be spread directly into an argv builder (sshpass/ssh/scp). Both the
+// password (sshpass) virsh path and the scp disk-copy path consume this.
+func (p hostKeyPolicy) sshHostKeyOptions() []string {
+	return []string{
+		"-o", "StrictHostKeyChecking=" + p.strictHostKeyChecking(),
+		"-o", "UserKnownHostsFile=" + p.knownHostsFile(),
+	}
+}
+
+// sshConfigStanza returns the body written into the provider's ~/.ssh/config so
+// any ssh invocation that reads the config (notably libvirt's own qemu+ssh://
+// transport) honours the same host-key policy as the explicit-argv paths.
+func (p hostKeyPolicy) sshConfigStanza() string {
+	return fmt.Sprintf(`Host *
+    StrictHostKeyChecking %s
+    PasswordAuthentication yes
+    PubkeyAuthentication no
+    UserKnownHostsFile %s
+    LogLevel ERROR
+`, p.strictHostKeyChecking(), p.knownHostsFile())
+}
+
+// applyURIHostKeyOptions sets the host-key-related query parameters on the
+// qemu+ssh:// URI used by libvirt's key-based transport. On the insecure path it
+// restores the legacy `no_verify=1`; on the verifying path it omits no_verify
+// entirely (so libvirt's ssh transport falls through to the verifying ~/.ssh/config
+// + known_hosts written by createSSHConfig). The caller owns no_tty.
+func (p hostKeyPolicy) applyURIHostKeyOptions(query interface {
+	Set(key, value string)
+	Del(key string)
+}) {
+	if p.insecure {
+		query.Set("no_verify", "1")
+	} else {
+		query.Del("no_verify")
+	}
+}
+
+// verifyKnownHostsPresent is the loud, actionable hard-fail gate. When
+// verification is ON it requires that a non-empty known_hosts file is present at
+// KnownHostsFile; otherwise it returns an error that names (a) the host, (b) the
+// expected file path, (c) the ssh-keyscan recipe to populate it, and (d) the
+// escape-hatch env var as the explicit opt-out. On the insecure path it is a
+// no-op (the WARN log carries the audit signal instead).
+//
+// We deliberately reject trust-on-first-use: TOFU accepts whatever key the host
+// presents on the first connection, which is exactly the MITM window #149 is
+// about. The hard fail forces the operator to seed an out-of-band trust anchor.
+//
+// Interaction with I1 (ADR-0004): post-#149, an operator hitting the I1 libvirt
+// connectivity failure with a stale/missing known_hosts will see a clean
+// "Host key verification failed" (or this pre-flight error) instead of the old
+// silent no_verify=1 success. That is the security control working as designed,
+// not a regression — the two failure modes are distinguishable by error string
+// (kex_exchange_identification = connectivity/host-side; host-key = trust
+// material).
+func (p hostKeyPolicy) verifyKnownHostsPresent(host string) error {
+	if p.insecure {
+		return nil
+	}
+
+	// A present, non-empty file is the only acceptable state. A missing file,
+	// or a file that exists but is empty (no trust material), both fall through
+	// to the actionable hard-fail error below.
+	if info, err := os.Stat(filepath.Clean(KnownHostsFile)); err == nil && info.Size() > 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"libvirt SSH host-key verification is on (default) but no usable known_hosts "+
+			"was found at %s for host %q. Seed it from a trusted bastion with "+
+			"`ssh-keyscan -H %s >> known_hosts` and add it as the `known_hosts` key in the "+
+			"credentials Secret referenced by the Provider's credentialSecretRef, OR set "+
+			"%s=true to connect without verification (audit-flagged, NOT recommended for production)",
+		KnownHostsFile, host, host, EnvInsecureSkipHostKeyVerification,
+	)
+}
+
+// logVerificationMode emits exactly one startup/connect audit line for the
+// policy. Banking auditors grep for this line, the same way they grep
+// ADR-0003's TLSConfigured. On the insecure path it is a loud WARN that names
+// the MITM exposure, that it is audit-flagged, and that it is intended only for
+// lab/migration; on the verifying path it is an INFO naming the known_hosts
+// path. Structured fields carry the host and provider for correlation.
+func (p hostKeyPolicy) logVerificationMode(logger *slog.Logger, host string) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if p.insecure {
+		logger.Warn("LIBVIRT SSH HOST-KEY VERIFICATION DISABLED: "+
+			"connecting without verifying the hypervisor's SSH host key. "+
+			"The manager→hypervisor SSH/scp channel is exposed to MITM (credential leak + injected virsh/disk-image tampering). "+
+			"This is audit-flagged per ADR-0004 and intended ONLY for lab/migration. "+
+			"Unset "+EnvInsecureSkipHostKeyVerification+" and seed known_hosts to re-enable verification.",
+			"provider", "libvirt",
+			"host", host,
+			"env_var", EnvInsecureSkipHostKeyVerification,
+		)
+		return
+	}
+	logger.Info("libvirt SSH host-key verification: enabled",
+		"provider", "libvirt",
+		"host", host,
+		"known_hosts", KnownHostsFile,
+	)
+}

--- a/internal/providers/libvirt/sshhostkey_test.go
+++ b/internal/providers/libvirt/sshhostkey_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"bytes"
+	"log/slog"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// optsToString flattens the alternating ["-o", "k=v", ...] option slice into a
+// single space-joined string for easy substring assertions.
+func optsToString(opts []string) string {
+	return strings.Join(opts, " ")
+}
+
+// TestResolveHostKeyPolicy_EnvParsing verifies the escape-hatch env var is
+// honoured ONLY for the literal word "true" (case-insensitive, trimmed) and
+// keeps verification ON for every other value. Mirrors ADR-0003's
+// isInsecureOptedIn semantics.
+func TestResolveHostKeyPolicy_EnvParsing(t *testing.T) {
+	tests := []struct {
+		name         string
+		setEnv       bool
+		envValue     string
+		wantInsecure bool
+	}{
+		{name: "unset -> verify", setEnv: false, wantInsecure: false},
+		{name: "empty -> verify", setEnv: true, envValue: "", wantInsecure: false},
+		{name: "false -> verify", setEnv: true, envValue: "false", wantInsecure: false},
+		{name: "1 -> verify (not the word true)", setEnv: true, envValue: "1", wantInsecure: false},
+		{name: "yes -> verify (not the word true)", setEnv: true, envValue: "yes", wantInsecure: false},
+		{name: "true -> insecure", setEnv: true, envValue: "true", wantInsecure: true},
+		{name: "TRUE -> insecure (case-insensitive)", setEnv: true, envValue: "TRUE", wantInsecure: true},
+		{name: "  true  -> insecure (trimmed)", setEnv: true, envValue: "  true  ", wantInsecure: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(EnvInsecureSkipHostKeyVerification, tt.envValue)
+			} else {
+				// Ensure a clean env even if the host has it set.
+				t.Setenv(EnvInsecureSkipHostKeyVerification, "")
+			}
+			policy := resolveHostKeyPolicy()
+			assert.Equal(t, tt.wantInsecure, policy.insecure)
+		})
+	}
+}
+
+// TestHostKeyPolicy_SSHHostKeyOptions_Verifying asserts the verifying policy
+// produces StrictHostKeyChecking=yes pointing at the credentials-mounted
+// known_hosts, and never emits the insecure literals. This covers the password
+// (sshpass/ssh) and scp transports, which both consume sshHostKeyOptions.
+func TestHostKeyPolicy_SSHHostKeyOptions_Verifying(t *testing.T) {
+	policy := hostKeyPolicy{insecure: false}
+	opts := optsToString(policy.sshHostKeyOptions())
+
+	assert.Contains(t, opts, "StrictHostKeyChecking=yes")
+	assert.Contains(t, opts, "UserKnownHostsFile="+KnownHostsFile)
+	assert.Equal(t, "/etc/virtrigaud/credentials/known_hosts", KnownHostsFile,
+		"known_hosts must resolve inside the existing credentials mount")
+
+	assert.NotContains(t, opts, "accept-new")
+	assert.NotContains(t, opts, "/tmp/known_hosts")
+	assert.NotContains(t, opts, "no_verify")
+}
+
+// TestHostKeyPolicy_SSHHostKeyOptions_Insecure asserts the escape-hatch policy
+// restores the legacy accept-new + ephemeral known_hosts behaviour.
+func TestHostKeyPolicy_SSHHostKeyOptions_Insecure(t *testing.T) {
+	policy := hostKeyPolicy{insecure: true}
+	opts := optsToString(policy.sshHostKeyOptions())
+
+	assert.Contains(t, opts, "StrictHostKeyChecking=accept-new")
+	assert.Contains(t, opts, "UserKnownHostsFile=/tmp/known_hosts")
+	assert.NotContains(t, opts, "StrictHostKeyChecking=yes")
+}
+
+// TestHostKeyPolicy_SSHConfigStanza covers the ~/.ssh/config body used by the
+// key-based qemu+ssh:// transport for both policies.
+func TestHostKeyPolicy_SSHConfigStanza(t *testing.T) {
+	verifying := hostKeyPolicy{insecure: false}.sshConfigStanza()
+	assert.Contains(t, verifying, "StrictHostKeyChecking yes")
+	assert.Contains(t, verifying, "UserKnownHostsFile "+KnownHostsFile)
+	assert.NotContains(t, verifying, "accept-new")
+	assert.NotContains(t, verifying, "/tmp/known_hosts")
+
+	insecure := hostKeyPolicy{insecure: true}.sshConfigStanza()
+	assert.Contains(t, insecure, "StrictHostKeyChecking accept-new")
+	assert.Contains(t, insecure, "UserKnownHostsFile /tmp/known_hosts")
+}
+
+// TestHostKeyPolicy_ApplyURIHostKeyOptions covers the key-based URI transport:
+// no_verify=1 is set ONLY on the insecure path and deleted on the verifying
+// path.
+func TestHostKeyPolicy_ApplyURIHostKeyOptions(t *testing.T) {
+	t.Run("verifying drops no_verify", func(t *testing.T) {
+		q := url.Values{}
+		q.Set("no_verify", "1") // simulate a legacy/leftover value
+		hostKeyPolicy{insecure: false}.applyURIHostKeyOptions(q)
+		assert.Empty(t, q.Get("no_verify"))
+	})
+
+	t.Run("insecure sets no_verify", func(t *testing.T) {
+		q := url.Values{}
+		hostKeyPolicy{insecure: true}.applyURIHostKeyOptions(q)
+		assert.Equal(t, "1", q.Get("no_verify"))
+	})
+}
+
+// TestHostKeyPolicy_VerifyKnownHostsPresent covers the loud hard-fail gate.
+func TestHostKeyPolicy_VerifyKnownHostsPresent(t *testing.T) {
+	t.Run("insecure path is a no-op", func(t *testing.T) {
+		err := hostKeyPolicy{insecure: true}.verifyKnownHostsPresent("172.16.56.8")
+		assert.NoError(t, err)
+	})
+
+	t.Run("verifying + missing known_hosts -> actionable error", func(t *testing.T) {
+		// KnownHostsFile points at /etc/virtrigaud/credentials/known_hosts,
+		// which does not exist in the test environment.
+		err := hostKeyPolicy{insecure: false}.verifyKnownHostsPresent("172.16.56.8")
+		require.Error(t, err)
+		msg := err.Error()
+		// (a) names the host
+		assert.Contains(t, msg, "172.16.56.8")
+		// (b) names the expected file path
+		assert.Contains(t, msg, KnownHostsFile)
+		// (c) gives the ssh-keyscan recipe
+		assert.Contains(t, msg, "ssh-keyscan")
+		// (d) names the escape-hatch env var as the explicit opt-out
+		assert.Contains(t, msg, EnvInsecureSkipHostKeyVerification)
+	})
+}
+
+// TestHostKeyPolicy_LogVerificationMode_WARN asserts that the escape hatch
+// fires a WARN log carrying the audit signal (provider + host structured
+// fields, MITM wording, env-var name). Captured via an in-memory slog handler.
+func TestHostKeyPolicy_LogVerificationMode_WARN(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	hostKeyPolicy{insecure: true}.logVerificationMode(logger, "172.16.56.8")
+
+	out := buf.String()
+	assert.Contains(t, out, "level=WARN")
+	assert.Contains(t, out, "DISABLED")
+	assert.Contains(t, out, "MITM")
+	assert.Contains(t, out, "audit-flagged")
+	assert.Contains(t, out, "provider=libvirt")
+	assert.Contains(t, out, "host=172.16.56.8")
+	assert.Contains(t, out, EnvInsecureSkipHostKeyVerification)
+}
+
+// TestHostKeyPolicy_LogVerificationMode_INFO asserts the verifying path logs an
+// INFO line naming the known_hosts path (the auditor's greppable signal).
+func TestHostKeyPolicy_LogVerificationMode_INFO(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	hostKeyPolicy{insecure: false}.logVerificationMode(logger, "172.16.56.8")
+
+	out := buf.String()
+	assert.Contains(t, out, "level=INFO")
+	assert.Contains(t, out, "host-key verification: enabled")
+	assert.Contains(t, out, "known_hosts="+KnownHostsFile)
+	assert.NotContains(t, out, "level=WARN")
+}
+
+// TestHostKeyPolicy_LogVerificationMode_NilLogger ensures a nil logger does not
+// panic (falls back to slog.Default()).
+func TestHostKeyPolicy_LogVerificationMode_NilLogger(t *testing.T) {
+	assert.NotPanics(t, func() {
+		hostKeyPolicy{insecure: false}.logVerificationMode(nil, "host")
+		hostKeyPolicy{insecure: true}.logVerificationMode(nil, "host")
+	})
+}
+
+// TestSetupConnection_VerifyingMissingKnownHosts_HardFails is the integration
+// point: with verification on (default) and no known_hosts on disk, setting up
+// an SSH-based connection must hard-fail with the actionable error rather than
+// silently connecting insecurely.
+func TestSetupConnection_VerifyingMissingKnownHosts_HardFails(t *testing.T) {
+	t.Setenv(EnvInsecureSkipHostKeyVerification, "") // verification ON (default)
+
+	v := &VirshProvider{
+		config: &ProviderConfig{
+			Spec: ProviderSpec{Endpoint: "qemu+ssh://virtrigaud@172.16.56.8/system"},
+		},
+		credentials: &Credentials{Username: "virtrigaud"},
+	}
+
+	err := v.setupConnection()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host-key verification")
+	assert.Contains(t, err.Error(), KnownHostsFile)
+	assert.Contains(t, err.Error(), EnvInsecureSkipHostKeyVerification)
+}
+
+// TestSetupConnection_EscapeHatch_SetsNoVerify confirms that with the escape
+// hatch engaged the URI carries no_verify=1 (legacy behaviour) and the missing
+// known_hosts does NOT block startup.
+func TestSetupConnection_EscapeHatch_SetsNoVerify(t *testing.T) {
+	t.Setenv(EnvInsecureSkipHostKeyVerification, "true")
+
+	v := &VirshProvider{
+		config: &ProviderConfig{
+			Spec: ProviderSpec{Endpoint: "qemu+ssh://virtrigaud@172.16.56.8/system"},
+		},
+		credentials: &Credentials{Username: "virtrigaud"},
+	}
+
+	err := v.setupConnection()
+	require.NoError(t, err)
+	assert.Contains(t, v.uri, "no_verify=1")
+	assert.True(t, v.hostKey.insecure)
+}
+
+// TestSetupConnection_VerifyingLocalURI_NoSSH confirms a local (non-SSH) URI is
+// unaffected by the host-key policy (no known_hosts requirement, no no_verify).
+func TestSetupConnection_VerifyingLocalURI_NoSSH(t *testing.T) {
+	t.Setenv(EnvInsecureSkipHostKeyVerification, "")
+
+	v := &VirshProvider{
+		config:      &ProviderConfig{Spec: ProviderSpec{Endpoint: "qemu:///system"}},
+		credentials: &Credentials{},
+	}
+
+	err := v.setupConnection()
+	require.NoError(t, err)
+	assert.NotContains(t, v.uri, "no_verify")
+}

--- a/internal/providers/libvirt/virsh.go
+++ b/internal/providers/libvirt/virsh.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/url"
 	"os"
 	"os/exec"
@@ -34,6 +35,16 @@ type VirshProvider struct {
 	credentials *Credentials
 	uri         string
 	env         []string
+
+	// hostKey is the resolved SSH host-key verification policy (ADR-0004,
+	// #149). It is computed once in setupConnection and consumed by every
+	// SSH/scp call site so the on/off decision lives in exactly one place.
+	hostKey hostKeyPolicy
+
+	// logger is used for the structured host-key verification-mode audit log
+	// (WARN on the escape hatch, INFO when verifying). Defaults to
+	// slog.Default() when nil.
+	logger *slog.Logger
 }
 
 // VirshDomain represents a VM domain from virsh list output
@@ -139,8 +150,19 @@ func (v *VirshProvider) loadCredentialsFromEnv() error {
 	return nil
 }
 
-// setupConnection prepares the libvirt URI and environment for virsh commands
+// setupConnection prepares the libvirt URI and environment for virsh commands.
+//
+// As of #149 / ADR-0004 it also resolves the SSH host-key verification policy
+// (default ON; opt-out via LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true),
+// emits the one-line verification-mode audit log, points the SSH transport at
+// the credentials-mounted known_hosts, and hard-fails (no TOFU) when
+// verification is on but no usable known_hosts material is present.
 func (v *VirshProvider) setupConnection() error {
+	// Resolve the host-key verification policy once for this provider process.
+	// Every SSH/scp call site consumes v.hostKey so the decision is taken here
+	// and nowhere else.
+	v.hostKey = resolveHostKeyPolicy()
+
 	// Get base URI from config
 	uri := v.config.Spec.Endpoint
 	if uri == "" {
@@ -161,12 +183,24 @@ func (v *VirshProvider) setupConnection() error {
 		}
 	}
 
-	// Add SSH options for container environments
+	// Add SSH options for container environments. Host-key handling is delegated
+	// to the centralized policy: insecure path restores no_verify=1, the
+	// verifying path omits it and relies on the verifying ~/.ssh/config +
+	// known_hosts written below.
 	if strings.Contains(parsedURI.Scheme, "ssh") {
 		query := parsedURI.Query()
-		query.Set("no_verify", "1") // Skip host key verification
-		query.Set("no_tty", "1")    // Non-interactive mode
+		v.hostKey.applyURIHostKeyOptions(query)
+		query.Set("no_tty", "1") // Non-interactive mode
 		parsedURI.RawQuery = query.Encode()
+
+		// Emit the one-line host-key verification-mode audit log (WARN on the
+		// escape hatch, INFO when verifying) and hard-fail if verification is on
+		// but no usable known_hosts is present (no TOFU).
+		v.hostKey.logVerificationMode(v.logger, parsedURI.Host)
+		if err := v.hostKey.verifyKnownHostsPresent(parsedURI.Host); err != nil {
+			return fmt.Errorf("libvirt SSH host-key verification pre-flight failed: %w", err)
+		}
+
 		log.Printf("INFO Added SSH options for container environment")
 	}
 
@@ -252,13 +286,13 @@ func (v *VirshProvider) runVirshCommand(ctx context.Context, args ...string) (*V
 			sshArgs := []string{
 				"-e", // Read password from SSHPASS environment variable
 				"ssh",
-				"-o", "StrictHostKeyChecking=accept-new",
 				"-o", "PasswordAuthentication=yes",
 				"-o", "PubkeyAuthentication=no",
-				"-o", "UserKnownHostsFile=/tmp/known_hosts",
 				"-o", "LogLevel=ERROR",
-				fmt.Sprintf("%s@%s", user, host),
 			}
+			// Host-key options come from the centralized policy (#149/ADR-0004).
+			sshArgs = append(sshArgs, v.hostKey.sshHostKeyOptions()...)
+			sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host))
 			sshArgs = append(sshArgs, directArgs...)
 
 			cmd = exec.CommandContext(ctx, "sshpass", sshArgs...)
@@ -284,14 +318,13 @@ func (v *VirshProvider) runVirshCommand(ctx context.Context, args ...string) (*V
 			sshArgs := []string{
 				"-e", // Read password from SSHPASS environment variable
 				"ssh",
-				"-o", "StrictHostKeyChecking=accept-new",
 				"-o", "PasswordAuthentication=yes",
 				"-o", "PubkeyAuthentication=no",
-				"-o", "UserKnownHostsFile=/tmp/known_hosts",
 				"-o", "LogLevel=ERROR",
-				fmt.Sprintf("%s@%s", user, host),
-				"virsh",
 			}
+			// Host-key options come from the centralized policy (#149/ADR-0004).
+			sshArgs = append(sshArgs, v.hostKey.sshHostKeyOptions()...)
+			sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host), "virsh")
 			sshArgs = append(sshArgs, args...)
 
 			cmd = exec.CommandContext(ctx, "sshpass", sshArgs...)
@@ -465,7 +498,11 @@ func (v *VirshProvider) getDomainInfo(ctx context.Context, domainName string) (m
 	return info, nil
 }
 
-// createSSHConfig creates an SSH configuration file for non-interactive authentication
+// createSSHConfig writes an SSH configuration file for non-interactive
+// authentication that honours the centralized host-key verification policy
+// (#149/ADR-0004). It is consumed by libvirt's own qemu+ssh:// transport (the
+// key-based path), so the config must enforce the same StrictHostKeyChecking +
+// UserKnownHostsFile that the explicit-argv password/scp paths use.
 func (v *VirshProvider) createSSHConfig() error {
 	sshDir := "/home/app/.ssh"
 	configPath := sshDir + "/config"
@@ -484,21 +521,18 @@ func (v *VirshProvider) createSSHConfig() error {
 		log.Printf("INFO Using /tmp as HOME for SSH config")
 	}
 
-	// SSH config content for automatic host key acceptance
-	sshConfig := `Host *
-    StrictHostKeyChecking accept-new
-    PasswordAuthentication yes
-    PubkeyAuthentication no
-    UserKnownHostsFile /tmp/known_hosts
-    LogLevel ERROR
-`
+	// SSH config content honouring the centralized host-key policy
+	// (#149/ADR-0004). Verifying by default (StrictHostKeyChecking yes +
+	// credentials-mounted known_hosts); legacy accept-new + /tmp/known_hosts
+	// only on the explicit escape-hatch path.
+	sshConfig := v.hostKey.sshConfigStanza()
 
 	// Write SSH config file
 	if err := os.WriteFile(configPath, []byte(sshConfig), 0600); err != nil {
 		return fmt.Errorf("failed to write SSH config: %w", err)
 	}
 
-	log.Printf("INFO Created SSH config at %s for automatic host key acceptance", configPath)
+	log.Printf("INFO Created SSH config at %s honouring host-key policy", configPath)
 	return nil
 }
 


### PR DESCRIPTION
Closes #149.

Last HIGH-severity item from the v0.3.6 security audit. The libvirt provider is a virsh-CLI-over-SSH provider that disabled SSH host-key verification on **every** code path, leaving the manager→hypervisor channel open to MITM (SSH credential leak + injected `virsh`/disk-image tampering). This flips verification **on by default** per **ADR-0004** (Accepted 2026-05-27), the provider→hypervisor sibling of ADR-0003's manager→provider mTLS work.

## Summary

### All FIVE bypass paths closed, routed through ONE centralized helper
The bug existed because five independently-maintained host-key policies drifted. They now all consume a single `hostKeyPolicy` value resolved once in `setupConnection` (new file `internal/providers/libvirt/sshhostkey.go`):

| # | Location | Was | Now |
|---|----------|-----|-----|
| 1 | `virsh.go` URI builder | unconditional `no_verify=1` | policy-gated (omitted when verifying) |
| 2 | `virsh.go` `!`-direct ssh argv | `accept-new` + `/tmp/known_hosts` | `policy.sshHostKeyOptions()` |
| 3 | `virsh.go` standard virsh-over-ssh argv | `accept-new` + `/tmp/known_hosts` | `policy.sshHostKeyOptions()` |
| 4 | `virsh.go` `createSSHConfig` (`~/.ssh/config`) | `accept-new` + `/tmp/known_hosts` | `policy.sshConfigStanza()` |
| 5 | `server.go` `copyDiskToRemote` scp (sshpass + key fallback) | `accept-new` + `/tmp/known_hosts` | `policy.sshHostKeyOptions()` + re-emitted audit line + re-run hard-fail gate |

There is now exactly one host-key literal of each kind in the tree — in the helper.

### Option C + named escape hatch
Secure-by-default. The single, audit-visible opt-out is env var `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true` (honoured only for the literal word `true`, case-insensitive/trimmed — mirrors ADR-0003's `isInsecureOptedIn`), settable per-Provider via the existing `spec.runtime.env`. **No CRD change.** When engaged it restores the legacy insecure behaviour but logs a loud WARN on every connect/scp.

### known_hosts source
New `known_hosts` key in the **existing** `credentialSecretRef` Secret; mounts read-only at `/etc/virtrigaud/credentials/known_hosts`. Zero controller/mount change.

### Hard-fail UX (no TOFU)
When verification is on and `known_hosts` is missing or empty, the provider hard-fails with an actionable error naming (a) the host, (b) the expected path, (c) the `ssh-keyscan -H <host> >> known_hosts` recipe, and (d) the escape-hatch env var. TOFU is rejected — it preserves the exact MITM window #149 is about.

### ADR-0004 promotion
Flipped to Accepted (2026-05-27), Open Questions → "Decisions resolved" table, added an "Implementation status — as shipped" note (centralized helper, scp re-emit, `slog` audit, empty-file hard-fail, I1 interaction). Promoted to `docs/adr/0004-libvirt-ssh-host-key-verification.md` and indexed in `docs/adr/README.md`.

### Interaction with I1
Post-#149, an operator hitting the I1 libvirt connectivity failure with a stale/missing `known_hosts` will see a clean `Host key verification failed` (or the pre-flight error naming the path) instead of the old `kex_exchange_identification: Connection closed`. Recorded in the ADR and a code comment so I1 debugging isn't confused — the two failure modes stay distinguishable by error string.

## Breaking change for v0.3.7 release notes

**Existing v0.3.6 libvirt Providers that connect over SSH and relied on the implicit `no_verify=1` will STOP connecting after upgrade** until the operator either (a) adds a `known_hosts` key to the credentials Secret (`ssh-keyscan -H <host> >> known_hosts` from a trusted bastion) OR (b) sets `LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true` in `spec.runtime.env` (audit-flagged WARN). Intentional — same callout class as ADR-0003's nil-TLS-block loud failure.

## Verification

- `make fmt` — clean (libvirt excluded by Makefile design; `gofmt -s` run directly on touched files).
- `golangci-lint run ./...` — **0 issues** (v2 linter matching `.golangci.yml version: "2"`).
- `make test` — full suite green; `go test -race ./internal/providers/libvirt/...` green.
- `make build` — manager binary built.
- `make build-provider-libvirt` (`CGO_ENABLED=1`) — **libvirt binary built locally** (libvirt headers present; no CGO caveat needed in this environment). CI's libvirt Build job remains the authoritative CGO validation.

## Test plan

- [ ] CI: gosec passes (insecure path is env-gated + WARN-logged; no new subprocess in the helper).
- [ ] CI: Lint passes.
- [ ] CI: Test passes.
- [ ] CI: libvirt Build (CGO) passes.