### PR TITLE
fix(build): make kubectl image arch-aware (TARGETARCH) — fixes v0.3.7-rc1 arm64 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-29 18:40] - v0.3.7: Fix kubectl image arm64 build (hardcoded amd64 download)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `build/Dockerfile.kubectl`: the kubectl binary download URL hardcoded `linux/amd64`, so the new arm64 image (added in #165 PR-B) installed an amd64 binary and the `RUN kubectl version --client` verify failed with a syntax/exec error on the arm64 leg — failing the `v0.3.7-rc1` release run (`Build and Push Images (kubectl, arm64)`; all 4 real components built arm64 cleanly). Added `ARG TARGETARCH` (auto-populated by BuildKit per target platform) and switched both download URLs to `linux/${TARGETARCH}/kubectl`, matching the k8s release-URL convention.
+
+### Why
+The multi-arch release build (#165) added arm64 to all image components including the `kubectl` CRD-upgrade utility image, but that image downloads a prebuilt kubectl binary rather than cross-compiling Go — so it needed to be made arch-aware. Validated locally with `docker buildx build --platform linux/arm64`: the arm64 binary downloads and `kubectl version --client` reports `Client Version: v1.32.0`. Unblocks recutting `v0.3.7-rc2`.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] Config change only — release build infra
+- [ ] Documentation only
+
 ## [2026-05-29 16:20] - v0.3.7: Ship arm64 release images via native per-arch build + manifest merge, with full attestation parity (PR-B of #165; closes #169)
 **Author:** @wrkode (William Rizzo)
 

--- a/build/Dockerfile.kubectl
+++ b/build/Dockerfile.kubectl
@@ -5,9 +5,15 @@ FROM alpine:3.20
 # Install kubectl from official Kubernetes release
 # Using v1.32.0 which is built with Go 1.23.12+ (fixes CVE-2024-34156, CVE-2025-47907)
 ARG KUBECTL_VERSION=1.32.0
+# TARGETARCH is auto-populated by BuildKit/buildx per target platform (amd64,
+# arm64) and matches the k8s release URL convention (linux/<arch>). Hardcoding
+# amd64 here made the arm64 image install an amd64 binary, which then failed the
+# `kubectl version --client` verify with "exec/syntax error" on the arm64 leg
+# (the multi-arch release build, #165).
+ARG TARGETARCH
 RUN apk add --no-cache curl ca-certificates bash && \
-    curl --retry 5 --retry-delay 3 --retry-connrefused -f -L -o kubectl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
-    curl --retry 5 --retry-delay 3 --retry-connrefused -f -L -o kubectl.sha256 "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" && \
+    curl --retry 5 --retry-delay 3 --retry-connrefused -f -L -o kubectl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" && \
+    curl --retry 5 --retry-delay 3 --retry-connrefused -f -L -o kubectl.sha256 "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl.sha256" && \
     echo "$(cat kubectl.sha256)  kubectl" | sha256sum -c && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl kubectl.sha256 && \


### PR DESCRIPTION
## What broke
The `v0.3.7-rc1` release run failed on **`Build and Push Images (kubectl, arm64)`** — all 9 other legs (manager/libvirt/vsphere/proxmox × amd64+arm64, kubectl amd64) succeeded, including the previously-timing-out libvirt arm64. Downstream (merge/sign/sbom/provenance/release) skipped.

Root cause: `build/Dockerfile.kubectl` hardcoded `linux/amd64` in the kubectl download URL, so the arm64 image installed an **amd64** binary and the `RUN kubectl version --client` verify failed:
```
/usr/local/bin/kubectl: line 0: syntax error: unexpected word (expecting ")")
ERROR: process "/bin/sh -c kubectl version --client" did not complete successfully: exit code: 2
```
The 4 real components are Go cross-compiled (TARGETARCH-aware via build-push-action), so only this download-a-prebuilt-binary image was arch-blind.

## Fix
```diff
+ARG TARGETARCH
-  ... "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" ...
+  ... "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" ...
```
`TARGETARCH` is auto-populated by BuildKit per target platform (`amd64`/`arm64`) and matches the k8s release-URL convention.

## Validated locally (not merge-and-find-out)
`docker buildx build --platform linux/arm64 -f build/Dockerfile.kubectl`:
- download resolves to `linux/arm64/kubectl`
- `RUN kubectl version --client` → `Client Version: v1.32.0` ✅

## Next
Merge → recut **`v0.3.7-rc2`** (rc1 produced no GitHub Release — create-release skipped — so nothing published to supersede; recutting as rc2 keeps tags immutable).