### PR TITLE
ci(images): fix push-by-digest "tag is needed" error (fix-forward for #166)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,10 @@ jobs:
           file: ${{ matrix.component == 'manager' && './build/Dockerfile.manager' || format('./cmd/{0}/Dockerfile', matrix.component) }}
           platforms: linux/${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          # push-by-digest still needs the repository NAME so buildx knows where
+          # to push the digest (the tag itself is applied later in merge-images).
+          # Omitting name= fails with "tag is needed when pushing to registry".
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
           # Disable GitHub Actions cache due to reliability issues
           # cache-from: type=gha
           # cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-29 15:05] - v0.3.7: Fix push-by-digest "tag is needed" in CI image build (fix-forward for #166)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `.github/workflows/ci.yml`: the per-arch `build-images` step used `outputs: type=image,push-by-digest=true,...` **without a `name=`**, so every leg (all 4 components × amd64+arm64) failed at buildx validation with `ERROR: tag is needed when pushing to registry` — the first post-merge `main` run after #166 failed all 8 legs in <20s. push-by-digest still needs the repository **name** so buildx knows where to push the digest (the tag is applied later in `merge-images`). Added `name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/${{ matrix.component }}` to the `outputs:`.
+
+### Why
+PR #166 (PR-A of #165) restructured dev-image builds to native per-arch runners + manifest merge, but omitted the `name=` token required by push-by-digest. `actionlint` can't catch it (it's a runtime buildx requirement). The fix was **validated locally end-to-end** against a `docker-container` buildx builder + a throwaway registry: the broken form reproduces the exact error; the fixed form builds + pushes both arches by digest and `imagetools create` assembles a valid multi-arch manifest. Unblocks the #165 PR-A validation on `main`.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] Config change only — CI build infra
+- [ ] Documentation only
+
 ## [2026-05-29 14:10] - v0.3.7: CI dev images build arm64 on native runners (PR-A of #165)
 **Author:** @wrkode (William Rizzo)
 


### PR DESCRIPTION
Part of #165. Fix-forward for #166.

## What broke

The first post-merge `main` run after #166 (`26631911375`) **failed all 8 `build-images` legs** (every component × amd64+arm64) within <20s:

```
ERROR: failed to build: tag is needed when pushing to registry
```

This is **not** an arm64/runner problem — the amd64 legs on `ubuntu-22.04` failed identically and just as fast. Root cause: the per-arch build step used `outputs: type=image,push-by-digest=true,name-canonical=true,push=true` **without `name=`**. push-by-digest still needs the repository *name* so buildx knows where to push the digest (the tag is applied later in `merge-images`). `actionlint` can't catch this — it's a runtime buildx requirement.

## Fix

One token added to the `outputs:`:

```diff
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
```

## Validated locally (end-to-end, not merge-and-find-out)

Against a real `docker-container` buildx builder + a throwaway local registry:

- **Broken form** → reproduces `ERROR: tag is needed when pushing to registry` exactly.
- **Fixed form** → both `linux/amd64` and `linux/arm64` legs build + push-by-digest successfully, each producing a digest.
- **`docker buildx imagetools create`** → merges the two digests into a valid multi-arch OCI manifest (confirmed `linux/amd64` + `linux/arm64` platform entries via `imagetools inspect`).

## Validation note

`build-images` is `push`-to-main-gated, so **this PR's own CI won't exercise it** (it'll show skipped, same as #166). The local proof above is the pre-merge validation; the post-merge `main` run is the final confirmation. The one thing still genuinely unproven until that run is the **first successful native libvirt `arm64` CGO compile** (previously masked by the QEMU timeout) — if it surfaces an arm64 build issue, that's a separate, clear build error to fix.