### PR TITLE
fix(libvirt): wire ExportDisk/GetDiskInfo into the gRPC server (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-06 08:04] - Libvirt: wire ExportDisk/GetDiskInfo into the gRPC server (#177)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/libvirt/server.go`: added `Server.ExportDisk` and `Server.GetDiskInfo`, which delegate to the existing libvirt `Provider` implementations in `provider_virsh.go` (translating between the gRPC and provider-contract types). These RPCs were previously unreachable over gRPC — the embedded `UnimplementedProviderServer` answered them — so libvirt could not act as a disk-export source or report disk info for migration despite having working implementations.
+- `internal/providers/libvirt/server.go`: `GetCapabilities` now advertises `SupportsDiskExport=true`, `SupportsDiskImport=true`, `SupportedExportFormats=[qcow2, raw]`, `SupportedImportFormats=[qcow2, raw, vmdk]`, and `SupportsExportCompression=false`, matching the now-reachable behavior.
+
+### Added
+- `internal/providers/libvirt/server_test.go`: tests covering request/response type conversion for both RPCs (including the `DestinationUrl`→`DestinationURL` and `TaskRef`→`Task` mappings), the nil-provider error path, and the new capability flags. Uses an embedded-interface fake provider so only the two methods under test are implemented.
+
+### Why
+The libvirt provider already implemented `ExportDisk`/`GetDiskInfo` (in `provider_virsh.go`), but the gRPC `Server` never delegated to them, so the manager's migration controller received `Unimplemented`. Wiring them restores libvirt as a migration source and makes its capability advertisement honest. Fixes #177.
+
+### Impact
+- [ ] Breaking change — additive: an RPC that returned `Unimplemented` now returns real results
+- [ ] Requires cluster rollout — effect applies after the libvirt provider image is updated
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-06 06:55] - Security: bump Go toolchain 1.26.3 → 1.26.4 (clears 3 stdlib CVEs)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -459,6 +459,76 @@ func (s *Server) GetCapabilities(ctx context.Context, req *providerv1.GetCapabil
 		SupportsImageImport:         false, // ImagePrepare RPC not implemented yet (issue #154)
 		SupportedDiskTypes:          []string{"qcow2", "raw", "vmdk"},
 		SupportedNetworkTypes:       []string{"virtio", "e1000", "rtl8139"},
+		SupportsDiskExport:          true, // ExportDisk wired to virsh impl (issue #177)
+		SupportsDiskImport:          true, // ImportDisk wired (pvc:///file:// sources)
+		SupportedExportFormats:      []string{"qcow2", "raw"},
+		SupportedImportFormats:      []string{"qcow2", "raw", "vmdk"},
+		SupportsExportCompression:   false, // Export path does not compress (migration favours speed)
+	}, nil
+}
+
+// ExportDisk exports a VM disk for migration. It delegates to the libvirt
+// Provider implementation (provider_virsh.go), translating between the gRPC and
+// provider-contract types. Previously this RPC was unreachable over gRPC and
+// returned Unimplemented despite a working implementation (issue #177).
+func (s *Server) ExportDisk(ctx context.Context, req *providerv1.ExportDiskRequest) (*providerv1.ExportDiskResponse, error) {
+	if s.provider == nil {
+		return nil, fmt.Errorf("provider not initialized")
+	}
+
+	resp, err := s.provider.ExportDisk(ctx, contracts.ExportDiskRequest{
+		VmId:           req.VmId,
+		DiskId:         req.DiskId,
+		SnapshotId:     req.SnapshotId,
+		DestinationURL: req.DestinationUrl,
+		Format:         req.Format,
+		Compress:       req.Compress,
+		Credentials:    req.Credentials,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to export disk: %w", err)
+	}
+
+	result := &providerv1.ExportDiskResponse{
+		ExportId:           resp.ExportId,
+		EstimatedSizeBytes: resp.EstimatedSizeBytes,
+		Checksum:           resp.Checksum,
+	}
+	if resp.TaskRef != "" {
+		result.Task = &providerv1.TaskRef{Id: resp.TaskRef}
+	}
+
+	return result, nil
+}
+
+// GetDiskInfo returns details about a VM disk for migration planning. It
+// delegates to the libvirt Provider implementation (provider_virsh.go),
+// translating between the gRPC and provider-contract types. Previously this RPC
+// was unreachable over gRPC and returned Unimplemented (issue #177).
+func (s *Server) GetDiskInfo(ctx context.Context, req *providerv1.GetDiskInfoRequest) (*providerv1.GetDiskInfoResponse, error) {
+	if s.provider == nil {
+		return nil, fmt.Errorf("provider not initialized")
+	}
+
+	resp, err := s.provider.GetDiskInfo(ctx, contracts.GetDiskInfoRequest{
+		VmId:       req.VmId,
+		DiskId:     req.DiskId,
+		SnapshotId: req.SnapshotId,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get disk info: %w", err)
+	}
+
+	return &providerv1.GetDiskInfoResponse{
+		DiskId:           resp.DiskId,
+		Format:           resp.Format,
+		VirtualSizeBytes: resp.VirtualSizeBytes,
+		ActualSizeBytes:  resp.ActualSizeBytes,
+		Path:             resp.Path,
+		IsBootable:       resp.IsBootable,
+		Snapshots:        resp.Snapshots,
+		BackingFile:      resp.BackingFile,
+		Metadata:         resp.Metadata,
 	}, nil
 }
 

--- a/internal/providers/libvirt/server_test.go
+++ b/internal/providers/libvirt/server_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
 	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
 )
 
@@ -79,4 +80,152 @@ func TestServer_GetCapabilities_HonestFlags(t *testing.T) {
 		"libvirt must not advertise image import while ImagePrepare is unimplemented (issue #154)")
 	assert.True(t, caps.SupportsSnapshots,
 		"libvirt snapshots are implemented and must remain advertised")
+}
+
+// TestServer_GetCapabilities_DiskMigration verifies the disk-migration
+// capabilities advertised after wiring ExportDisk/GetDiskInfo (issue #177).
+func TestServer_GetCapabilities_DiskMigration(t *testing.T) {
+	s := &Server{}
+
+	caps, err := s.GetCapabilities(context.Background(), &providerv1.GetCapabilitiesRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, caps)
+	assert.True(t, caps.SupportsDiskExport, "ExportDisk is now wired over gRPC (issue #177)")
+	assert.True(t, caps.SupportsDiskImport, "ImportDisk is wired over gRPC")
+	assert.Equal(t, []string{"qcow2", "raw"}, caps.SupportedExportFormats)
+	assert.Equal(t, []string{"qcow2", "raw", "vmdk"}, caps.SupportedImportFormats)
+	assert.False(t, caps.SupportsExportCompression, "export path does not compress")
+}
+
+// fakeDiskProvider is a minimal contracts.Provider used to exercise the Server's
+// ExportDisk/GetDiskInfo delegation and type conversion without a live libvirt.
+// It embeds the interface so only the two methods under test need real bodies;
+// no other interface method is invoked by these tests.
+type fakeDiskProvider struct {
+	contracts.Provider
+
+	gotExport  contracts.ExportDiskRequest
+	exportResp contracts.ExportDiskResponse
+	exportErr  error
+
+	gotDiskInfo contracts.GetDiskInfoRequest
+	diskResp    contracts.GetDiskInfoResponse
+	diskErr     error
+}
+
+func (f *fakeDiskProvider) ExportDisk(_ context.Context, req contracts.ExportDiskRequest) (contracts.ExportDiskResponse, error) {
+	f.gotExport = req
+	return f.exportResp, f.exportErr
+}
+
+func (f *fakeDiskProvider) GetDiskInfo(_ context.Context, req contracts.GetDiskInfoRequest) (contracts.GetDiskInfoResponse, error) {
+	f.gotDiskInfo = req
+	return f.diskResp, f.diskErr
+}
+
+// TestServer_ExportDisk_DelegatesAndConverts verifies the Server translates the
+// gRPC request to the provider contract and the contract response back to gRPC,
+// including the DestinationUrl→DestinationURL and TaskRef→Task field mappings.
+func TestServer_ExportDisk_DelegatesAndConverts(t *testing.T) {
+	fake := &fakeDiskProvider{
+		exportResp: contracts.ExportDiskResponse{
+			ExportId:           "export-123",
+			TaskRef:            "task-abc",
+			EstimatedSizeBytes: 4096,
+			Checksum:           "deadbeef",
+		},
+	}
+	s := &Server{provider: fake}
+
+	resp, err := s.ExportDisk(context.Background(), &providerv1.ExportDiskRequest{
+		VmId:           "vm-1",
+		DiskId:         "disk-0",
+		SnapshotId:     "snap-1",
+		DestinationUrl: "pvc://mig/out.qcow2",
+		Format:         "qcow2",
+		Compress:       true,
+		Credentials:    map[string]string{"k": "v"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Request fields converted correctly.
+	assert.Equal(t, "vm-1", fake.gotExport.VmId)
+	assert.Equal(t, "disk-0", fake.gotExport.DiskId)
+	assert.Equal(t, "snap-1", fake.gotExport.SnapshotId)
+	assert.Equal(t, "pvc://mig/out.qcow2", fake.gotExport.DestinationURL)
+	assert.Equal(t, "qcow2", fake.gotExport.Format)
+	assert.True(t, fake.gotExport.Compress)
+	assert.Equal(t, map[string]string{"k": "v"}, fake.gotExport.Credentials)
+
+	// Response fields converted correctly.
+	assert.Equal(t, "export-123", resp.ExportId)
+	assert.Equal(t, int64(4096), resp.EstimatedSizeBytes)
+	assert.Equal(t, "deadbeef", resp.Checksum)
+	require.NotNil(t, resp.Task)
+	assert.Equal(t, "task-abc", resp.Task.Id)
+}
+
+// TestServer_ExportDisk_NoTaskRefOmitsTask verifies an empty TaskRef yields a nil
+// Task (rather than an empty TaskRef object).
+func TestServer_ExportDisk_NoTaskRefOmitsTask(t *testing.T) {
+	fake := &fakeDiskProvider{exportResp: contracts.ExportDiskResponse{ExportId: "e1"}}
+	s := &Server{provider: fake}
+
+	resp, err := s.ExportDisk(context.Background(), &providerv1.ExportDiskRequest{VmId: "vm-1"})
+
+	require.NoError(t, err)
+	assert.Nil(t, resp.Task, "empty TaskRef must map to a nil Task")
+}
+
+// TestServer_GetDiskInfo_DelegatesAndConverts verifies the full field mapping for
+// GetDiskInfo.
+func TestServer_GetDiskInfo_DelegatesAndConverts(t *testing.T) {
+	fake := &fakeDiskProvider{
+		diskResp: contracts.GetDiskInfoResponse{
+			DiskId:           "vm-1-disk",
+			Format:           "qcow2",
+			VirtualSizeBytes: 10 << 30,
+			ActualSizeBytes:  2 << 30,
+			Path:             "/var/lib/libvirt/images/vm-1-disk",
+			IsBootable:       true,
+			Snapshots:        []string{"s1", "s2"},
+			BackingFile:      "base.qcow2",
+			Metadata:         map[string]string{"pool": "default"},
+		},
+	}
+	s := &Server{provider: fake}
+
+	resp, err := s.GetDiskInfo(context.Background(), &providerv1.GetDiskInfoRequest{
+		VmId:   "vm-1",
+		DiskId: "disk-0",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, "vm-1", fake.gotDiskInfo.VmId)
+	assert.Equal(t, "disk-0", fake.gotDiskInfo.DiskId)
+
+	assert.Equal(t, "vm-1-disk", resp.DiskId)
+	assert.Equal(t, "qcow2", resp.Format)
+	assert.Equal(t, int64(10<<30), resp.VirtualSizeBytes)
+	assert.Equal(t, int64(2<<30), resp.ActualSizeBytes)
+	assert.Equal(t, "/var/lib/libvirt/images/vm-1-disk", resp.Path)
+	assert.True(t, resp.IsBootable)
+	assert.Equal(t, []string{"s1", "s2"}, resp.Snapshots)
+	assert.Equal(t, "base.qcow2", resp.BackingFile)
+	assert.Equal(t, map[string]string{"pool": "default"}, resp.Metadata)
+}
+
+// TestServer_DiskOps_NilProvider verifies both RPCs error cleanly when the
+// provider is not initialized rather than panicking.
+func TestServer_DiskOps_NilProvider(t *testing.T) {
+	s := &Server{}
+
+	_, err := s.ExportDisk(context.Background(), &providerv1.ExportDiskRequest{VmId: "vm-1"})
+	require.Error(t, err)
+
+	_, err = s.GetDiskInfo(context.Background(), &providerv1.GetDiskInfoRequest{VmId: "vm-1"})
+	require.Error(t, err)
 }


### PR DESCRIPTION
## What

Wire libvirt's `ExportDisk` and `GetDiskInfo` into the gRPC server.

- `internal/providers/libvirt/server.go`: add `Server.ExportDisk` and `Server.GetDiskInfo` that delegate to the existing `Provider` implementations in `provider_virsh.go` (translating gRPC ↔ provider-contract types).
- `GetCapabilities` now advertises `SupportsDiskExport=true`, `SupportsDiskImport=true`, `SupportedExportFormats=[qcow2, raw]`, `SupportedImportFormats=[qcow2, raw, vmdk]`, `SupportsExportCompression=false`.
- `internal/providers/libvirt/server_test.go`: conversion + nil-provider + capability tests.

Fixes #177.

## Why

The libvirt provider **already had working `ExportDisk`/`GetDiskInfo`** (`provider_virsh.go`: real `qemu-img`/storage-pool logic), but the gRPC `Server` never delegated to them — the embedded `UnimplementedProviderServer` answered the RPCs. So over the wire libvirt returned `Unimplemented`, and the manager's migration controller couldn't use libvirt as a disk-export source or read disk info, despite the implementation existing. This is dead-but-correct code made reachable.

## Verification

- `make lint` → 0 issues
- `make build` → OK (manager + `provider-libvirt`)
- `make test` → all packages pass
- `go test -race ./internal/providers/libvirt/` → pass, incl. 5 new tests (conversion correctness, `DestinationUrl`→`DestinationURL` and `TaskRef`→`Task` mappings, nil-provider error, capability flags)
- No existing conformance/contract test asserted the old `Unimplemented` behavior (grep clean).
- **Lab validation pending** — I'll exercise a real libvirt disk export on vr1 before recommending merge (this RPC is reachable via the migration controller).

## Risk

Low/additive. Libvirt-only; no proto/CRD change. An RPC that returned `Unimplemented` now returns real results. Manager-side client already had `ExportDisk`/`GetDiskInfo` wrappers, so no manager change was needed. Reversible by revert.
