### PR TITLE
fix(controller): don't mount deleting migration PVCs; watch them (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-06 13:57] - Fix: migration PVCs being deleted no longer wedge the provider rollout (#184)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/controller/provider_controller.go`: `discoverMigrationPVCs` and `discoverMigrationVolumeMounts` now **skip migration PVCs that are being deleted** (`DeletionTimestamp != nil`). Mounting a `Terminating` PVC into a freshly-rolled provider pod made that pod unschedulable (`persistentvolumeclaim "<pvc>" is being deleted`); combined with the running pod holding the PVC, this deadlocked both the PVC deletion and the provider rollout.
+- `internal/controller/provider_controller.go`: the provider controller now **watches migration-storage PVCs** and re-reconciles the namespace's `Provider`s when one appears or starts deleting, so provider Deployments mount/unmount migration storage promptly instead of waiting for the next resync.
+- Extracted the migration-PVC label into `migrationPVCLabelKey`/`migrationPVCLabelValue` constants (was a repeated literal).
+
+### Added
+- `internal/controller/provider_controller_migration_test.go`: unit tests (fake client) asserting deleting PVCs are skipped by both discovery functions and that the PVC→Provider watch map function enqueues same-namespace providers (and ignores non-migration PVCs).
+
+### Why
+A `VMMigration` that fails or is deleted mid-flight leaves its scratch PVC being deleted while the long-running provider pod still mounts it. The provider controller previously re-mounted every `migration-storage` PVC unconditionally, so the deleting PVC could never be unmounted — wedging the source provider's next rollout and leaving the PVC stuck `Terminating`. Observed on the lab during #177 validation; recovery required manual finalizer/annotation surgery. Fixes #184.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout — manager image must be updated to get the fix
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-06 08:04] - Libvirt: wire ExportDisk/GetDiskInfo into the gRPC server (#177)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -34,7 +34,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
 	"github.com/projectbeskar/virtrigaud/internal/k8s"
@@ -913,6 +915,25 @@ func (r *ProviderReconciler) buildPodVolumes(provider *infravirtrigaudiov1beta1.
 	return volumes
 }
 
+const (
+	// migrationPVCLabelKey and migrationPVCLabelValue identify a migration scratch
+	// PVC created by the VMMigration controller. The provider controller discovers
+	// these PVCs and mounts them into provider pods so migrations can read/write
+	// the transfer disk.
+	migrationPVCLabelKey   = "virtrigaud.io/component"
+	migrationPVCLabelValue = "migration-storage"
+)
+
+// migrationPVCIsMountable reports whether a discovered migration PVC should be
+// mounted into provider pods. PVCs that are being deleted are skipped: mounting a
+// Terminating PVC into a freshly-rolled provider pod makes that pod
+// unschedulable ("persistentvolumeclaim is being deleted") and, because the
+// running provider pod keeps the PVC mounted, prevents the PVC from ever
+// finishing deletion — which wedges the provider rollout (issue #184).
+func migrationPVCIsMountable(pvc *corev1.PersistentVolumeClaim) bool {
+	return pvc.DeletionTimestamp.IsZero()
+}
+
 // discoverMigrationPVCs finds all migration PVCs in the namespace and returns volume definitions for them
 func (r *ProviderReconciler) discoverMigrationPVCs(ctx context.Context, namespace string) []corev1.Volume {
 	var volumes []corev1.Volume
@@ -922,7 +943,7 @@ func (r *ProviderReconciler) discoverMigrationPVCs(ctx context.Context, namespac
 	err := r.List(ctx, pvcList,
 		client.InNamespace(namespace),
 		client.MatchingLabels{
-			"virtrigaud.io/component": "migration-storage",
+			migrationPVCLabelKey: migrationPVCLabelValue,
 		},
 	)
 
@@ -932,7 +953,12 @@ func (r *ProviderReconciler) discoverMigrationPVCs(ctx context.Context, namespac
 	}
 
 	// Create a volume for each migration PVC
-	for _, pvc := range pvcList.Items {
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+		if !migrationPVCIsMountable(pvc) {
+			continue // PVC is being deleted; do not mount it (issue #184)
+		}
+
 		// Generate a safe volume name from PVC name (K8s volume names must be DNS label)
 		volumeName := fmt.Sprintf("migration-%s", pvc.Name)
 
@@ -958,7 +984,7 @@ func (r *ProviderReconciler) discoverMigrationVolumeMounts(ctx context.Context, 
 	err := r.List(ctx, pvcList,
 		client.InNamespace(namespace),
 		client.MatchingLabels{
-			"virtrigaud.io/component": "migration-storage",
+			migrationPVCLabelKey: migrationPVCLabelValue,
 		},
 	)
 
@@ -968,7 +994,12 @@ func (r *ProviderReconciler) discoverMigrationVolumeMounts(ctx context.Context, 
 	}
 
 	// Create a volume mount for each migration PVC
-	for _, pvc := range pvcList.Items {
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+		if !migrationPVCIsMountable(pvc) {
+			continue // PVC is being deleted; do not mount it (issue #184)
+		}
+
 		// Generate a safe volume name (must match the volume name in buildPodVolumes)
 		volumeName := fmt.Sprintf("migration-%s", pvc.Name)
 
@@ -984,6 +1015,31 @@ func (r *ProviderReconciler) discoverMigrationVolumeMounts(ctx context.Context, 
 	}
 
 	return mounts
+}
+
+// providersForMigrationPVC maps a migration storage PVC event to reconcile
+// requests for every Provider in the PVC's namespace, so provider Deployments
+// are re-rolled promptly when a migration PVC appears or starts deleting —
+// rather than waiting for the next periodic resync (issue #184). Non-migration
+// PVCs are ignored.
+func (r *ProviderReconciler) providersForMigrationPVC(ctx context.Context, obj client.Object) []reconcile.Request {
+	if obj.GetLabels()[migrationPVCLabelKey] != migrationPVCLabelValue {
+		return nil
+	}
+
+	providerList := &infravirtrigaudiov1beta1.ProviderList{}
+	if err := r.List(ctx, providerList, client.InNamespace(obj.GetNamespace())); err != nil {
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(providerList.Items))
+	for i := range providerList.Items {
+		p := &providerList.Items[i]
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: p.Namespace, Name: p.Name},
+		})
+	}
+	return requests
 }
 
 // countConnectedVMs counts the number of VirtualMachines managed by this provider
@@ -1048,6 +1104,13 @@ func (r *ProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&infravirtrigaudiov1beta1.Provider{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		// Re-reconcile a namespace's Providers when a migration storage PVC
+		// appears or starts deleting, so provider Deployments mount/unmount it
+		// promptly instead of waiting for the next resync (issue #184).
+		Watches(
+			&corev1.PersistentVolumeClaim{},
+			handler.EnqueueRequestsFromMapFunc(r.providersForMigrationPVC),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 5, // Process up to 5 providers in parallel
 		}).

--- a/internal/controller/provider_controller_migration_test.go
+++ b/internal/controller/provider_controller_migration_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+)
+
+// migrationTestScheme builds a scheme with the core + infra types used by these tests.
+func migrationTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, infravirtrigaudiov1beta1.AddToScheme(s))
+	return s
+}
+
+func migrationPVC(name, ns string, withFinalizer bool) *corev1.PersistentVolumeClaim {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{migrationPVCLabelKey: migrationPVCLabelValue},
+		},
+	}
+	if withFinalizer {
+		// A finalizer lets the fake client retain the object (with a
+		// DeletionTimestamp) after Delete, simulating a stuck Terminating PVC.
+		pvc.Finalizers = []string{"kubernetes.io/pvc-protection"}
+	}
+	return pvc
+}
+
+// TestDiscoverMigrationPVCs_SkipsDeletingPVCs verifies that a migration PVC that
+// is being deleted is NOT turned into a provider volume (issue #184): mounting a
+// Terminating PVC would wedge the provider rollout.
+func TestDiscoverMigrationPVCs_SkipsDeletingPVCs(t *testing.T) {
+	ctx := context.Background()
+	scheme := migrationTestScheme(t)
+	ns := "default"
+
+	normal := migrationPVC("mig-normal", ns, false)
+	deleting := migrationPVC("mig-deleting", ns, true)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(normal, deleting).Build()
+	// Delete the second PVC: its finalizer keeps it present with a DeletionTimestamp.
+	require.NoError(t, c.Delete(ctx, deleting))
+
+	r := &ProviderReconciler{Client: c, Scheme: scheme}
+
+	volumes := r.discoverMigrationPVCs(ctx, ns)
+
+	require.Len(t, volumes, 1, "only the non-deleting migration PVC should be mounted")
+	assert.Equal(t, "migration-mig-normal", volumes[0].Name)
+	require.NotNil(t, volumes[0].PersistentVolumeClaim)
+	assert.Equal(t, "mig-normal", volumes[0].PersistentVolumeClaim.ClaimName)
+}
+
+// TestDiscoverMigrationVolumeMounts_SkipsDeletingPVCs verifies the mount side
+// mirrors the volume side (issue #184).
+func TestDiscoverMigrationVolumeMounts_SkipsDeletingPVCs(t *testing.T) {
+	ctx := context.Background()
+	scheme := migrationTestScheme(t)
+	ns := "default"
+
+	normal := migrationPVC("mig-normal", ns, false)
+	deleting := migrationPVC("mig-deleting", ns, true)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(normal, deleting).Build()
+	require.NoError(t, c.Delete(ctx, deleting))
+
+	r := &ProviderReconciler{Client: c, Scheme: scheme}
+
+	mounts := r.discoverMigrationVolumeMounts(ctx, ns)
+
+	require.Len(t, mounts, 1, "only the non-deleting migration PVC should be mounted")
+	assert.Equal(t, "migration-mig-normal", mounts[0].Name)
+	assert.Equal(t, "/mnt/migration-storage/mig-normal", mounts[0].MountPath)
+}
+
+// TestProvidersForMigrationPVC verifies the watch map function enqueues every
+// Provider in the PVC's namespace for a migration PVC, and ignores non-migration
+// PVCs (issue #184).
+func TestProvidersForMigrationPVC(t *testing.T) {
+	ctx := context.Background()
+	scheme := migrationTestScheme(t)
+	ns := "default"
+
+	p1 := &infravirtrigaudiov1beta1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: ns}}
+	p2 := &infravirtrigaudiov1beta1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: ns}}
+	other := &infravirtrigaudiov1beta1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "p3", Namespace: "other-ns"}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(p1, p2, other).Build()
+	r := &ProviderReconciler{Client: c, Scheme: scheme}
+
+	t.Run("migration PVC enqueues same-namespace providers", func(t *testing.T) {
+		reqs := r.providersForMigrationPVC(ctx, migrationPVC("mig-x", ns, false))
+		names := map[string]bool{}
+		for _, req := range reqs {
+			assert.Equal(t, ns, req.Namespace)
+			names[req.Name] = true
+		}
+		assert.Len(t, reqs, 2)
+		assert.True(t, names["p1"] && names["p2"], "both same-namespace providers enqueued")
+		assert.False(t, names["p3"], "providers in other namespaces are not enqueued")
+	})
+
+	t.Run("non-migration PVC is ignored", func(t *testing.T) {
+		plain := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "plain", Namespace: ns}}
+		assert.Nil(t, r.providersForMigrationPVC(ctx, plain))
+	})
+}


### PR DESCRIPTION
## What

Stop a deleting/failed `VMMigration`'s scratch PVC from wedging the source provider's rollout.

- `internal/controller/provider_controller.go`:
  - `discoverMigrationPVCs` / `discoverMigrationVolumeMounts` now **skip migration PVCs with a `DeletionTimestamp`** (don't mount a `Terminating` PVC).
  - The provider controller now **watches `migration-storage` PVCs** and re-reconciles the namespace's `Provider`s when one appears or starts deleting, so the Deployment mounts/unmounts migration storage promptly (not at the next resync).
  - Migration-PVC label extracted to `migrationPVCLabelKey`/`migrationPVCLabelValue` constants.
- `internal/controller/provider_controller_migration_test.go`: fake-client unit tests for the skip logic (both discover funcs) and the PVC→Provider watch map func.

Fixes #184.

## Why

The provider controller mounted **every** `migration-storage`-labeled PVC into the long-running provider pod, unconditionally on every reconcile. When a migration's PVC was deleted (migration completes/fails, or `VMMigration` deleted mid-flight) it got stuck `Terminating` because the provider pod still mounted it; meanwhile the controller kept re-adding the volume, so any provider rollout produced a pod stuck `Pending` (`persistentvolumeclaim "<pvc>" is being deleted`). Deadlock. This actually wedged the lab's libvirt provider during #177 validation and required manual finalizer surgery to recover.

Skipping PVCs that are being deleted breaks the deadlock: the controller drops the volume, the provider rolls to a clean pod, the PVC unmounts and finishes deleting.

## Verification

- `make fmt` clean · `make lint` 0 issues · `make build` OK · `make test` controller package passes (incl. 3 new tests, `-race`).
- New unit tests assert: deleting PVCs are excluded from both volumes and mounts; the watch map func enqueues same-namespace providers and ignores non-migration PVCs.
- RBAC unchanged — the provider controller already declares `get;list;watch` on `persistentvolumeclaims`.
- Lab validation on `vr1` (isolated throwaway provider/PVC, **not** the 13-VM production provider) to follow before merge.

## Risk

Low. Manager-only controller change; no proto/CRD/provider change. Behavior is strictly more conservative (skips a PVC that's going away) plus a watch that improves responsiveness. Reverts cleanly.
