### PR TITLE
fix(vsphere): advertise disk export/import capabilities accurately (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-07 12:05] - vSphere: advertise disk export/import capabilities accurately (#178)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/vsphere/server.go`: `GetCapabilities` now reports `SupportsDiskExport=true`, `SupportsDiskImport=true`, `SupportedExportFormats=[vmdk, qcow2, raw]`, `SupportedImportFormats=[vmdk, qcow2, raw]`, and `SupportsExportCompression=true`. These were previously left at the zero value (`false`/empty), understating capabilities that vSphere actually implements (`ExportDisk` clones to a compressed streamOptimized VMDK and converts to the target format; `ImportDisk` accepts and converts those formats).
+
+### Added
+- `internal/providers/vsphere/capabilities_test.go`: asserts the corrected disk-migration flags + formats, and that existing flags are unchanged.
+
+### Why
+The understated flags are harmless today (the manager surfaces but does not yet enforce capabilities) but become load-bearing once `--enforce-provider-capabilities` (#176) is enabled: gating on `SupportsDiskExport`/`SupportsDiskImport=false` would wrongly refuse vSphere migrations it can actually perform. Confirmed live on the lab during #176 validation — vSphere's `status.reportedCapabilities` showed disk export/import absent (false). This unblocks safely enabling capability gating. Fixes #178.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout — only to ship the rebuilt vSphere provider image; no behavior change (capabilities are advisory until gating is enabled)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-07 12:00] - Capability negotiation: surface provider capabilities + opt-in gating (#176)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/vsphere/capabilities_test.go
+++ b/internal/providers/vsphere/capabilities_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestGetCapabilities_DiskMigration verifies vSphere advertises its implemented
+// disk export/import capabilities and formats accurately (issue #178). These
+// were previously left at the zero value, understating real support — which
+// would wrongly block vSphere migrations once capability gating is enabled (#176).
+func TestGetCapabilities_DiskMigration(t *testing.T) {
+	p := &Provider{}
+
+	caps, err := p.GetCapabilities(context.Background(), &providerv1.GetCapabilitiesRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, caps)
+
+	// The corrected disk-migration flags (issue #178).
+	assert.True(t, caps.SupportsDiskExport, "vSphere implements ExportDisk")
+	assert.True(t, caps.SupportsDiskImport, "vSphere implements ImportDisk")
+	assert.Equal(t, []string{"vmdk", "qcow2", "raw"}, caps.SupportedExportFormats)
+	assert.Equal(t, []string{"vmdk", "qcow2", "raw"}, caps.SupportedImportFormats)
+	assert.True(t, caps.SupportsExportCompression, "export uses compressed streamOptimized VMDK")
+
+	// Sanity: existing flags remain unchanged.
+	assert.True(t, caps.SupportsSnapshots)
+	assert.True(t, caps.SupportsLinkedClones)
+	assert.False(t, caps.SupportsMemorySnapshots)
+}

--- a/internal/providers/vsphere/server.go
+++ b/internal/providers/vsphere/server.go
@@ -379,6 +379,14 @@ func (p *Provider) GetCapabilities(ctx context.Context, req *providerv1.GetCapab
 		SupportsImageImport:         true,
 		SupportedDiskTypes:          []string{"thin", "thick", "eager-zeroed"},
 		SupportedNetworkTypes:       []string{"standard", "distributed"},
+		// Disk migration: ExportDisk and ImportDisk are implemented (issue #178).
+		// Previously these were left at the zero value, understating real support
+		// and (once capability gating is enabled, #176) wrongly blocking migration.
+		SupportsDiskExport:        true,
+		SupportsDiskImport:        true,
+		SupportedExportFormats:    []string{"vmdk", "qcow2", "raw"}, // ExportDisk converts the streamOptimized VMDK to these
+		SupportedImportFormats:    []string{"vmdk", "qcow2", "raw"}, // ImportDisk accepts these and converts to VMDK
+		SupportsExportCompression: true,                             // export uses the compressed streamOptimized VMDK format
 	}, nil
 }
 


### PR DESCRIPTION
## What

Correct vSphere `GetCapabilities` to advertise its real disk-migration support (#178):

- `SupportsDiskExport=true`, `SupportsDiskImport=true`
- `SupportedExportFormats=[vmdk, qcow2, raw]`, `SupportedImportFormats=[vmdk, qcow2, raw]`
- `SupportsExportCompression=true`

These were previously left at the zero value (`false`/empty), understating capabilities vSphere actually implements: `ExportDisk` clones the disk to a compressed streamOptimized VMDK and converts to the requested format via `diskutil`; `ImportDisk` accepts `vmdk`/`qcow2`/`raw` and converts to VMDK.

Closes #178.

## Why

Harmless today (the manager surfaces capabilities but doesn't enforce them), but **load-bearing once `--enforce-provider-capabilities` (#176) is enabled**: gating on `SupportsDiskExport`/`SupportsDiskImport=false` would wrongly refuse vSphere migrations it can actually perform. This was **confirmed live** during #176 lab validation — vSphere's `status.reportedCapabilities` showed disk export/import absent (false). This PR is the prerequisite for safely enabling capability gating.

## Verification

- `make fmt` clean · `make lint` 0 issues · `make build` OK · `make test` passes.
- New unit test `internal/providers/vsphere/capabilities_test.go` asserts the corrected flags + formats and that existing flags are unchanged.
- **Lab validation deferred to the next RC** (normal `helm upgrade` on vr1): this is a capability-flag-only change with no behavior change to the already-working export/import, and the surfacing path was validated live in #176. Rolling the production vSphere provider for a flag string would be disproportionate risk.

## Risk

Minimal. vSphere-provider-only `GetCapabilities` response change; no change to actual export/import behavior, no proto/CRD change. The corrected flags only become behavior-affecting if/when gating is explicitly enabled.
