### PR TITLE
fix(release): drop unsupported --recursive from cosign attest (fixes v0.3.7-rc2 SBOM job)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -555,11 +555,17 @@ jobs:
 
       - name: Attest SBOM to multi-arch index (keyless)
         run: |
-          # --recursive attaches the attestation to the manifest INDEX and every
-          # per-arch child image it references, matching the recursive cosign
-          # sign in merge-and-sign so both amd64 and arm64 carry the SBOM. We
+          # Attach the SBOM attestation to the manifest INDEX digest. NOTE:
+          # `cosign attest` does NOT support `--recursive` (only `cosign sign`
+          # does, and that flag was removed from `attest` in current cosign) —
+          # an earlier rc failed with "unknown flag: --recursive". Attesting the
+          # index is the correct + verifiable target: `cosign verify-attestation
+          # <image>:<tag>` resolves the tag -> index -> this attestation. We
           # attest by index digest (not tag) for an immutable, race-free target.
-          cosign attest --yes --recursive \
+          # The SBOM predicate is essentially arch-independent (Go module set),
+          # so an index-level attestation covers the released artifact; per-arch
+          # SBOM attestation would require per-arch Syft scans (future work).
+          cosign attest --yes \
             --type spdxjson \
             --predicate "sbom-${{ matrix.component }}.spdx.json" \
             "${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/${{ matrix.component }}@${{ steps.index.outputs.digest }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-05-29 19:25] - v0.3.7: Fix SBOM attestation (cosign attest has no --recursive)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `.github/workflows/release.yml`: the `Generate SBOMs` job's SBOM attestation used `cosign attest --yes --recursive`, but `cosign attest` does **not** support `--recursive` (only `cosign sign` does; current cosign removed it from `attest`). The `v0.3.7-rc2` release run failed with `Error: unknown flag: --recursive` on the manager SBOM leg (fail-fast cancelled the rest), skipping `create-release`. Removed `--recursive`; the SBOM is now attested to the multi-arch **index** digest, which is the correct, verifiable target (`cosign verify-attestation <image>:<tag>` resolves tag → index → attestation).
+
+### Why
+rc2 proved the whole pipeline EXCEPT this: all 10 build legs, 5 manifest merges, `cosign sign --recursive` (index + both arch children), Trivy, and the full SLSA provenance generator chain all succeeded. Only the SBOM attestation flag was wrong. Index-level SBOM attestation is not a regression vs v0.3.6 (which was amd64-only with a single SBOM attestation) — the SBOM predicate is essentially arch-independent (Go module set). No supply-chain control weakened: signing stays recursive over index+children, SLSA provenance is per-component, SBOM covers the released artifact. Unblocks recutting `v0.3.7-rc3`.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] Config change only — release build infra
+- [ ] Documentation only
+
 ## [2026-05-29 18:40] - v0.3.7: Fix kubectl image arm64 build (hardcoded amd64 download)
 **Author:** @wrkode (William Rizzo)
 


### PR DESCRIPTION
## What broke
`v0.3.7-rc2` got all the way through the release pipeline EXCEPT the final SBOM job:
```
Error: unknown flag: --recursive
```
`cosign attest` does not support `--recursive` (only `cosign sign` does — and current cosign removed it from `attest` entirely). The manager SBOM leg failed, fail-fast cancelled the other 4, and `create-release` skipped.

**rc2 proved everything else end-to-end** (first time): all 10 build legs (incl. kubectl arm64 after #170), all 5 manifest merges, `cosign sign --recursive` over index+children, Collect Signed Index Digests fan-in, all 5 Trivy scans, and **all 5 SLSA provenance chains (detect-env → generator → final)**.

## Fix
```diff
-          cosign attest --yes --recursive \
+          cosign attest --yes \
             --type spdxjson \
             --predicate "sbom-${{ matrix.component }}.spdx.json" \
             "...@${{ steps.index.outputs.digest }}"
```
Attest the SBOM to the multi-arch **index** digest. This is the correct, verifiable target: `cosign verify-attestation <image>:<tag>` resolves tag → index → attestation.

## No supply-chain compromise
- `cosign sign --recursive` (index + both arch children) — **unchanged**, already worked in rc2.
- SLSA provenance — per-component generator, **unchanged**, worked in rc2.
- SBOM attestation — now on the index (≥ v0.3.6, which was amd64-only with one SBOM). The SBOM predicate is arch-independent (Go module set); per-arch-accurate SBOMs would need per-arch Syft scans (future work, additive — not a v0.3.6 regression).

actionlint: clean. Next: merge → recut `v0.3.7-rc3`.