### PR TITLE
ci(images): build dev arm64 on native ubuntu-24.04-arm runner (PR-A of #165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,21 +326,95 @@ jobs:
           name: cli-tools
           path: bin/*
 
+  # Stage 1: build each component for each architecture on a NATIVE runner and
+  # push by digest (not by tag). arm64 builds on a native ubuntu-24.04-arm
+  # runner instead of QEMU emulation — the emulated arm64 libvirt (CGO) build
+  # exceeded the 30m job timeout and cancelled the whole run (see #165).
   build-images:
     name: Build Container Images
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     needs: [test, lint, security]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
+      fail-fast: false
       matrix:
         component: [manager, provider-libvirt, provider-vsphere, provider-proxmox]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+      # No QEMU: each leg builds a single NATIVE architecture on its own runner.
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/${{ matrix.component }}
+
+      - name: Build and push image by digest
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          file: ${{ matrix.component == 'manager' && './build/Dockerfile.manager' || format('./cmd/{0}/Dockerfile', matrix.component) }}
+          platforms: linux/${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          # Disable GitHub Actions cache due to reliability issues
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: digests-${{ matrix.component }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stage 2: merge the per-arch digests for each component into a single
+  # multi-arch manifest published under the dev tags (:main, :main-<sha>,
+  # :latest). Tag scheme is identical to the previous single-job build.
+  merge-images:
+    name: Merge Container Image Manifests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    needs: [build-images]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [manager, provider-libvirt, provider-vsphere, provider-proxmox]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.component }}-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
@@ -362,18 +436,17 @@ jobs:
             type=sha,prefix={{branch}}-
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push development image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
-        with:
-          context: .
-          file: ${{ matrix.component == 'manager' && './build/Dockerfile.manager' || format('./cmd/{0}/Dockerfile', matrix.component) }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Disable GitHub Actions cache due to reliability issues
-          # cache-from: type=gha
-          # cache-to: type=gha,mode=max
+      - name: Create multi-arch manifest from digests
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/${{ matrix.component }}@sha256:%s ' *)
+
+      - name: Inspect published manifest
+        run: |
+          docker buildx imagetools inspect \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/${{ matrix.component }}:${{ steps.meta.outputs.version }}"
 
   helm:
     name: Validate Helm Charts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-29 14:10] - v0.3.7: CI dev images build arm64 on native runners (PR-A of #165)
+**Author:** @wrkode (William Rizzo)
+
+### Changed
+- `.github/workflows/ci.yml`: restructure the `build-images` job into the canonical two-stage multi-arch buildx pattern. **Stage 1** (`build-images`) fans out over `component × arch` (8 legs): the `arm64` legs now run on a **native `ubuntu-24.04-arm` GitHub-hosted runner** instead of QEMU emulation, the `amd64` legs on `ubuntu-22.04`. QEMU setup is dropped. Each leg builds a single native arch and pushes **by digest** (`outputs: type=image,push-by-digest=true,name-canonical=true,push=true`), exporting the digest as a per-`component`/`arch` artifact. **Stage 2** (`merge-images`, `needs: build-images`, per `component`) downloads the digests and runs `docker buildx imagetools create` to assemble the multi-arch manifest under the unchanged dev tags, then `imagetools inspect` to confirm. The published tag scheme (`:main`, `:main-<sha>`, `:latest`-on-default-branch), the image-name pattern (`${REGISTRY}/${IMAGE_NAME_PREFIX}/<component>`), and the per-component Dockerfile paths (manager → `build/Dockerfile.manager`, providers → `cmd/<component>/Dockerfile`) are preserved byte-for-byte. The build stays gated to `push` on `main` only, so PR CI does not exercise it.
+
+### Why
+The post-merge `main` run for #164 ended `cancelled`: the emulated `arm64` leg of the libvirt image (CGO + libvirt headers) hit the `timeout-minutes: 30` ceiling (libvirt 30m20s → cancelled → whole run cancelled). Building each architecture on its own native runner eliminates QEMU emulation entirely — native arm64 builds in minutes rather than ~25m emulated — and removes the timeout class of failure. This is **PR-A of #165** and covers the CI dev-image workflow only; the release workflow (`release.yml`, which adds `linux/arm64` to shipped images) is **PR-B** and is untouched here. Validation note: because `build-images` runs only on push to `main`, this is verified by the **post-merge `main` run**, not by this PR's own CI (where it shows skipped).
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] Config change only — CI build infrastructure; no runtime, Go, Dockerfile, or shipped-artifact change
+- [ ] Documentation only
+
 ## [2026-05-29 12:30] - v0.3.7: Fix `make test-e2e` to actually run the e2e suite (closes #146)
 **Author:** @wrkode (William Rizzo)
 


### PR DESCRIPTION
Part of #165 (PR-A of 2).

## Summary

The post-merge `main` run for #164 (`b2cd5d9`) ended **`cancelled`**: the `Build Container Images (provider-libvirt)` leg hit the `build-images` job's `timeout-minutes: 30` ceiling (libvirt **30m20s → cancelled → whole run cancelled**; proxmox 4m, vsphere 19m, manager 25m). Root cause: `ci.yml`'s `build-images` builds dev images **multi-arch (`linux/amd64,linux/arm64`)** and the `arm64` leg runs under **QEMU emulation**, which for the CGO + libvirt-headers image blows the timeout.

This PR restructures `build-images` into the canonical **per-arch native-runner matrix + manifest-merge** buildx pattern (docker docs: "Distribute build across multiple runners"), eliminating QEMU emulation for `arm64` entirely. **PR-A is CI dev images only**; the release workflow (`release.yml`) is **PR-B** and is untouched here.

## What changed (`.github/workflows/ci.yml`)

### Stage 1 — `build-images` (per `component × arch`, build-and-push-by-digest)
- Matrix is now `component: [manager, provider-libvirt, provider-vsphere, provider-proxmox]` × `arch: [amd64, arm64]` (**8 legs**), with `include` mapping each arch to its native runner: `amd64 → ubuntu-22.04`, **`arm64 → ubuntu-24.04-arm`**. `runs-on: ${{ matrix.runner }}`, `fail-fast: false`.
- **QEMU setup removed** — each leg builds a single native arch.
- Builds with `platforms: linux/${{ matrix.arch }}` and pushes **by digest** (`outputs: type=image,push-by-digest=true,name-canonical=true,push=true`) instead of by tag. The digest is exported (`${digest#sha256:}` → `/tmp/digests/`) and uploaded as a `digests-<component>-<arch>` artifact (`if-no-files-found: error`, `retention-days: 1`).

### Stage 2 — `merge-images` (per `component`, manifest merge)
- `needs: build-images`. Downloads the per-arch digests (`pattern: digests-<component>-*`, `merge-multiple: true`), runs `docker/metadata-action` for the **same tag set**, then `docker buildx imagetools create` to assemble the multi-arch manifest, and `imagetools inspect` to confirm.

## Preserved byte-for-byte
- **Published tags:** `:main` (`type=ref,event=branch`), `:main-<sha>` (`type=sha,prefix={{branch}}-`), `:latest`-on-default-branch (`type=raw,value=latest,enable={{is_default_branch}}`) — identical block, moved to `merge-images`.
- **Image-name pattern:** `${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/<component>`.
- **Dockerfile paths:** manager → `build/Dockerfile.manager`, providers → `cmd/<component>/Dockerfile` (same conditional expression).
- **Build gate:** `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` on both stages (dev images publish on `main` push only).
- **SHA-pinning:** all added/kept actions stay SHA-pinned with `# vX.Y.Z` comments; `upload-artifact`/`download-artifact` reuse the exact SHAs already used elsewhere in this repo (`043fb46…` v7.0.1, `3e5f45b…` v8.0.1).

## CI Summary gate
`build-images` is **not** in the `ci` summary job's `needs` list (it's push-only, the summary covers PR-relevant jobs). Confirmed and left as-is — no image build was added to the PR gate.

## Validation caveat (important)
`build-images` runs **only on push to `main`**, so **this PR's own CI does NOT exercise it** — it shows **skipped** on the PR, exactly as today. Green PR CI here is **necessary but not sufficient**. The real proof is the **post-merge `main` push run**; that is where the native `arm64` legs and manifest merge actually execute.

What I could validate locally, since PR CI can't run `build-images`:
- `actionlint` (v1.7.x, `go install …/actionlint@latest`) on `.github/workflows/ci.yml` → **clean (exit 0)**, including its embedded shellcheck over the `run:` blocks. Ran against the whole `.github/workflows/` tree → **clean**.
- Verified the matrix expands to the intended 8 `{component, arch}` combinations (base vectors `component × arch`; `include` only attaches `runner` to the matching `arch`, it does not create extra legs).

## Assumptions flagged
- **`ubuntu-24.04-arm` hosted-runner availability** for this public repo is assumed (GitHub provides free arm64 hosted runners to public repos). This cannot be confirmed from PR CI; the **post-merge `main` run is the confirmation point**.

## Out of scope (not touched)
- `release.yml` (that's PR-B — adds `linux/arm64` to shipped release images).
- Any `Dockerfile`, Go source, or the Go toolchain.

---
*Part of the v0.3.7 track. Needs **post-merge `main` validation** before proceeding to PR-B.*