### PR TITLE
fix(make): pass -tags=e2e to test-e2e so the e2e suite actually runs (closes #146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-29 12:30] - v0.3.7: Fix `make test-e2e` to actually run the e2e suite (closes #146)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `Makefile`: the `test-e2e` target's `go test ./test/e2e/ -v -ginkgo.v` invocation now passes **`-tags=e2e`**. PR #133 added `//go:build e2e` constraints to `test/e2e/e2e_test.go` and `e2e_suite_test.go`, but the target was never updated to set the tag — so `go test` saw "build constraints exclude all Go files" and ran **zero** e2e tests. The failure was masked because the target's preamble exits early when no Kind cluster is present, so the broken `go test` line was rarely reached. Verified: `go test -tags=e2e -list '.*' ./test/e2e/` now discovers `TestE2E`; without the tag the package fails to build. The flag is additive (it only includes the `e2e`-tagged files; no untagged files are dropped).
+
+### Why
+A test target that silently runs nothing gives false confidence — the e2e suite has been effectively dark since PR #133. Restoring the tag makes `make test-e2e` exercise the Ginkgo e2e suite as intended on a Kind cluster.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] Config change only — build/test tooling; no runtime or shipped-artifact change
+- [ ] Documentation only
+
 ## [2026-05-29 06:49] - v0.3.7: Remediate reachable CVEs + add blocking govulncheck CI gate (closes #151)
 **Author:** @wrkode (William Rizzo)
 

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ test-e2e: gen-crds generate fmt vet ## Run the e2e tests. Expected an isolated e
 		echo "No Kind cluster is running. Please start a Kind cluster before running the e2e tests."; \
 		exit 1; \
 	}
-	go test ./test/e2e/ -v -ginkgo.v
+	go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter


### PR DESCRIPTION
Closes #146.

## Summary

The `test-e2e` Makefile target ran **zero** e2e tests. PR #133 added `//go:build e2e` constraints to `test/e2e/e2e_test.go` and `e2e_suite_test.go`, but the target's `go test ./test/e2e/ -v -ginkgo.v` was never updated to set the tag — so `go test` matched no buildable files. The breakage stayed hidden because the target's preamble exits early when no Kind cluster is present, so the broken `go test` line was rarely reached.

## Change

One line in the `test-e2e` target:

```diff
-	go test ./test/e2e/ -v -ginkgo.v
+	go test -tags=e2e ./test/e2e/ -v -ginkgo.v
```

The flag is **additive** — `-tags=e2e` includes the `e2e`-tagged files and drops no untagged files.

## Verification

```
# WITHOUT the tag (current main): build fails, zero tests
$ go test -list '.*' ./test/e2e/
package .../test/e2e: build constraints exclude all Go files ... [setup failed]

# WITH -tags=e2e (this PR): TestE2E is discovered and the package builds
$ go test -tags=e2e -list '.*' ./test/e2e/
TestE2E
ok  	github.com/projectbeskar/virtrigaud/test/e2e
```

(Running the suite itself still requires a Kind cluster, per the target's preamble — unchanged.)

## Impact

Build/test tooling only — no runtime, shipped-artifact, or API change.