### PR TITLE
fix(chart): disable templated standalone providers by default (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ The libvirt provider already implemented `ExportDisk`/`GetDiskInfo` (in `provide
 - [ ] Config change only
 - [ ] Documentation only
 
+## [2026-06-06 07:50] - Chart: disable templated standalone providers by default (#173)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `charts/virtrigaud/values.yaml`: `providers.libvirt.enabled` and `providers.vsphere.enabled` now default to `false` (proxmox already was). Under the v0.3.7 secure-by-default provider auth (ADR-0003 / #148), a default `helm install` rendered standalone provider Deployments with neither TLS material nor the plaintext opt-out, so they fail-closed and crash-looped. Providers are normally deployed by the manager's ProviderController from `Provider` CRs; the chart-templated Deployments are an opt-in.
+- `charts/virtrigaud/README.md`: removed `--set providers.*.enabled=true` from the casual install example, updated the Provider Configuration section to the new defaults, and documented that opting in also requires the `providerTLS` block (`secretName` for mTLS, or `insecure=true` for audit-flagged plaintext) — otherwise the provider crash-loops.
+- `charts/virtrigaud/values.yaml`: added an explanatory comment on the `providers:` block describing the opt-in contract.
+
+### Why
+The out-of-box experience of the published chart was a crash-loop (the manager and CR-deployed providers were unaffected). Defaulting the templated providers to disabled matches the documented architecture — providers come from `Provider` CRs — and the opt-in path (verified via `helm template`) still wires `providerTLS` correctly. Fixes #173.
+
+### Impact
+- [ ] Breaking change — only affects operators who relied on the chart auto-templating standalone libvirt/vsphere providers (which were crash-looping anyway); they now set `providers.<name>.enabled=true` explicitly plus `providerTLS`.
+- [ ] Requires cluster rollout
+- [x] Chart + docs change only
+- [ ] Documentation only
+
 ## [2026-06-06 06:55] - Security: bump Go toolchain 1.26.3 → 1.26.4 (clears 3 stdlib CVEs)
 **Author:** @wrkode (William Rizzo)
 

--- a/charts/virtrigaud/README.md
+++ b/charts/virtrigaud/README.md
@@ -36,10 +36,13 @@ helm install virtrigaud virtrigaud/virtrigaud \
 helm install virtrigaud virtrigaud/virtrigaud \
   -n virtrigaud-system \
   --create-namespace \
-  --set manager.replicaCount=2 \
-  --set providers.vsphere.enabled=true \
-  --set providers.libvirt.enabled=true
+  --set manager.replicaCount=2
 ```
+
+> Providers are normally deployed by the manager from `Provider` CRs — not via
+> Helm flags. The chart-templated `providers.*` Deployments are disabled by
+> default (#173); see [Provider Configuration](#provider-configuration) before
+> opting in.
 
 ### Installation from Local Chart
 
@@ -125,20 +128,27 @@ helm upgrade virtrigaud virtrigaud/virtrigaud \
 
 ### Provider Configuration
 
-Each provider (vSphere, Libvirt, Proxmox) can be enabled/disabled:
+In normal operation you do **not** enable providers here — the manager's
+ProviderController deploys provider pods automatically from `Provider` CRs
+(`spec.runtime`), which also wires each provider's TLS posture. The chart can
+optionally template standalone provider Deployments, but they are **disabled by
+default** (#173).
+
+> **If you opt in** (`providers.<name>.enabled: true`) you must also configure the
+> `providerTLS` block — set `providerTLS.secretName` (mTLS) or
+> `providerTLS.insecure=true` (audit-flagged plaintext). Otherwise the provider
+> fail-closes on startup (ADR-0003, v0.3.7 secure-by-default) and crash-loops.
 
 ```yaml
 providers:
   vsphere:
-    enabled: true
+    enabled: false  # opt-in; also requires providerTLS (see note above)
     replicaCount: 1
-    image:
-      tag: "v0.2.0"
-  
+
   libvirt:
-    enabled: true
+    enabled: false  # opt-in; also requires providerTLS (see note above)
     replicaCount: 1
-  
+
   proxmox:
     enabled: false
 ```

--- a/charts/virtrigaud/values.yaml
+++ b/charts/virtrigaud/values.yaml
@@ -84,10 +84,18 @@ manager:
   volumeMounts: []
 
 # Provider configuration
+#
+# These are OPTIONAL chart-templated standalone provider Deployments. They are
+# DISABLED by default (#173): in normal operation providers are deployed by the
+# manager's ProviderController from Provider CRs (spec.runtime), which wires the
+# provider's TLS posture from the CR. Enable one here only if you are NOT using a
+# Provider CR for it AND you have configured the providerTLS block below (set
+# providerTLS.secretName, or providerTLS.insecure=true) — otherwise the provider
+# fail-closes on startup per ADR-0003 (v0.3.7 secure-by-default) and crash-loops.
 providers:
   # Libvirt provider
   libvirt:
-    enabled: true
+    enabled: false
     replicaCount: 1
     image:
       repository: projectbeskar/virtrigaud/provider-libvirt
@@ -102,7 +110,7 @@ providers:
 
   # vSphere provider  
   vsphere:
-    enabled: true
+    enabled: false
     replicaCount: 1
     image:
       repository: projectbeskar/virtrigaud/provider-vsphere


### PR DESCRIPTION
## What

Default the chart-templated standalone provider Deployments to **disabled**:

- `charts/virtrigaud/values.yaml`: `providers.libvirt.enabled` and `providers.vsphere.enabled` → `false` (proxmox already was), plus an explanatory comment on the opt-in contract.
- `charts/virtrigaud/README.md`: removed `--set providers.*.enabled=true` from the casual install example; updated the Provider Configuration section to the new defaults and the `providerTLS` requirement.

Fixes #173.

## Why

Under v0.3.7 secure-by-default provider auth (ADR-0003 / #148), a default `helm install virtrigaud/virtrigaud` rendered standalone provider Deployments with **neither TLS material nor the plaintext opt-out**, so they fail-closed and **crash-looped out of the box**:

```
level=ERROR msg="Failed to resolve TLS configuration"
  error="TLS material missing at /etc/virtrigaud/tls and VIRTRIGAUD_PROVIDER_INSECURE is not set to \"true\" ..."
```

The manager and CR-deployed providers were unaffected. Providers are normally deployed by the manager's ProviderController from `Provider` CRs — the chart-templated Deployments are an opt-in. This is the maintainer's preferred fix (Option 1 in the issue).

## Validation (`helm template` / `helm lint`)

- **Default install** → renders only the manager Deployment; **no provider Deployments** (no crash-loopers). ✓
- **Opt-in `--set providers.libvirt.enabled=true --set providerTLS.insecure=true`** → renders the Deployment with `VIRTRIGAUD_PROVIDER_INSECURE`. ✓
- **Opt-in `--set providers.libvirt.enabled=true --set providerTLS.secretName=my-tls`** → mounts the Secret at `/etc/virtrigaud/tls`. ✓
- `helm lint` → 0 failures.

This change will also be applied to **vr1.lab.k8** to clear the two crash-looping templated provider deployments (~1,980 restarts) once approved.

## Scope / follow-ups (intentionally not in this PR)

Two latent defects in the same provider templates, left out to keep this fix surgical — I'll file them separately:
- Stale default image tags (`providers.libvirt.image.tag: v0.3.17-dev`, vsphere/proxmox `v0.3.0`) — the opt-in path pulls a non-existent/old tag.
- A duplicated `{{- if .Values.providers.<name>.enabled }}` / `{{- end }}` guard in each of the 3 provider templates.

## Impact / risk

Low. Chart + docs only; no Go/proto/CRD change. Only affects operators who relied on the chart auto-templating standalone libvirt/vsphere providers (which were crash-looping anyway) — they now opt in explicitly plus configure `providerTLS`.
