### PR TITLE
chore(security): bump Go toolchain 1.26.3 → 1.26.4 (clears 3 stdlib CVEs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-06 06:55] - Security: bump Go toolchain 1.26.3 → 1.26.4 (clears 3 stdlib CVEs)
+**Author:** @wrkode (William Rizzo)
+
+### Security
+- `go.mod`, `sdk/go.mod`, `proto/go.mod`: bump the `go` directive 1.26.3 → 1.26.4.
+- `build/Dockerfile.manager`, `cmd/provider-{libvirt,mock,proxmox,vsphere}/Dockerfile`: bump the golang builder image 1.26.3 → 1.26.4.
+- Clears three Go standard-library vulnerabilities flagged by `govulncheck` (all fixed in go1.26.4): **GO-2026-5037** (`crypto/x509`), **GO-2026-5038** (`mime`), **GO-2026-5039** (`net/textproto`).
+
+### Why
+The stdlib CVEs were disclosed after the last `main` CI run, so the required `govulncheck` job began failing repo-wide on every branch (including `main` HEAD), independent of any code change. Bumping the toolchain to the fixed release restores a green supply-chain scan and removes the `crypto/x509` exposure relevant to the project's regulated-deployment posture. Verified locally under go1.26.4: `govulncheck ./...` and `cd sdk && govulncheck ./...` both report "No vulnerabilities found"; `make lint`/`make build`/`make test` pass.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout — only to ship rebuilt images carrying the patched stdlib; running clusters are unaffected until upgraded
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-05-29 19:25] - v0.3.7: Fix SBOM attestation (cosign attest has no --recursive)
 **Author:** @wrkode (William Rizzo)
 

--- a/build/Dockerfile.manager
+++ b/build/Dockerfile.manager
@@ -5,7 +5,7 @@
 # point at their internal mirrors (Artifactory, Harbor, etc.) without
 # patching this Dockerfile. Defaults match the previously-hardcoded
 # images so upstream release behaviour is unchanged.
-ARG BUILDER_IMAGE=docker.io/golang:1.26.3
+ARG BUILDER_IMAGE=docker.io/golang:1.26.4
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM ${BUILDER_IMAGE} AS builder

--- a/cmd/provider-libvirt/Dockerfile
+++ b/cmd/provider-libvirt/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage with CGO support for libvirt
-ARG BUILDER_IMAGE=golang:1.26.3-bookworm
+ARG BUILDER_IMAGE=golang:1.26.4-bookworm
 ARG BASE_IMAGE=debian:bookworm-slim
 FROM ${BUILDER_IMAGE} AS builder
 

--- a/cmd/provider-mock/Dockerfile
+++ b/cmd/provider-mock/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage for mock provider
-FROM golang:1.26.3-bookworm AS builder
+FROM golang:1.26.4-bookworm AS builder
 
 WORKDIR /workspace
 

--- a/cmd/provider-proxmox/Dockerfile
+++ b/cmd/provider-proxmox/Dockerfile
@@ -1,5 +1,5 @@
 # Build the provider binary
-ARG BUILDER_IMAGE=golang:1.26.3
+ARG BUILDER_IMAGE=golang:1.26.4
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 FROM --platform=${BUILDPLATFORM:-linux/amd64} ${BUILDER_IMAGE} as builder
 ARG BUILDPLATFORM

--- a/cmd/provider-vsphere/Dockerfile
+++ b/cmd/provider-vsphere/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage for vSphere provider (pure Go, no CGO)
-ARG BUILDER_IMAGE=golang:1.26.3-bookworm
+ARG BUILDER_IMAGE=golang:1.26.4-bookworm
 ARG BASE_IMAGE=debian:bookworm-slim
 FROM ${BUILDER_IMAGE} AS builder
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectbeskar/virtrigaud
 
-go 1.26.3
+go 1.26.4
 
 // Local development replacements
 replace github.com/projectbeskar/virtrigaud/proto => ./proto

--- a/proto/go.mod
+++ b/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectbeskar/virtrigaud/proto
 
-go 1.26.3
+go 1.26.4
 
 require (
 	google.golang.org/grpc v1.67.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectbeskar/virtrigaud/sdk
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/projectbeskar/virtrigaud v0.1.0


### PR DESCRIPTION
## What

Bump the Go toolchain **1.26.3 → 1.26.4** across all three modules and the active builder Dockerfiles.

- `go.mod`, `sdk/go.mod`, `proto/go.mod`: `go` directive → `1.26.4`
- `build/Dockerfile.manager`, `cmd/provider-{libvirt,mock,proxmox,vsphere}/Dockerfile`: golang builder image → `1.26.4`

## Why

`govulncheck` (the required **Supply Chain Vulnerability Scan** check) started failing **repo-wide on every branch, including `main` HEAD**, after three Go standard-library CVEs were disclosed in the last week:

| ID | Package | Fixed in |
|----|---------|----------|
| GO-2026-5037 | `crypto/x509` | go1.26.4 |
| GO-2026-5038 | `mime` | go1.26.4 |
| GO-2026-5039 | `net/textproto` | go1.26.4 |

This is **not** caused by any code change — `main` last ran CI on 2026-05-29 (before disclosure) and passed; the vuln database updated since. The `crypto/x509` CVE is security-relevant to VirtRigaud's regulated-deployment posture.

## Verification (local, under go1.26.4)

- `govulncheck ./...` → **No vulnerabilities found**
- `cd sdk && govulncheck ./...` → **No vulnerabilities found**
- `make lint` → 0 issues
- `make build` → OK
- `make test` → all packages pass

## Impact / risk

Low. Toolchain-only bump; no source, API, proto, or behavior changes. Unblocks the supply-chain check on all open PRs (incl. #180). Out of scope: the stale, unused `build/Dockerfile.provider-{vsphere,libvirt}` (pinned to golang:1.25 and not referenced by CI/release) — flagged for separate cleanup.
