### PR TITLE
fix(libvirt): return Unimplemented for Clone/ImagePrepare; honest capabilities (#153, #154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The stdlib CVEs were disclosed after the last `main` CI run, so the required `go
 ### Fixed
 - `internal/providers/libvirt/server.go`: `Clone` and `ImagePrepare` no longer fabricate a `TaskRef` for work they do not perform. They now return gRPC `Unimplemented` (via `sdk/provider/errors.NewUnimplemented`), so callers get an honest, actionable error instead of a fake success that never produces a VM/image. Removed the now-unused `generateTaskID`/`generateVMID` helpers.
 - `internal/providers/libvirt/server.go`: `GetCapabilities` now reports `SupportsLinkedClones=false` and `SupportsImageImport=false`, matching actual behavior (previously advertised `true`).
+- `cmd/provider-libvirt/main.go`: removed `linked-clones` from the provider's startup capabilities log banner so it no longer advertises a capability the provider does not implement.
 - `README.md`: corrected the provider capability matrix — Libvirt full clone / linked clones / Clone RPC / ImagePrepare RPC / Image Import are marked unsupported with issue references.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ The stdlib CVEs were disclosed after the last `main` CI run, so the required `go
 - [ ] Config change only
 - [ ] Documentation only
 
+## [2026-06-06 06:40] - Libvirt: honest Clone/ImagePrepare (return Unimplemented) + accurate capabilities
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/libvirt/server.go`: `Clone` and `ImagePrepare` no longer fabricate a `TaskRef` for work they do not perform. They now return gRPC `Unimplemented` (via `sdk/provider/errors.NewUnimplemented`), so callers get an honest, actionable error instead of a fake success that never produces a VM/image. Removed the now-unused `generateTaskID`/`generateVMID` helpers.
+- `internal/providers/libvirt/server.go`: `GetCapabilities` now reports `SupportsLinkedClones=false` and `SupportsImageImport=false`, matching actual behavior (previously advertised `true`).
+- `README.md`: corrected the provider capability matrix — Libvirt full clone / linked clones / Clone RPC / ImagePrepare RPC / Image Import are marked unsupported with issue references.
+
+### Added
+- `internal/providers/libvirt/server_test.go`: tests asserting `Clone`/`ImagePrepare` return `Unimplemented` and that `GetCapabilities` reports honest clone/image-import flags (snapshots remain supported).
+
+### Why
+The libvirt Clone and ImagePrepare RPCs were stubs that fabricated task IDs and reported success while doing nothing, and the provider advertised both as supported. A fabricated `TaskRef` is worse than an honest error — the manager would poll a task that never completes. These RPCs are not reachable from any manager controller today (no `Clone`/`ImagePrepare` in the manager gRPC client or `contracts.Provider`; `VMClone` has no reconciler), so this change is libvirt-provider-local and does not alter any manager-driven flow. Addresses #153 and #154.
+
+### Impact
+- [ ] Breaking change — provider-internal behavior correction only; no CRD/operator API change and no manager flow reaches these RPCs
+- [ ] Requires cluster rollout — optional; effect only applies after the libvirt provider image is updated
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-05-29 19:25] - v0.3.7: Fix SBOM attestation (cosign attest has no --recursive)
 **Author:** @wrkode (William Rizzo)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note: VMAdoption is a **controller** built into the manager, not a CRD.
 
 ## Provider Feature Matrix
 
-Per the [canonical capabilities matrix](https://projectbeskar.github.io/virtrigaud/providers/providers-capabilities/), verified against provider `GetCapabilities` responses in v0.3.6:
+Per the [canonical capabilities matrix](https://projectbeskar.github.io/virtrigaud/providers/providers-capabilities/), verified against provider `GetCapabilities` responses (Libvirt Clone/ImagePrepare corrected to unsupported — see [#153]/[#154]):
 
 | Feature | vSphere | Libvirt | Proxmox | Notes |
 |---------|---------|---------|---------|-------|
@@ -124,14 +124,14 @@ Per the [canonical capabilities matrix](https://projectbeskar.github.io/virtriga
 | **Disk Expansion** | ✅ | ⚠️ | ✅ | Libvirt: power-cycle required |
 | **Snapshots** | ✅ | ✅ | ✅ | Point-in-time captures |
 | **Memory Snapshots** | ❌ | ❌ | ✅ | RAM-inclusive snapshots (vSphere: no) |
-| **Cloning (full)** | ✅ | ✅ | ✅ | Independent copies |
-| **Linked Clones** | ✅ | ✅ | ✅ | COW-based (Libvirt: qcow2 backing) |
-| **Clone RPC** | ✅ | ⚠️ [#153] | ✅ | Libvirt Clone RPC is a stub in v0.3.6 |
-| **ImagePrepare RPC** | ✅ | ⚠️ [#154] | ✅ | Libvirt ImagePrepare is a stub in v0.3.6 |
+| **Cloning (full)** | ✅ | ❌ [#153] | ✅ | Libvirt: Clone RPC not implemented |
+| **Linked Clones** | ✅ | ❌ [#153] | ✅ | COW-based (vSphere/Proxmox); Libvirt: not implemented |
+| **Clone RPC** | ✅ | ❌ [#153] | ✅ | Libvirt Clone returns Unimplemented (honest; real impl tracked in #153) |
+| **ImagePrepare RPC** | ✅ | ❌ [#154] | ✅ | Libvirt ImagePrepare returns Unimplemented (honest; real impl tracked in #154) |
 | **Task Tracking** | ✅ | N/A | ✅ | Async operation monitoring |
 | **Console URLs** | ✅ | ✅ | ⚠️ | Proxmox console URL: planned |
 | **Guest Agent** | ✅ | ✅ | ✅ | IP detection and guest info |
-| **Image Import** | ✅ | ✅ | ✅ | vSphere: OVA/content library |
+| **Image Import** | ✅ | ❌ [#154] | ✅ | vSphere: OVA/content library; Libvirt: ImagePrepare not implemented |
 | **Multi-NIC** | ✅ | ✅ | ✅ | Multiple network interfaces |
 | **Circuit Breaker** | ✅ | ✅ | ✅ | One CB per Provider CR (v0.3.6) |
 

--- a/cmd/provider-libvirt/main.go
+++ b/cmd/provider-libvirt/main.go
@@ -127,7 +127,7 @@ func main() {
 		"port", port,
 		"health_port", healthPort,
 		"capabilities", []string{
-			"core", "snapshots", "linked-clones",
+			"core", "snapshots",
 			"online-reconfigure", "qemu-guest-agent",
 		},
 		"supported_platforms", []string{"kvm", "qemu", "libvirt"},

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
 	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+	"github.com/projectbeskar/virtrigaud/sdk/provider/errors"
 )
 
 // Server implements the providerv1.ProviderServer interface for Libvirt
@@ -424,33 +425,27 @@ func (s *Server) SnapshotRevert(ctx context.Context, req *providerv1.SnapshotRev
 	return &providerv1.TaskResponse{}, nil
 }
 
-// Clone creates a VM clone
+// Clone creates a VM clone.
+//
+// Not yet implemented for libvirt: a real implementation must perform a volume
+// clone (full or qcow2-backed for linked clones) plus a new domain definition.
+// Until that exists, this returns Unimplemented rather than a synthetic task
+// reference so callers receive an honest, actionable error instead of a
+// fabricated success that never produces a VM.
+// Tracked in https://github.com/projectbeskar/virtrigaud/issues/153.
 func (s *Server) Clone(ctx context.Context, req *providerv1.CloneRequest) (*providerv1.CloneResponse, error) {
-	// Libvirt supports cloning via volume clone + new domain definition
-	// Linked clones are supported with qcow2 backing files
-	targetVMID := fmt.Sprintf("vm-clone-%s", generateVMID())
-
-	// Simulate async clone operation
-	taskRef := &providerv1.TaskRef{
-		Id: fmt.Sprintf("task-clone-%s", generateTaskID()),
-	}
-
-	return &providerv1.CloneResponse{
-		TargetVmId: targetVMID,
-		Task:       taskRef,
-	}, nil
+	return nil, errors.NewUnimplemented("Clone operation is not implemented for libvirt (https://github.com/projectbeskar/virtrigaud/issues/153)")
 }
 
-// ImagePrepare prepares/imports a VM image
+// ImagePrepare prepares/imports a VM image.
+//
+// Not yet implemented for libvirt: a real implementation must download and/or
+// convert the image into a storage pool. Until that exists, this returns
+// Unimplemented rather than a synthetic task reference so callers are not given
+// a fabricated success for work that never happened.
+// Tracked in https://github.com/projectbeskar/virtrigaud/issues/154.
 func (s *Server) ImagePrepare(ctx context.Context, req *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
-	// Libvirt supports downloading qcow2/raw images to storage pools
-	taskRef := &providerv1.TaskRef{
-		Id: fmt.Sprintf("task-image-prepare-%s", generateTaskID()),
-	}
-
-	return &providerv1.TaskResponse{
-		Task: taskRef,
-	}, nil
+	return nil, errors.NewUnimplemented("ImagePrepare operation is not implemented for libvirt (https://github.com/projectbeskar/virtrigaud/issues/154)")
 }
 
 // GetCapabilities returns the capabilities of the Libvirt provider
@@ -460,8 +455,8 @@ func (s *Server) GetCapabilities(ctx context.Context, req *providerv1.GetCapabil
 		SupportsDiskExpansionOnline: false, // Disk expansion usually requires power cycle
 		SupportsSnapshots:           true,  // Libvirt supports snapshots (storage-dependent)
 		SupportsMemorySnapshots:     false, // Memory snapshots not always supported
-		SupportsLinkedClones:        true,  // Supported via qcow2 backing files
-		SupportsImageImport:         true,  // Supports downloading images to storage pools
+		SupportsLinkedClones:        false, // Clone RPC not implemented yet (issue #153)
+		SupportsImageImport:         false, // ImagePrepare RPC not implemented yet (issue #154)
 		SupportedDiskTypes:          []string{"qcow2", "raw", "vmdk"},
 		SupportedNetworkTypes:       []string{"virtio", "e1000", "rtl8139"},
 	}, nil
@@ -725,14 +720,6 @@ func (s *Server) copyDiskToRemote(ctx context.Context, virshProvider *VirshProvi
 // Helper functions for generating IDs and timestamps (shared with vSphere)
 func generateTimestamp() int64 {
 	return time.Now().Unix()
-}
-
-func generateTaskID() string {
-	return fmt.Sprintf("%d-%d", time.Now().Unix(), time.Now().Nanosecond())
-}
-
-func generateVMID() string {
-	return fmt.Sprintf("vm-%d", time.Now().Unix())
 }
 
 // sanitizeSnapshotName ensures snapshot name is valid for virsh

--- a/internal/providers/libvirt/server_test.go
+++ b/internal/providers/libvirt/server_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestServer_Clone_ReturnsUnimplemented verifies that the libvirt Clone RPC
+// returns a gRPC Unimplemented status rather than a fabricated task reference.
+// Clone is not implemented for libvirt (issue #153); returning Unimplemented is
+// the honest contract until a real volume-clone implementation exists.
+func TestServer_Clone_ReturnsUnimplemented(t *testing.T) {
+	s := &Server{}
+
+	resp, err := s.Clone(context.Background(), &providerv1.CloneRequest{
+		SourceVmId: "vm-source",
+		TargetName: "vm-target",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, codes.Unimplemented, status.Code(err),
+		"Clone must report Unimplemented so callers do not treat a no-op as success")
+}
+
+// TestServer_ImagePrepare_ReturnsUnimplemented verifies that the libvirt
+// ImagePrepare RPC returns a gRPC Unimplemented status rather than a fabricated
+// task reference. ImagePrepare is not implemented for libvirt (issue #154).
+func TestServer_ImagePrepare_ReturnsUnimplemented(t *testing.T) {
+	s := &Server{}
+
+	resp, err := s.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
+		TargetName: "fedora-tmpl",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, codes.Unimplemented, status.Code(err),
+		"ImagePrepare must report Unimplemented so callers do not treat a no-op as success")
+}
+
+// TestServer_GetCapabilities_HonestFlags verifies that the libvirt provider
+// advertises capabilities that match its actual behavior: linked clones and
+// image import are reported as unsupported (issues #153/#154) while snapshots
+// remain supported.
+func TestServer_GetCapabilities_HonestFlags(t *testing.T) {
+	s := &Server{}
+
+	caps, err := s.GetCapabilities(context.Background(), &providerv1.GetCapabilitiesRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, caps)
+	assert.False(t, caps.SupportsLinkedClones,
+		"libvirt must not advertise linked clones while Clone is unimplemented (issue #153)")
+	assert.False(t, caps.SupportsImageImport,
+		"libvirt must not advertise image import while ImagePrepare is unimplemented (issue #154)")
+	assert.True(t, caps.SupportsSnapshots,
+		"libvirt snapshots are implemented and must remain advertised")
+}


### PR DESCRIPTION
## What

Make the libvirt provider honest about Clone and ImagePrepare:

- `Clone` and `ImagePrepare` now return gRPC **`Unimplemented`** (via `sdk/provider/errors.NewUnimplemented`) instead of fabricating a `TaskRef` and reporting success while doing nothing.
- `GetCapabilities` now reports `SupportsLinkedClones=false` and `SupportsImageImport=false` (previously advertised `true`).
- Removed the now-unused `generateTaskID` / `generateVMID` helpers.
- Added `internal/providers/libvirt/server_test.go` covering the Unimplemented contract and honest capability flags.
- Corrected the README provider capability matrix.

Closes #153, Closes #154.

## Why

A fabricated `TaskRef` is worse than an honest error — the manager would poll a task that never completes, and a "clone" would "succeed" while producing no VM. This is exactly the kind of silent failure we don't want in production.

## Production-safety analysis

**This is libvirt-provider-local and does not change any manager-driven flow.** Verified before writing code:

- `Clone` / `ImagePrepare` are **not** in the manager gRPC client (`internal/transport/grpc/client.go`) or in the `contracts.Provider` interface — no controller can reach them.
- `VMImageReconciler` is a watch-only no-op stub; it never calls `ImagePrepare`.
- No controller references the `VMClone` kind (it has no reconciler).

So the only consumers of these RPCs are direct gRPC/conformance callers. The lab's libvirt provider (13 managed VMs) drives Create/Power/Describe/adopt — none of which touch these RPCs.

## Verification

- `make fmt` — clean (libvirt files gofmt-verified manually; `make fmt`/`make test` exclude libvirt packages by design)
- `make lint` — 0 issues
- `make build` — OK (manager + `provider-libvirt`)
- `make test` — all packages pass
- `go test -race ./internal/providers/libvirt/` — pass, incl. 3 new tests
- Lab validation on `vr1.lab.k8` will be performed before this is recommended for merge.

## Risk

Low. No CRD/API change, no proto change, no vSphere/proxmox/mock code touched. Reversible by revert.
