### PR TITLE
security(rbac): tighten manager ServiceAccount RBAC to least-privilege (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-29 05:10] - v0.3.7: Tighten manager ServiceAccount RBAC to least-privilege (closes #152)
+**Author:** @wrkode (William Rizzo)
+
+### Security
+- `charts/virtrigaud/templates/manager-rbac.yaml`: **narrowed the manager ClusterRole/Role** (the RBAC that actually ships and binds to the manager SA, since this chart is hand-maintained — not generated from `config/rbac/`). Both the cluster-scoped and namespace-scoped branches were tightened identically: **`secrets` dropped from full CRUD (`create;delete;get;list;patch;update;watch`) to `get;list;watch`** — the manager only reads credential/cloud-init/TLS Secrets (`internal/controller/cloudinit.go`, `internal/runtime/remote/resolver.go`), it never writes them; **`configmaps` removed entirely** (no controller references ConfigMaps); the **phantom CRDs `vmclones`, `vmsets`, `vmplacementpolicies` (+/status) removed** (CRDs exist but no controller reconciles them); **`metrics.k8s.io` `pods`/`nodes` removed** (unused); **`deployments/status` removed** (the manager reads Deployment status off the object but never writes the status subresource); **`events` narrowed to `create;patch`**; and the CRD mega-rule split so **`vmimages`/`vmnetworkattachments` are read-only (`get;list;watch`)** and `vmclasses` keeps `create` without `delete`.
+- `internal/controller/vmclass_controller.go`, `internal/controller/vmimage_controller.go`, `internal/controller/vmnetworkattachment_controller.go`: fixed the `+kubebuilder:rbac` markers, which named a **doubled, non-existent apiGroup `infra.virtrigaud.io.infra.virtrigaud.io`** and granted `create;update;patch;delete` + status + finalizers on it. These three reconcilers are watch-only no-op stubs (informer cache via `For()` only), so the markers were corrected to `groups=infra.virtrigaud.io` and narrowed to `get;list;watch` — the minimum the controller-runtime cache requires. This eliminated an entire phantom rule block from the generated `config/rbac/role.yaml`.
+- `internal/controller/vmadoption_controller.go`: narrowed the `vmimages` marker from `get;list;watch;create;update;patch` to `get;list;watch` — the adoption controller references existing disks rather than minting VMImages (it does still create/update VirtualMachine and VMClass, which retain their write verbs).
+
+### Changed
+- `config/rbac/role.yaml`: regenerated via `make manifests` (controller-gen). Net effect of the marker fixes: the phantom `infra.virtrigaud.io.infra.virtrigaud.io` group (3 rules) is gone and `vmimages`/`vmnetworkattachments` collapse into a single read-only rule.
+
+### Why
+#152 is a MEDIUM-severity finding from the v0.3.6 security audit: the manager SA held broader Secret access (and other excess grants) than minimal-functional requires, so a compromised manager could create/mutate Secrets cluster-wide as a data-exfiltration or credential-tampering vehicle. Least-privilege RBAC shrinks that blast radius, which matters for the regulated-banking deployment posture. The marker fixes also remove dead grants (a doubled apiGroup) that no Kubernetes API server would ever evaluate.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
+> **Requires cluster rollout** (`helm upgrade`) to apply the tightened ClusterRole/Role. The change is purely a verb/resource reduction matched against verified manager code paths; no controller logic, CRD, or provider RBAC was touched. Operators who extended the manager with custom controllers can re-add grants via `rbac.additionalRules` in values. **Residual risk:** envtest does not enforce RBAC, so unit tests cannot validate this — the real validation is the e2e suite running under the actual ServiceAccount. Recommend an e2e run before/after merge.
+
 ## [2026-05-29 04:40] - v0.3.7: Libvirt SSH host-key verification on by default (closes #149)
 **Author:** @wrkode (William Rizzo)
 

--- a/charts/virtrigaud/templates/manager-rbac.yaml
+++ b/charts/virtrigaud/templates/manager-rbac.yaml
@@ -21,32 +21,25 @@ metadata:
     {{- include "virtrigaud.labels" . | nindent 4 }}
     app.kubernetes.io/component: manager
 rules:
-# Core virtrigaud resources
+# virtrigaud CRDs the manager actively manages (create + mutate + delete).
+# Verb sets are least-privilege per issue #152: only the resources whose
+# controllers actually write are granted write verbs. vmclones, vmsets and
+# vmplacementpolicies were dropped — no controller reconciles them.
 - apiGroups:
   - infra.virtrigaud.io
   resources:
   - virtualmachines
   - virtualmachines/status
   - virtualmachines/finalizers
-  - vmclasses
-  - vmclasses/status
-  - vmimages
-  - vmimages/status
-  - vmnetworkattachments
-  - vmnetworkattachments/status
   - providers
   - providers/status
+  - providers/finalizers
   - vmsnapshots
   - vmsnapshots/status
-  - vmclones
-  - vmclones/status
+  - vmsnapshots/finalizers
   - vmmigrations
   - vmmigrations/status
   - vmmigrations/finalizers
-  - vmsets
-  - vmsets/status
-  - vmplacementpolicies
-  - vmplacementpolicies/status
   verbs:
   - create
   - delete
@@ -55,14 +48,47 @@ rules:
   - patch
   - update
   - watch
-# Core Kubernetes resources
+# VMClass is created/updated by the adoption controller but never deleted by
+# the manager, so it omits the delete verb.
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmclasses
+  - vmclasses/status
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# VMImage and VMNetworkAttachment are read-only inputs: the manager resolves
+# them when building VMs but never creates or mutates them (issue #152).
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmimages
+  - vmnetworkattachments
+  verbs:
+  - get
+  - list
+  - watch
+# Secrets hold provider credentials and TLS material. The manager only READS
+# them (cloud-init / credential / TLS Secret resolution); it never creates,
+# mutates, or deletes Secrets. Narrowed from full CRUD per issue #152.
 - apiGroups:
   - ""
   resources:
   - secrets
-  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+# Services for remote provider runtimes (provider_controller reconciles them).
+- apiGroups:
+  - ""
+  resources:
   - services
-  - events
   verbs:
   - create
   - delete
@@ -71,7 +97,15 @@ rules:
   - patch
   - update
   - watch
-# PersistentVolumeClaims for VM migration storage
+# Events: the manager only emits events (create/patch); it never lists/deletes.
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+# PersistentVolumeClaims for VM migration storage (vmmigration_controller).
 - apiGroups:
   - ""
   resources:
@@ -84,7 +118,8 @@ rules:
   - patch
   - update
   - watch
-# Pods for VM migration provider readiness checks
+# Pods for VM migration provider readiness checks (vmmigration_controller
+# lists provider pods to confirm the migration PVC is mounted). Read-only.
 - apiGroups:
   - ""
   resources:
@@ -93,12 +128,13 @@ rules:
   - get
   - list
   - watch
-# Deployment resources for remote providers
+# Deployment resources for remote providers (provider_controller reconciles
+# them). deployments/status dropped — the manager reads deployment status off
+# the object but never writes the status subresource.
 - apiGroups:
   - apps
   resources:
   - deployments
-  - deployments/status
   verbs:
   - create
   - delete
@@ -117,15 +153,6 @@ rules:
   - get
   - list
   - update
-# Metrics
-- apiGroups:
-  - metrics.k8s.io
-  resources:
-  - pods
-  - nodes
-  verbs:
-  - get
-  - list
 {{- with .Values.rbac.additionalRules }}
 {{- toYaml . | nindent 0 }}
 {{- end }}
@@ -155,32 +182,25 @@ metadata:
     {{- include "virtrigaud.labels" . | nindent 4 }}
     app.kubernetes.io/component: manager
 rules:
-# Core virtrigaud resources
+# virtrigaud CRDs the manager actively manages (create + mutate + delete).
+# Verb sets are least-privilege per issue #152: only the resources whose
+# controllers actually write are granted write verbs. vmclones, vmsets and
+# vmplacementpolicies were dropped — no controller reconciles them.
 - apiGroups:
   - infra.virtrigaud.io
   resources:
   - virtualmachines
   - virtualmachines/status
   - virtualmachines/finalizers
-  - vmclasses
-  - vmclasses/status
-  - vmimages
-  - vmimages/status
-  - vmnetworkattachments
-  - vmnetworkattachments/status
   - providers
   - providers/status
+  - providers/finalizers
   - vmsnapshots
   - vmsnapshots/status
-  - vmclones
-  - vmclones/status
+  - vmsnapshots/finalizers
   - vmmigrations
   - vmmigrations/status
   - vmmigrations/finalizers
-  - vmsets
-  - vmsets/status
-  - vmplacementpolicies
-  - vmplacementpolicies/status
   verbs:
   - create
   - delete
@@ -189,14 +209,47 @@ rules:
   - patch
   - update
   - watch
-# Core Kubernetes resources
+# VMClass is created/updated by the adoption controller but never deleted by
+# the manager, so it omits the delete verb.
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmclasses
+  - vmclasses/status
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# VMImage and VMNetworkAttachment are read-only inputs: the manager resolves
+# them when building VMs but never creates or mutates them (issue #152).
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmimages
+  - vmnetworkattachments
+  verbs:
+  - get
+  - list
+  - watch
+# Secrets hold provider credentials and TLS material. The manager only READS
+# them (cloud-init / credential / TLS Secret resolution); it never creates,
+# mutates, or deletes Secrets. Narrowed from full CRUD per issue #152.
 - apiGroups:
   - ""
   resources:
   - secrets
-  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+# Services for remote provider runtimes (provider_controller reconciles them).
+- apiGroups:
+  - ""
+  resources:
   - services
-  - events
   verbs:
   - create
   - delete
@@ -205,7 +258,15 @@ rules:
   - patch
   - update
   - watch
-# PersistentVolumeClaims for VM migration storage
+# Events: the manager only emits events (create/patch); it never lists/deletes.
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+# PersistentVolumeClaims for VM migration storage (vmmigration_controller).
 - apiGroups:
   - ""
   resources:
@@ -218,7 +279,8 @@ rules:
   - patch
   - update
   - watch
-# Pods for VM migration provider readiness checks
+# Pods for VM migration provider readiness checks (vmmigration_controller
+# lists provider pods to confirm the migration PVC is mounted). Read-only.
 - apiGroups:
   - ""
   resources:
@@ -227,12 +289,13 @@ rules:
   - get
   - list
   - watch
-# Deployment resources for remote providers
+# Deployment resources for remote providers (provider_controller reconciles
+# them). deployments/status dropped — the manager reads deployment status off
+# the object but never writes the status subresource.
 - apiGroups:
   - apps
   resources:
   - deployments
-  - deployments/status
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -83,7 +83,6 @@ rules:
   - infra.virtrigaud.io
   resources:
   - vmclasses
-  - vmimages
   verbs:
   - create
   - get
@@ -94,40 +93,9 @@ rules:
 - apiGroups:
   - infra.virtrigaud.io
   resources:
-  - vmnetworkattachments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - infra.virtrigaud.io.infra.virtrigaud.io
-  resources:
-  - vmclasses
   - vmimages
   - vmnetworkattachments
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
-- apiGroups:
-  - infra.virtrigaud.io.infra.virtrigaud.io
-  resources:
-  - vmclasses/finalizers
-  - vmimages/finalizers
-  - vmnetworkattachments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - infra.virtrigaud.io.infra.virtrigaud.io
-  resources:
-  - vmclasses/status
-  - vmimages/status
-  - vmnetworkattachments/status
-  verbs:
-  - get
-  - patch
-  - update

--- a/internal/controller/vmadoption_controller.go
+++ b/internal/controller/vmadoption_controller.go
@@ -85,11 +85,18 @@ type VMAdoptionReconciler struct {
 	RemoteResolver *remote.Resolver
 }
 
+// VMAdoptionReconciler watches Providers and, on the adoption annotation,
+// provisions VirtualMachine + VMClass objects for already-existing hypervisor
+// VMs. RBAC reflects exactly that (issue #152): it creates/updates
+// VirtualMachine and VMClass and writes Provider status, but only READS
+// VMImage — adoption references the existing disk rather than minting a
+// VMImage (see ensureVMClass / the adoptVM disk-reference path), so vmimages
+// is narrowed to get;list;watch.
 // +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=providers,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=providers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=virtualmachines,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmclasses,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmimages,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmimages,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile handles adoption requests.

--- a/internal/controller/vmclass_controller.go
+++ b/internal/controller/vmclass_controller.go
@@ -34,9 +34,14 @@ type VMClassReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=infra.virtrigaud.io.infra.virtrigaud.io,resources=vmclasses,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=infra.virtrigaud.io.infra.virtrigaud.io,resources=vmclasses/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=infra.virtrigaud.io.infra.virtrigaud.io,resources=vmclasses/finalizers,verbs=update
+// VMClassReconciler is a watch-only stub: its Reconcile is a no-op and it
+// holds an informer cache on VMClass via For(). Least-privilege (issue #152)
+// therefore grants only the get;list;watch the cache requires — no write,
+// status, or finalizer verbs are exercised. (vmadoption_controller.go owns
+// the create/update grant for the VMClass objects it provisions during
+// adoption.) The apiGroup is infra.virtrigaud.io; the previous doubled value
+// generated a phantom rule for a non-existent group.
+// +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmclasses,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/vmimage_controller.go
+++ b/internal/controller/vmimage_controller.go
@@ -34,9 +34,13 @@ type VMImageReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=infra.virtrigaud.io.infra.virtrigaud.io,resources=vmimages,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=infra.virtrigaud.io.infra.virtrigaud.io,resources=vmimages/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=infra.virtrigaud.io.infra.virtrigaud.io,resources=vmimages/finalizers,verbs=update
+// VMImageReconciler is a watch-only stub: its Reconcile is a no-op and it
+// holds an informer cache on VMImage via For(). Least-privilege (issue #152)
+// therefore grants only the get;list;watch the cache requires — VMImage is
+// read-only across the whole manager (no controller creates or mutates it).
+// The apiGroup is infra.virtrigaud.io; the previous doubled value generated a
+// phantom rule for a non-existent group.
+// +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmimages,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/vmnetworkattachment_controller.go
+++ b/internal/controller/vmnetworkattachment_controller.go
@@ -34,9 +34,14 @@ type VMNetworkAttachmentReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=infra.virtrigaud.io.infra.virtrigaud.io,resources=vmnetworkattachments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=infra.virtrigaud.io.infra.virtrigaud.io,resources=vmnetworkattachments/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=infra.virtrigaud.io.infra.virtrigaud.io,resources=vmnetworkattachments/finalizers,verbs=update
+// VMNetworkAttachmentReconciler is a watch-only stub: its Reconcile is a
+// no-op and it holds an informer cache on VMNetworkAttachment via For().
+// Least-privilege (issue #152) therefore grants only the get;list;watch the
+// cache requires — VMNetworkAttachment is read-only across the whole manager
+// (no controller creates or mutates it). The apiGroup is infra.virtrigaud.io;
+// the previous doubled value generated a phantom rule for a non-existent
+// group.
+// +kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmnetworkattachments,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Closes #152.

MEDIUM-severity finding from the v0.3.6 security audit — first of three v0.3.7 cleanup items. Tightens the **manager** ServiceAccount RBAC to least-privilege.

## Summary

Two RBAC surfaces feed the manager SA, and they had drifted apart:

1. **`config/rbac/role.yaml`** — generated from `+kubebuilder:rbac` markers.
2. **`charts/virtrigaud/templates/manager-rbac.yaml`** — **hand-maintained**, and it is what actually ships in a `helm install`/`upgrade`. It was *significantly broader* than the generated role and is where the real #152 grants lived (full-CRUD on `secrets`, `configmaps`, phantom CRDs). A tightened `config/rbac` alone would not have shipped — both had to be fixed.

No controller logic, CRD `*_types.go`, or **provider** RBAC was touched (out of scope).

## Investigation: every grant audited against runtime code

| apiGroup | resource | current verbs | decision | justification (code path / evidence) |
|---|---|---|---|---|
| `""` | **secrets** | create;delete;get;list;patch;update;watch | **NARROW → get;list;watch** | Only ever read: `cloudinit.go` (`r.Get`), `runtime/remote/resolver.go` (`client.Get`). No Secret write anywhere. **(#152 headline)** |
| `""` | **configmaps** | full CRUD | **REMOVE** | No `ConfigMap` reference in `internal/`. |
| `""` | services | full CRUD | KEEP | `provider_controller.go` reconcileService create/update/delete + `Owns(&Service{})` cache. |
| `""` | events | full CRUD | **NARROW → create;patch** | Manager only emits events; never lists/deletes. Matches generated role. |
| `""` | persistentvolumeclaims | full CRUD | KEEP | `vmmigration_controller.go` creates/deletes migration PVCs; `provider_controller.go` lists them. |
| `""` | pods | get;list;watch | KEEP | `vmmigration_controller.go:1736` lists provider pods for migration readiness. (Issue speculated unused — it is used.) |
| apps | deployments | full CRUD | KEEP | `provider_controller.go` create/update/delete + `Owns(&Deployment{})`. |
| apps | **deployments/status** | full CRUD | **REMOVE** | Manager reads `.Status.ReadyReplicas` off the object; never writes the status subresource. |
| coordination | leases | create;get;list;update | KEEP | Leader election (`--leader-elect`). |
| metrics.k8s.io | **pods/nodes** | get;list | **REMOVE** | No metrics client anywhere (ClusterRole branch only). |
| infra | virtualmachines (+status,+finalizers) | full CRUD | KEEP | vmadoption creates VMs; VM controller updates status + finalizers. |
| infra | providers (+status,+finalizers) | full CRUD | KEEP | provider/vmadoption write status + finalizers (manager doesn't create Provider CRs, but kept conservatively). |
| infra | vmsnapshots (+status,+finalizers) | full CRUD | KEEP | vmsnapshot controller creates/deletes/finalizes. |
| infra | vmmigrations (+status,+finalizers) | full CRUD | KEEP | vmmigration controller creates/finalizes. |
| infra | **vmclasses (+status)** | full CRUD | **NARROW → create;get;list;patch;update;watch** | vmadoption `r.Create`s VMClasses; never deletes → drop `delete`. |
| infra | **vmimages** | full CRUD | **NARROW → get;list;watch** | Read-only everywhere (resolved when building VMs; never written). |
| infra | **vmnetworkattachments** | full CRUD | **NARROW → get;list;watch** | Read-only everywhere. |
| infra | **vmclones / vmsets / vmplacementpolicies (+status)** | full CRUD | **REMOVE** | CRDs/types exist but **no controller reconciles them**. |

Both ClusterRole (default `rbac.scope=cluster`) and the namespaced Role branch were tightened identically.

### Marker fixes (generated `config/rbac/role.yaml`)

- `vmclass`/`vmimage`/`vmnetworkattachment` controllers named a **doubled, non-existent apiGroup `infra.virtrigaud.io.infra.virtrigaud.io`** and granted `create;update;patch;delete` + status + finalizers on it. These three reconcilers are watch-only no-op stubs (informer cache via `For()` only), so the markers were corrected to `groups=infra.virtrigaud.io` and narrowed to `get;list;watch`. This removed an entire phantom rule block (3 rules) from the generated role.
- `vmadoption` controller: `vmimages` marker narrowed `get;list;watch;create;update;patch` → `get;list;watch` (adoption references existing disks rather than minting VMImages).

## Riskiest removal & why it is safe

The `secrets` CRUD → read-only narrowing is the highest-impact change. It is safe because every Secret access in the manager is a `r.Get`/`client.Get` (verified across `internal/controller/cloudinit.go` and `internal/runtime/remote/resolver.go`); there is no `Create`/`Update`/`Delete`/`Status().Update` on a Secret anywhere. `list`/`watch` are **preserved** because the controller-runtime client reads Secrets through its cache (informer), which needs `list`+`watch` even when the code only `Get`s — stripping those would break credential resolution at runtime. The same `list`+`watch`-preservation rule was applied to every cached type (pods, vmimages, vmnetworkattachments, the `For()`/`Owns()` types).

## Verification

- `make manifests` regenerates `config/rbac/role.yaml` deterministically; the committed file matches the markers (the CI "Verify Generated Files" job runs `make generate && make gen-crds && make proto` then `git diff --exit-code`).
- `make fmt` (no diff), `go vet ./internal/controller/...` (clean), `make build` (ok), `make test` (all packages pass; `internal/controller` ok). `helm lint` + `helm template` render cleanly for both `rbac.scope` values.
- `make lint` fails **locally** only on a pre-existing toolchain mismatch (vendored `golangci-lint` built with go1.24 vs `go.mod` go1.26.0) — unrelated to these comment-only Go edits; CI's matched lint runner is authoritative.

## Residual risk (please read before merge)

**envtest does not enforce RBAC, and unit tests therefore cannot catch an over-tightening.** Only the e2e suite runs under the actual ServiceAccount. The changes here were matched conservatively against verified code paths and `list`/`watch` were preserved on every cached type, but the real validation is an **e2e run under the tightened SA** — recommend confirming the e2e/conformance job is green before merge. Operators with custom controllers can re-add grants via `rbac.additionalRules` in values.

## Out of scope (untouched)

- **Provider** runtime RBAC (`charts/virtrigaud-provider-runtime/templates/rbac.yaml`) — already tight (namespaced Role, `configmaps`/`secrets` `get;list;watch`, `events` `create;patch`, no wildcards). No follow-up needed.
- CRD `*_types.go`, controller logic, mTLS / libvirt SSH (other v0.3.7 tracks).

## Impact

- [ ] Breaking change
- [x] Requires cluster rollout (`helm upgrade` to apply the tightened role)
- [ ] Config change only
- [ ] Documentation only