### PR TITLE
feat(controller): VMClone controller (MVP) + VMSet stub + VM double-create guard (#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-07 09:00] - VMClone controller (MVP), VMSet stub, VMPlacementPolicy reference-only, VM double-create guard (#179)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/contracts/clone.go`: `CloneRequest`/`CloneResponse` structs and a narrow `Cloner` optional capability interface (mirrors `CapabilityReporter`; does NOT widen the core `Provider` interface).
+- `internal/transport/grpc/client.go`: `(*Client).Clone` implementing `contracts.Cloner` over the existing proto `Clone` RPC; compile-time assertions that `*Client` satisfies `Provider`, `CapabilityReporter`, and `Cloner`.
+- `internal/controller/vmclone_controller.go`: new VMClone reconciler (MVP) — `source.vmRef` only, same-provider, full & linked clones. Resolves source VM + provider, intrinsic linked-clone capability pre-check (fail-open), idempotent clone, task polling, and binds a target VirtualMachine CR (seeds `Status.ID`, `virtrigaud.io/adopted=true`, clone provenance annotations). Deleting a VMClone never deletes the produced VM.
+- `internal/controller/vmset_controller.go`: not-yet-active VMSet stub reconciler that sets `Ready=False / ControllerNotImplemented` and nothing else.
+- `api/infra.virtrigaud.io/v1beta1/vmclone_types.go`: additive `Status.TargetVMID` field to persist the provider's cloned VM ID across reconciles.
+- `cmd/manager/main.go`: register the VMClone and VMSet reconcilers.
+- `internal/controller/{vmclone,vmset,virtualmachine_controller_adopted}_controller_test.go`: unit tests — VMClone happy path / idempotency / linked-blocked / linked-fail-open / non-vmRef source / non-Cloner provider / source-missing / deletion-preserves-target; VMSet stub condition; Part B adopted-guard (no provider Create) + non-adopted control.
+- `examples/vmclone-basic.yaml`: vmRef-source full-clone example.
+
+### Changed
+- `internal/controller/virtualmachine_controller.go`: the create decision now skips create for a VM labeled `virtrigaud.io/adopted=true` while `Status.ID` is empty (requeues instead), preventing a double-create while the adoption/clone controller sets `Status.ID`. Behavior for normal VMs is unchanged. Added `vmIsAdopted` helper.
+- `internal/controller/vmadoption_controller.go`: promoted the `virtrigaud.io/adopted` label key/value to shared `AdoptedLabel`/`AdoptedLabelValue` constants and reuse them in place of literals.
+- `config/crd/bases/`, `charts/virtrigaud/crds/`: regenerated VMClone CRD with the new `targetVMID` status field.
+- `config/rbac/role.yaml`, `charts/virtrigaud/templates/manager-rbac.yaml`: added RBAC for `vmclones` (get/list/watch/update/patch + status + finalizers) and `vmsets` (get/list/watch + status); VirtualMachine create was already granted.
+- `README.md`: CRD table now lists controller status — VMClone active (MVP), VMSet not yet active (stub), VMPlacementPolicy reference-only.
+
+### Why
+VMClone, VMSet, and VMPlacementPolicy shipped as CRDs without controllers. This wires VMClone end-to-end (MVP), marks VMSet explicitly not-yet-active rather than silently inert, and documents VMPlacementPolicy as a reference-only policy object. The VirtualMachine double-create guard closes a real correctness gap: an adopted/cloned VM CR briefly has an empty `Status.ID`, during which the VM controller would otherwise create a second VM on the provider. libvirt's `Clone` is `Unimplemented`, so a libvirt clone surfaces a clear `Phase=Failed/ProviderError` rather than a silent no-op.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (CRD `targetVMID` field, new RBAC, two new controllers)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Usage
+```yaml
+apiVersion: infra.virtrigaud.io/v1beta1
+kind: VMClone
+metadata:
+  name: basic-clone
+  namespace: default
+spec:
+  source:
+    vmRef:
+      name: my-source-vm
+  target:
+    name: my-cloned-vm
+    classRef:
+      name: standard-vm
+  options:
+    type: FullClone   # or LinkedClone (requires provider support)
+```
+
+---
+
 ## [2026-06-07 12:05] - vSphere: advertise disk export/import capabilities accurately (#178)
 **Author:** @wrkode (William Rizzo)
 

--- a/README.md
+++ b/README.md
@@ -98,18 +98,18 @@ For a full security disclosure, see the [Security Operations Guide](https://proj
 
 ## CRDs (10 total, all v1beta1)
 
-| CRD | Short name | Description |
-|-----|-----------|-------------|
-| VirtualMachine | vm | A virtual machine instance |
-| VMClass | vmc | Resource profile (CPU, memory, disk) |
-| VMImage | vmi | Base template or image reference |
-| VMNetworkAttachment | vmna | Network configuration |
-| Provider | prov | Hypervisor connection + runtime config |
-| VMMigration | vmmig | Cross-provider VM migration |
-| VMSet | vmset | Multi-VM replica set |
-| VMPlacementPolicy | — | Placement rules (affinity, resources) |
-| VMSnapshot | — | Snapshot lifecycle management |
-| VMClone | — | Cloning operations |
+| CRD | Short name | Controller | Description |
+|-----|-----------|------------|-------------|
+| VirtualMachine | vm | active | A virtual machine instance |
+| VMClass | vmc | active | Resource profile (CPU, memory, disk) |
+| VMImage | vmi | active | Base template or image reference |
+| VMNetworkAttachment | vmna | active | Network configuration |
+| Provider | prov | active | Hypervisor connection + runtime config |
+| VMMigration | vmmig | active | Cross-provider VM migration |
+| VMSnapshot | — | active | Snapshot lifecycle management |
+| VMClone | vmclone | active (MVP) | Cloning operations — MVP: `source.vmRef` source, same-provider, full & linked clones |
+| VMSet | vmset | not yet active | Multi-VM replica set — controller is a stub that reports `Ready=False / ControllerNotImplemented` |
+| VMPlacementPolicy | — | reference-only | Placement rules (affinity, resources) — a policy object referenced by `VirtualMachine.spec.placementRef`; no standalone controller |
 
 Note: VMAdoption is a **controller** built into the manager, not a CRD.
 

--- a/api/infra.virtrigaud.io/v1beta1/vmclone_types.go
+++ b/api/infra.virtrigaud.io/v1beta1/vmclone_types.go
@@ -484,6 +484,13 @@ type VMCloneStatus struct {
 	// +optional
 	TargetRef *LocalObjectReference `json:"targetRef,omitempty"`
 
+	// TargetVMID is the provider-specific identifier of the cloned VM as
+	// returned by the provider Clone operation. The controller persists it so
+	// the produced VirtualMachine CR's Status.ID can be seeded after an
+	// asynchronous clone task completes.
+	// +optional
+	TargetVMID string `json:"targetVMID,omitempty"`
+
 	// Phase represents the current phase of the clone operation
 	// +optional
 	Phase ClonePhase `json:"phase,omitempty"`

--- a/charts/virtrigaud/templates/manager-rbac.yaml
+++ b/charts/virtrigaud/templates/manager-rbac.yaml
@@ -23,8 +23,9 @@ metadata:
 rules:
 # virtrigaud CRDs the manager actively manages (create + mutate + delete).
 # Verb sets are least-privilege per issue #152: only the resources whose
-# controllers actually write are granted write verbs. vmclones, vmsets and
-# vmplacementpolicies were dropped — no controller reconciles them.
+# controllers actually write are granted write verbs. vmplacementpolicy
+# remains reference-only (no standalone controller); vmclones and vmsets now
+# have controllers and are granted their scoped verbs below (issue #179).
 - apiGroups:
   - infra.virtrigaud.io
   resources:
@@ -48,6 +49,39 @@ rules:
   - patch
   - update
   - watch
+# VMClone has a controller (issue #179) that updates the VMClone and its
+# status/finalizers but never creates or deletes VMClones (users do). It
+# creates VirtualMachines — that write verb is granted in the block above.
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmclones
+  - vmclones/status
+  - vmclones/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# VMSet has a not-yet-active stub controller (issue #179) that only reports a
+# ControllerNotImplemented condition: read VMSets, write only their status.
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmsets/status
+  verbs:
+  - get
+  - patch
+  - update
 # VMClass is created/updated by the adoption controller but never deleted by
 # the manager, so it omits the delete verb.
 - apiGroups:
@@ -184,8 +218,9 @@ metadata:
 rules:
 # virtrigaud CRDs the manager actively manages (create + mutate + delete).
 # Verb sets are least-privilege per issue #152: only the resources whose
-# controllers actually write are granted write verbs. vmclones, vmsets and
-# vmplacementpolicies were dropped — no controller reconciles them.
+# controllers actually write are granted write verbs. vmplacementpolicy
+# remains reference-only (no standalone controller); vmclones and vmsets now
+# have controllers and are granted their scoped verbs below (issue #179).
 - apiGroups:
   - infra.virtrigaud.io
   resources:
@@ -209,6 +244,39 @@ rules:
   - patch
   - update
   - watch
+# VMClone has a controller (issue #179) that updates the VMClone and its
+# status/finalizers but never creates or deletes VMClones (users do). It
+# creates VirtualMachines — that write verb is granted in the block above.
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmclones
+  - vmclones/status
+  - vmclones/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# VMSet has a not-yet-active stub controller (issue #179) that only reports a
+# ControllerNotImplemented condition: read VMSets, write only their status.
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
+  - vmsets/status
+  verbs:
+  - get
+  - patch
+  - update
 # VMClass is created/updated by the adoption controller but never deleted by
 # the manager, so it omits the delete verb.
 - apiGroups:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -357,6 +357,28 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "VMAdoption")
 		os.Exit(1)
 	}
+
+	// Register VMClone controller (MVP: vmRef source, same-provider, full/linked)
+	vmcloneReconciler := controller.NewVMCloneReconciler(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		remoteResolver,
+		mgr.GetEventRecorderFor("vmclone-controller"),
+	)
+	if err = vmcloneReconciler.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VMClone")
+		os.Exit(1)
+	}
+
+	// Register VMSet controller (not-yet-active stub; reports
+	// ControllerNotImplemented condition only)
+	if err = (&controller.VMSetReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VMSet")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	// Register cert watchers with the manager so they run as Runnables

--- a/config/crd/bases/infra.virtrigaud.io_vmclones.yaml
+++ b/config/crd/bases/infra.virtrigaud.io_vmclones.yaml
@@ -978,6 +978,13 @@ spec:
                 required:
                 - name
                 type: object
+              targetVMID:
+                description: |-
+                  TargetVMID is the provider-specific identifier of the cloned VM as
+                  returned by the provider Clone operation. The controller persists it so
+                  the produced VirtualMachine CR's Status.ID can be seeded after an
+                  asynchronous clone task completes.
+                type: string
               taskRef:
                 description: TaskRef tracks any ongoing async operations
                 type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -64,6 +64,7 @@ rules:
   resources:
   - providers/finalizers
   - virtualmachines/finalizers
+  - vmclones/finalizers
   - vmmigrations/finalizers
   - vmsnapshots/finalizers
   verbs:
@@ -73,7 +74,9 @@ rules:
   resources:
   - providers/status
   - virtualmachines/status
+  - vmclones/status
   - vmmigrations/status
+  - vmsets/status
   - vmsnapshots/status
   verbs:
   - get
@@ -93,8 +96,19 @@ rules:
 - apiGroups:
   - infra.virtrigaud.io
   resources:
+  - vmclones
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infra.virtrigaud.io
+  resources:
   - vmimages
   - vmnetworkattachments
+  - vmsets
   verbs:
   - get
   - list

--- a/examples/vmclone-basic.yaml
+++ b/examples/vmclone-basic.yaml
@@ -1,0 +1,45 @@
+# Basic VM Clone Example (MVP, issue #179)
+#
+# Clones an existing VirtualMachine into a new one on the SAME provider.
+#
+# MVP scope:
+#   - Only source.vmRef is supported (snapshotRef/templateRef/imageRef are
+#     not yet implemented and will set Phase=Failed).
+#   - Same-provider clone only: the cloned VM lives on the source VM's
+#     provider.
+#   - FullClone (default) and LinkedClone are supported. LinkedClone is
+#     pre-checked against the provider's reported capabilities; a provider
+#     that does not support linked clones will set Phase=Failed.
+#
+# The controller produces a VirtualMachine CR named spec.target.name, seeds
+# its Status.ID with the provider's cloned VM ID, and labels it
+# virtrigaud.io/adopted=true so the VirtualMachine controller does not try to
+# create a second VM. Deleting this VMClone does NOT delete the produced VM.
+
+apiVersion: infra.virtrigaud.io/v1beta1
+kind: VMClone
+metadata:
+  name: basic-clone
+  namespace: default
+spec:
+  # Source: reference to an existing VirtualMachine CR in this namespace whose
+  # Status.ID is already populated (i.e. it has been provisioned).
+  source:
+    vmRef:
+      name: my-source-vm
+
+  # Target: the VirtualMachine CR the controller will create.
+  target:
+    name: my-cloned-vm
+    # Optional: override the VMClass for the clone. Defaults to the source
+    # VM's class when omitted.
+    classRef:
+      name: standard-vm
+    # Optional labels applied to the produced VM (the controller always also
+    # adds virtrigaud.io/adopted=true).
+    labels:
+      app: cloned-app
+
+  # Optional: clone behavior. Defaults to FullClone.
+  options:
+    type: FullClone # or LinkedClone (requires provider support)

--- a/internal/controller/virtualmachine_controller.go
+++ b/internal/controller/virtualmachine_controller.go
@@ -248,8 +248,25 @@ func (r *VirtualMachineReconciler) reconcileVM(ctx context.Context, vm *infravir
 		k8s.SetReconfiguringCondition(&vm.Status.Conditions, metav1.ConditionFalse, k8s.ReasonReconcileSuccess, "VM reconfigured successfully")
 	}
 
-	// Ensure VM exists
+	// Ensure VM exists.
+	//
+	// An adopted VM (labeled virtrigaud.io/adopted=true) has its underlying
+	// hypervisor VM created by the adoption/clone controller, which then sets
+	// Status.ID out-of-band. Between the CR appearing and that Status.ID write
+	// landing, Status.ID is briefly empty. Creating here in that window would
+	// produce a SECOND VM on the provider — the exact double-create the clone
+	// controller's Status.ID write is meant to prevent. So we only enter the
+	// create path for non-adopted VMs; an adopted VM with an empty Status.ID
+	// waits for its ID to be set (issue #179).
 	if vm.Status.ID == "" {
+		if vmIsAdopted(vm) {
+			logger.Info("Adopted VM has no Status.ID yet; waiting for adoption/clone controller to set it (not creating)",
+				"name", vm.Name, "namespace", vm.Namespace)
+			k8s.SetProvisioningCondition(&vm.Status.Conditions, metav1.ConditionTrue,
+				k8s.ReasonWaitingForDependencies, "Waiting for adoption/clone controller to set Status.ID")
+			r.updateStatus(ctx, vm)
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
 		logger.Info("Creating VM")
 		return r.createVM(ctx, vm, providerInstance, vmClass, vmImage, networks)
 	}
@@ -1094,6 +1111,16 @@ func recordIPDiscoveryIfFirstSeen(currentIPs, descIPs []string, creationTime met
 		return // defensive — CRs fetched via the API server always have this
 	}
 	metrics.RecordIPDiscovery(providerType, time.Since(creationTime.Time))
+}
+
+// vmIsAdopted reports whether the VirtualMachine is marked adopted, i.e. its
+// underlying hypervisor VM is created by the adoption/clone controller (which
+// sets Status.ID out-of-band) rather than by the VirtualMachine controller.
+// The VirtualMachine controller consults this before its create decision to
+// avoid double-creating a VM whose Status.ID has not yet been written (issue
+// #179).
+func vmIsAdopted(vm *infravirtrigaudiov1beta1.VirtualMachine) bool {
+	return vm.Labels[AdoptedLabel] == AdoptedLabelValue
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/virtualmachine_controller_adopted_test.go
+++ b/internal/controller/virtualmachine_controller_adopted_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+)
+
+// createCountingProvider records how many times Create is invoked. It embeds
+// stubProvider (Describe returns Exists=false by default, which would normally
+// trigger a create on the non-adopted path).
+type createCountingProvider struct {
+	stubProvider
+	createCnt int
+}
+
+func (p *createCountingProvider) Create(_ context.Context, _ contracts.CreateRequest) (contracts.CreateResponse, error) {
+	p.createCnt++
+	return contracts.CreateResponse{ID: "vm-newly-created"}, nil
+}
+
+// TestReconcileVM_AdoptedEmptyID_DoesNotCreate is the Part B guard test: an
+// adopted VM (virtrigaud.io/adopted=true) with an empty Status.ID must NOT be
+// sent to provider Create — its ID is set by the adoption/clone controller. The
+// controller should instead requeue and wait (issue #179).
+func TestReconcileVM_AdoptedEmptyID_DoesNotCreate(t *testing.T) {
+	s := coverageTestScheme(t)
+	ns := "default"
+	prov, class := providerAndClass(ns)
+
+	adoptedVM := baseVM(ns)
+	adoptedVM.Name = "adopted-vm"
+	adoptedVM.Labels = map[string]string{AdoptedLabel: AdoptedLabelValue}
+	// Status.ID is intentionally empty.
+
+	cp := &createCountingProvider{}
+	r := newTestReconciler(s, &stubResolver{provider: cp}, prov, class, adoptedVM)
+
+	res, err := r.reconcileVM(context.Background(), adoptedVM)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, cp.createCnt, "adopted VM with empty Status.ID must NOT be created")
+	assert.True(t, res.RequeueAfter > 0, "expected a requeue while waiting for Status.ID to be set")
+}
+
+// TestReconcileVM_NonAdoptedEmptyID_DoesCreate is the negative control: a NORMAL
+// (non-adopted) VM with an empty Status.ID still follows the create path, so the
+// guard does not regress normal VMs.
+func TestReconcileVM_NonAdoptedEmptyID_DoesCreate(t *testing.T) {
+	s := coverageTestScheme(t)
+	ns := "default"
+	prov, class := providerAndClass(ns)
+
+	normalVM := baseVM(ns)
+	normalVM.Name = "normal-vm"
+	// An ImportedDisk so createVM's "imageRef or importedDisk" validation passes.
+	normalVM.Spec.ImportedDisk = &infravirtrigaudiov1beta1.ImportedDiskRef{
+		DiskID: "disk-1",
+		Format: "qcow2",
+		Source: "manual",
+	}
+	// No adopted label, empty Status.ID.
+
+	cp := &createCountingProvider{}
+	r := newTestReconciler(s, &stubResolver{provider: cp}, prov, class, normalVM)
+
+	_, err := r.reconcileVM(context.Background(), normalVM)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, cp.createCnt, "normal VM with empty Status.ID must be created (no regression)")
+}
+
+// TestVMIsAdopted unit-tests the pure guard helper.
+func TestVMIsAdopted(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{"nil labels", nil, false},
+		{"no adopted label", map[string]string{"app": "x"}, false},
+		{"adopted true", map[string]string{AdoptedLabel: AdoptedLabelValue}, true},
+		{"adopted false", map[string]string{AdoptedLabel: "false"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vm := &infravirtrigaudiov1beta1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{Labels: tc.labels},
+			}
+			assert.Equal(t, tc.want, vmIsAdopted(vm))
+		})
+	}
+}

--- a/internal/controller/vmadoption_controller.go
+++ b/internal/controller/vmadoption_controller.go
@@ -60,6 +60,16 @@ const (
 	// Format: JSON object with optional fields: namePattern, powerState, minCPU, minMemoryMiB, maxCPU, maxMemoryMiB
 	// Example: {"namePattern": "prod-.*", "powerState": "on", "minCPU": 2}
 	AdoptionFilterAnnotation = "virtrigaud.io/adopt-filter"
+	// AdoptedLabel marks a VirtualMachine CR whose underlying VM already
+	// exists on the provider (it was adopted from the hypervisor or produced
+	// by the clone controller) rather than created by the VirtualMachine
+	// controller. The VirtualMachine controller uses this label to avoid a
+	// double-create while the adopting/cloning controller is still setting
+	// Status.ID (issue #179).
+	AdoptedLabel = "virtrigaud.io/adopted"
+	// AdoptedLabelValue is the value AdoptedLabel must hold to mark a VM as
+	// adopted.
+	AdoptedLabelValue = "true"
 )
 
 // VMAdoptionFilter defines the filter criteria for VM adoption
@@ -324,7 +334,7 @@ func (r *VMAdoptionReconciler) adoptVM(ctx context.Context, provider *infravirtr
 	}
 	if err := r.Get(ctx, vmKey, existingVM); err == nil {
 		// VM CR exists - check if it's an adopted VM that needs Status.ID fixed
-		if existingVM.Labels != nil && existingVM.Labels["virtrigaud.io/adopted"] == "true" {
+		if existingVM.Labels != nil && existingVM.Labels[AdoptedLabel] == AdoptedLabelValue {
 			if existingVM.Status.ID == "" {
 				// This is an adopted VM created before the status fix - update status now
 				logger.Info("Fixing Status.ID for existing adopted VM", "vm_name", vmName, "vm_id", vmInfo.ID)
@@ -365,7 +375,7 @@ func (r *VMAdoptionReconciler) adoptVM(ctx context.Context, provider *infravirtr
 			Name:      vmName,
 			Namespace: provider.Namespace,
 			Labels: map[string]string{
-				"virtrigaud.io/adopted": "true",
+				AdoptedLabel: AdoptedLabelValue,
 			},
 		},
 		Spec: infravirtrigaudiov1beta1.VirtualMachineSpec{
@@ -469,7 +479,7 @@ func (r *VMAdoptionReconciler) ensureVMClass(ctx context.Context, vmInfo contrac
 			Name:      className,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"virtrigaud.io/adopted": "true",
+				AdoptedLabel: AdoptedLabelValue,
 			},
 		},
 		Spec: infravirtrigaudiov1beta1.VMClassSpec{

--- a/internal/controller/vmclone_controller.go
+++ b/internal/controller/vmclone_controller.go
@@ -1,0 +1,627 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/obs/logging"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	"github.com/projectbeskar/virtrigaud/internal/util/k8s"
+)
+
+const (
+	// vmCloneFinalizer guards a VMClone so the controller runs its (minimal)
+	// cleanup before the object disappears. Deleting a VMClone never cascades
+	// to the produced target VM — only the finalizer is removed.
+	vmCloneFinalizer = "clone.infra.virtrigaud.io/finalizer"
+
+	// errReasonGetClone is the metrics.RecordError reason for a failed VMClone
+	// Get in the reconcile entry path.
+	errReasonGetClone = "get-clone"
+
+	// CloneAnnotationClonedFrom records the source VM the target was cloned
+	// from (provenance) on the produced VirtualMachine CR.
+	CloneAnnotationClonedFrom = "virtrigaud.io/cloned-from"
+	// CloneAnnotationClone records the VMClone resource that produced the
+	// target VirtualMachine CR (provenance).
+	CloneAnnotationClone = "virtrigaud.io/clone"
+
+	// cloneReasonUnsupportedSource is the condition reason used when the
+	// requested clone source type is not implemented in this MVP.
+	cloneReasonUnsupportedSource = "UnsupportedSource"
+	// cloneReasonLinkedUnsupported is the condition reason used when the
+	// provider reports it cannot perform linked clones.
+	cloneReasonLinkedUnsupported = "LinkedCloneUnsupported"
+)
+
+// VMCloneReconciler reconciles a VMClone object. It supports the MVP source
+// type (spec.source.vmRef), same-provider clones only: the produced VM lives
+// on the source VM's provider (issue #179).
+type VMCloneReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	// RemoteResolver resolves a Provider CR to a provider implementation. It
+	// is the ProviderResolver interface (satisfied by *remote.Resolver in
+	// production) so unit tests can inject a fake provider — mirroring the
+	// VirtualMachine controller.
+	RemoteResolver ProviderResolver
+	Recorder       record.EventRecorder
+}
+
+// NewVMCloneReconciler creates a new VMClone reconciler.
+func NewVMCloneReconciler(
+	c client.Client,
+	scheme *runtime.Scheme,
+	remoteResolver ProviderResolver,
+	recorder record.EventRecorder,
+) *VMCloneReconciler {
+	return &VMCloneReconciler{
+		Client:         c,
+		Scheme:         scheme,
+		RemoteResolver: remoteResolver,
+		Recorder:       recorder,
+	}
+}
+
+//+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmclones,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmclones/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmclones/finalizers,verbs=update
+//+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=virtualmachines,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=virtualmachines/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmclasses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=providers,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
+// Reconcile drives a VMClone through its phases: validate the source, resolve
+// the provider, pre-check linked-clone capability, clone (idempotently), poll
+// the task, then bind a target VirtualMachine CR to the produced VM.
+//
+// Observability: per-call timer + outcome inference via deferred block emits
+// `virtrigaud_manager_reconcile_total{kind="VMClone",outcome=...}` and the
+// duration histogram. Named return values (`result`, `retErr`) are required by
+// the deferred block — do not change the signature without updating the defer.
+func (r *VMCloneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
+	timer := metrics.NewReconcileTimer("VMClone")
+	defer func() {
+		outcome := metrics.OutcomeSuccess
+		switch {
+		case retErr != nil:
+			outcome = metrics.OutcomeError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metrics.OutcomeRequeue
+		}
+		timer.Finish(outcome)
+	}()
+
+	ctx = logging.WithCorrelationID(ctx, fmt.Sprintf("vmclone-%s/%s", req.Namespace, req.Name))
+	logger := logging.FromContext(ctx)
+	logger.Info("Reconciling VMClone", "clone", req.NamespacedName)
+
+	clone := &infrav1beta1.VMClone{}
+	if err := r.Get(ctx, req.NamespacedName, clone); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			logger.Info("VMClone not found, ignoring")
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Failed to get VMClone")
+		metrics.RecordError(errReasonGetClone, metrics.ComponentManager)
+		return ctrl.Result{}, err
+	}
+
+	// Handle deletion: removing a VMClone must NOT delete the target VM. Just
+	// drop the finalizer.
+	if !clone.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, clone)
+	}
+
+	// Add finalizer if needed.
+	if !controllerutil.ContainsFinalizer(clone, vmCloneFinalizer) {
+		controllerutil.AddFinalizer(clone, vmCloneFinalizer)
+		if err := r.Update(ctx, clone); err != nil {
+			logger.Error(err, "Failed to add finalizer")
+			metrics.RecordError(errReasonAddFinalizer, metrics.ComponentManager)
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Terminal states: nothing further to do.
+	switch clone.Status.Phase {
+	case infrav1beta1.ClonePhaseReady, infrav1beta1.ClonePhaseFailed:
+		return ctrl.Result{}, nil
+	}
+
+	clone.Status.ObservedGeneration = clone.Generation
+
+	// Validate source type: MVP supports only spec.source.vmRef.
+	if clone.Spec.Source.VMRef == nil || clone.Spec.Source.VMRef.Name == "" {
+		return r.markFailed(ctx, clone, cloneReasonUnsupportedSource,
+			"clone source type not yet supported; use source.vmRef"), nil
+	}
+
+	// Resolve the source VirtualMachine CR (same namespace as the VMClone).
+	sourceVM := &infrav1beta1.VirtualMachine{}
+	sourceKey := client.ObjectKey{Namespace: clone.Namespace, Name: clone.Spec.Source.VMRef.Name}
+	if err := r.Get(ctx, sourceKey, sourceVM); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("Source VM not found yet, waiting", "vm", sourceKey.Name)
+			return r.markPending(ctx, clone, infrav1beta1.VMCloneReasonSourceNotFound,
+				fmt.Sprintf("source VM %q not found", sourceKey.Name)), nil
+		}
+		logger.Error(err, "Failed to get source VM", "vm", sourceKey.Name)
+		metrics.RecordError(errReasonGetVM, metrics.ComponentManager)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	if sourceVM.Status.ID == "" {
+		logger.Info("Source VM not yet provisioned (empty Status.ID), waiting", "vm", sourceKey.Name)
+		return r.markPending(ctx, clone, infrav1beta1.VMCloneReasonCloning,
+			"waiting for source VM to be provisioned"), nil
+	}
+
+	// Resolve the source provider — the produced VM lives on this provider
+	// (same-provider clone only in this MVP).
+	provider := &infrav1beta1.Provider{}
+	providerKey := client.ObjectKey{
+		Name:      sourceVM.Spec.ProviderRef.Name,
+		Namespace: sourceVM.Namespace,
+	}
+	if sourceVM.Spec.ProviderRef.Namespace != "" {
+		providerKey.Namespace = sourceVM.Spec.ProviderRef.Namespace
+	}
+	if err := r.Get(ctx, providerKey, provider); err != nil {
+		logger.Error(err, "Failed to get provider", "provider", providerKey.Name)
+		return r.markPending(ctx, clone, infrav1beta1.VMCloneReasonProviderError,
+			fmt.Sprintf("provider %q not found", providerKey.Name)), nil
+	}
+
+	providerInstance, err := r.getProviderInstance(ctx, provider)
+	if err != nil {
+		logger.Error(err, "Failed to get provider instance", "provider", providerKey.Name)
+		return r.markPending(ctx, clone, infrav1beta1.VMCloneReasonProviderError,
+			fmt.Sprintf("failed to resolve provider %q: %v", providerKey.Name, err)), nil
+	}
+
+	// Determine target namespace (defaults to the VMClone namespace).
+	targetNamespace := clone.Spec.Target.Namespace
+	if targetNamespace == "" {
+		targetNamespace = clone.Namespace
+	}
+
+	linked := r.requestedCloneType(clone) == infrav1beta1.CloneTypeLinkedClone
+
+	// Linked-clone capability pre-check (intrinsic correctness, independent of
+	// the #176 enforcement flag). Fails OPEN if the provider is not a
+	// CapabilityReporter or the query errors.
+	if linked {
+		if blocked, res := r.gateLinkedClone(ctx, clone, providerInstance); blocked {
+			return res, nil
+		}
+	}
+
+	// Idempotency: if we already produced a target VM, or one with the target
+	// name already exists, do not clone again — move straight to binding.
+	if clone.Status.TargetRef != nil && clone.Status.TargetRef.Name != "" {
+		return r.bindTargetVM(ctx, clone, sourceVM, targetNamespace, clone.Status.TargetVMID, linked)
+	}
+	existing := &infrav1beta1.VirtualMachine{}
+	existingKey := client.ObjectKey{Namespace: targetNamespace, Name: clone.Spec.Target.Name}
+	if err := r.Get(ctx, existingKey, existing); err == nil {
+		logger.Info("Target VM already exists, binding without re-clone", "vm", existingKey.Name)
+		return r.finalizeReady(ctx, clone, existing)
+	} else if !errors.IsNotFound(err) {
+		logger.Error(err, "Failed to check for existing target VM", "vm", existingKey.Name)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	// If a clone task is already in flight, poll it.
+	if clone.Status.TaskRef != "" {
+		return r.pollCloneTask(ctx, clone, sourceVM, providerInstance, targetNamespace, linked)
+	}
+
+	// Issue the clone.
+	return r.startClone(ctx, clone, sourceVM, provider, providerInstance, targetNamespace, linked)
+}
+
+// startClone issues the Clone RPC and records the resulting task / target ID.
+func (r *VMCloneReconciler) startClone(
+	ctx context.Context,
+	clone *infrav1beta1.VMClone,
+	sourceVM *infrav1beta1.VirtualMachine,
+	provider *infrav1beta1.Provider,
+	providerInstance contracts.Provider,
+	targetNamespace string,
+	linked bool,
+) (ctrl.Result, error) {
+	logger := logging.FromContext(ctx)
+
+	// The provider must support cloning (optional Cloner capability).
+	cloner, ok := providerInstance.(contracts.Cloner)
+	if !ok {
+		return r.markFailed(ctx, clone, infrav1beta1.VMCloneReasonUnsupported,
+			"provider does not support clone"), nil
+	}
+
+	req := contracts.CloneRequest{
+		SourceVmID:    sourceVM.Status.ID,
+		TargetName:    clone.Spec.Target.Name,
+		Linked:        linked,
+		ClassJSON:     r.classJSON(ctx, clone),
+		PlacementJSON: r.placementJSON(ctx, clone),
+		CustomizeJSON: r.customizeJSON(ctx, clone),
+	}
+
+	now := metav1.Now()
+	clone.Status.Phase = infrav1beta1.ClonePhaseCloning
+	clone.Status.StartTime = &now
+	if linked {
+		clone.Status.ActualCloneType = infrav1beta1.CloneTypeLinkedClone
+	} else {
+		clone.Status.ActualCloneType = infrav1beta1.CloneTypeFullClone
+	}
+	k8s.SetCondition(&clone.Status.Conditions, infrav1beta1.VMCloneConditionCloning,
+		metav1.ConditionTrue, infrav1beta1.VMCloneReasonCloning, "Clone operation initiated")
+
+	resp, err := cloner.Clone(ctx, req)
+	if err != nil {
+		logger.Error(err, "Clone RPC failed")
+		r.Recorder.Event(clone, "Warning", infrav1beta1.VMCloneReasonProviderError,
+			fmt.Sprintf("Clone failed: %v", err))
+		return r.markFailed(ctx, clone, infrav1beta1.VMCloneReasonProviderError,
+			fmt.Sprintf("clone failed: %v", err)), nil
+	}
+
+	clone.Status.TargetVMID = resp.TargetVmID
+	clone.Status.TaskRef = resp.TaskRef
+
+	// Synchronous clone (no task): bind the target VM immediately.
+	if resp.TaskRef == "" {
+		logger.Info("Clone completed synchronously", "target_vm_id", resp.TargetVmID)
+		return r.bindTargetVM(ctx, clone, sourceVM, targetNamespace, resp.TargetVmID, linked)
+	}
+
+	if err := r.updateStatus(ctx, clone); err != nil {
+		return ctrl.Result{}, err
+	}
+	logger.Info("Clone task started", "task_ref", resp.TaskRef)
+	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+// pollCloneTask checks an in-flight clone task and, on completion, binds the
+// target VM.
+func (r *VMCloneReconciler) pollCloneTask(
+	ctx context.Context,
+	clone *infrav1beta1.VMClone,
+	sourceVM *infrav1beta1.VirtualMachine,
+	providerInstance contracts.Provider,
+	targetNamespace string,
+	linked bool,
+) (ctrl.Result, error) {
+	logger := logging.FromContext(ctx)
+
+	done, err := providerInstance.IsTaskComplete(ctx, clone.Status.TaskRef)
+	if err != nil {
+		logger.Error(err, "Clone task failed", "task_ref", clone.Status.TaskRef)
+		r.Recorder.Event(clone, "Warning", infrav1beta1.VMCloneReasonProviderError,
+			fmt.Sprintf("Clone task failed: %v", err))
+		return r.markFailed(ctx, clone, infrav1beta1.VMCloneReasonProviderError,
+			fmt.Sprintf("clone task failed: %v", err)), nil
+	}
+	if !done {
+		logger.Info("Clone task still in progress", "task_ref", clone.Status.TaskRef)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	clone.Status.TaskRef = ""
+	return r.bindTargetVM(ctx, clone, sourceVM, targetNamespace, clone.Status.TargetVMID, linked)
+}
+
+// bindTargetVM creates (idempotently) the target VirtualMachine CR for a
+// completed clone and seeds its Status.ID with the provider-reported target VM
+// ID. The adopted label plus the seeded Status.ID together stop the
+// VirtualMachine controller from creating a second VM (issue #179).
+func (r *VMCloneReconciler) bindTargetVM(
+	ctx context.Context,
+	clone *infrav1beta1.VMClone,
+	sourceVM *infrav1beta1.VirtualMachine,
+	targetNamespace string,
+	targetVMID string,
+	linked bool,
+) (ctrl.Result, error) {
+	logger := logging.FromContext(ctx)
+
+	if targetVMID == "" {
+		// Defensive: a completed clone with no target ID is a provider bug.
+		return r.markFailed(ctx, clone, infrav1beta1.VMCloneReasonProviderError,
+			"clone completed but provider returned no target VM ID"), nil
+	}
+
+	vmKey := client.ObjectKey{Namespace: targetNamespace, Name: clone.Spec.Target.Name}
+	targetVM := &infrav1beta1.VirtualMachine{}
+	err := r.Get(ctx, vmKey, targetVM)
+	switch {
+	case err == nil:
+		// Already created on a previous reconcile — finalize.
+		logger.Info("Target VM CR already exists", "vm", vmKey.Name)
+		return r.finalizeReady(ctx, clone, targetVM)
+	case !errors.IsNotFound(err):
+		logger.Error(err, "Failed to get target VM CR", "vm", vmKey.Name)
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	// Build the target VM CR.
+	labels := map[string]string{}
+	for k, v := range clone.Spec.Target.Labels {
+		labels[k] = v
+	}
+	labels[AdoptedLabel] = AdoptedLabelValue
+
+	annotations := map[string]string{
+		CloneAnnotationClonedFrom: sourceVM.Name,
+		CloneAnnotationClone:      clone.Name,
+	}
+	for k, v := range clone.Spec.Target.Annotations {
+		annotations[k] = v
+	}
+
+	classRef := sourceVM.Spec.ClassRef
+	if clone.Spec.Target.ClassRef != nil && clone.Spec.Target.ClassRef.Name != "" {
+		classRef = infrav1beta1.ObjectRef{Name: clone.Spec.Target.ClassRef.Name}
+	}
+
+	targetVM = &infrav1beta1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        clone.Spec.Target.Name,
+			Namespace:   targetNamespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: infrav1beta1.VirtualMachineSpec{
+			ProviderRef: sourceVM.Spec.ProviderRef,
+			ClassRef:    classRef,
+		},
+	}
+	if len(clone.Spec.Target.Networks) > 0 {
+		targetVM.Spec.Networks = clone.Spec.Target.Networks
+	}
+	if clone.Spec.Target.PlacementRef != nil && clone.Spec.Target.PlacementRef.Name != "" {
+		targetVM.Spec.PlacementRef = &infrav1beta1.LocalObjectReference{Name: clone.Spec.Target.PlacementRef.Name}
+	}
+
+	if err := r.Create(ctx, targetVM); err != nil {
+		if errors.IsAlreadyExists(err) {
+			// Lost a race — re-fetch and finalize.
+			if getErr := r.Get(ctx, vmKey, targetVM); getErr != nil {
+				logger.Error(getErr, "Failed to re-fetch target VM after AlreadyExists", "vm", vmKey.Name)
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
+			return r.finalizeReady(ctx, clone, targetVM)
+		}
+		logger.Error(err, "Failed to create target VM CR", "vm", vmKey.Name)
+		return r.markFailed(ctx, clone, infrav1beta1.VMCloneReasonProviderError,
+			fmt.Sprintf("failed to create target VM: %v", err)), nil
+	}
+
+	// Seed Status.ID out-of-band (the status subresource is not persisted on
+	// Create). This is what prevents the VirtualMachine controller from
+	// creating a second VM for the already-cloned target.
+	targetVM.Status.ID = targetVMID
+	if err := r.Status().Update(ctx, targetVM); err != nil {
+		logger.Error(err, "Failed to set Status.ID on target VM CR", "vm", vmKey.Name)
+		// The VM CR exists; retry the status write on the next reconcile.
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	logger.Info("Created target VM CR and seeded Status.ID", "vm", vmKey.Name, "vm_id", targetVMID)
+	r.Recorder.Event(clone, "Normal", infrav1beta1.VMCloneReasonCompleted,
+		fmt.Sprintf("Created target VM %q", vmKey.Name))
+	return r.finalizeReady(ctx, clone, targetVM)
+}
+
+// finalizeReady marks the VMClone Ready and records the target reference.
+func (r *VMCloneReconciler) finalizeReady(
+	ctx context.Context,
+	clone *infrav1beta1.VMClone,
+	targetVM *infrav1beta1.VirtualMachine,
+) (ctrl.Result, error) {
+	now := metav1.Now()
+	clone.Status.Phase = infrav1beta1.ClonePhaseReady
+	clone.Status.Message = "Clone completed successfully"
+	clone.Status.TaskRef = ""
+	clone.Status.CompletionTime = &now
+	clone.Status.TargetRef = &infrav1beta1.LocalObjectReference{Name: targetVM.Name}
+	k8s.SetCondition(&clone.Status.Conditions, infrav1beta1.VMCloneConditionReady,
+		metav1.ConditionTrue, infrav1beta1.VMCloneReasonCompleted, "Clone completed successfully")
+	k8s.SetCondition(&clone.Status.Conditions, infrav1beta1.VMCloneConditionCloning,
+		metav1.ConditionFalse, infrav1beta1.VMCloneReasonCompleted, "Clone completed")
+
+	if err := r.updateStatus(ctx, clone); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// gateLinkedClone refuses a linked-clone request when the resolved provider
+// reports it cannot perform linked clones. It is INTRINSIC clone correctness:
+// it always runs (independent of the #176 enforcement flag) but fails OPEN if
+// the provider does not implement contracts.CapabilityReporter or the
+// capability query errors. Returns blocked=true (with the ctrl.Result the
+// caller should return) only when the provider explicitly reports
+// !SupportsLinkedClones.
+func (r *VMCloneReconciler) gateLinkedClone(
+	ctx context.Context,
+	clone *infrav1beta1.VMClone,
+	providerInstance contracts.Provider,
+) (blocked bool, result ctrl.Result) {
+	logger := logging.FromContext(ctx)
+
+	reporter, ok := providerInstance.(contracts.CapabilityReporter)
+	if !ok {
+		logger.V(1).Info("Provider does not report capabilities; allowing linked clone (fail open)")
+		return false, ctrl.Result{}
+	}
+	caps, err := reporter.GetCapabilities(ctx)
+	if err != nil {
+		logger.V(1).Info("GetCapabilities failed; allowing linked clone (fail open)", "error", err.Error())
+		return false, ctrl.Result{}
+	}
+	if !caps.SupportsLinkedClones {
+		return true, r.markFailed(ctx, clone, cloneReasonLinkedUnsupported,
+			"provider does not support linked clones")
+	}
+	return false, ctrl.Result{}
+}
+
+// handleDeletion drops the finalizer without touching the produced target VM.
+func (r *VMCloneReconciler) handleDeletion(ctx context.Context, clone *infrav1beta1.VMClone) (ctrl.Result, error) {
+	logger := logging.FromContext(ctx)
+	logger.Info("Deleting VMClone (target VM is intentionally preserved)")
+
+	controllerutil.RemoveFinalizer(clone, vmCloneFinalizer)
+	if err := r.Update(ctx, clone); err != nil {
+		logger.Error(err, "Failed to remove finalizer")
+		metrics.RecordError(errReasonRemoveFinalizer, metrics.ComponentManager)
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// markFailed sets the VMClone to the Failed phase with a Ready=False / Failed
+// condition and persists status. It does not requeue, and Failed is terminal:
+// the Reconcile entry short-circuits on a Failed phase, so a failed clone is
+// not retried in place — recreate the VMClone to retry. This is deliberate:
+// a clone is a one-shot job and a partial provider-side clone makes blind
+// auto-retry unsafe (it could leave or create a duplicate provider VM).
+func (r *VMCloneReconciler) markFailed(ctx context.Context, clone *infrav1beta1.VMClone, reason, message string) ctrl.Result {
+	logger := logging.FromContext(ctx)
+	logger.Info("VMClone failed", "reason", reason, "message", message)
+
+	clone.Status.Phase = infrav1beta1.ClonePhaseFailed
+	clone.Status.Message = message
+	clone.Status.TaskRef = ""
+	k8s.SetCondition(&clone.Status.Conditions, infrav1beta1.VMCloneConditionReady,
+		metav1.ConditionFalse, reason, message)
+	k8s.SetCondition(&clone.Status.Conditions, infrav1beta1.VMCloneConditionFailed,
+		metav1.ConditionTrue, reason, message)
+	r.Recorder.Event(clone, "Warning", reason, message)
+
+	_ = r.updateStatus(ctx, clone) //nolint:errcheck // status errors retried next reconcile
+	return ctrl.Result{}
+}
+
+// markPending sets the VMClone to the Pending phase (still waiting on a
+// prerequisite) and requeues.
+func (r *VMCloneReconciler) markPending(ctx context.Context, clone *infrav1beta1.VMClone, reason, message string) ctrl.Result {
+	clone.Status.Phase = infrav1beta1.ClonePhasePending
+	clone.Status.Message = message
+	k8s.SetCondition(&clone.Status.Conditions, infrav1beta1.VMCloneConditionReady,
+		metav1.ConditionFalse, reason, message)
+	_ = r.updateStatus(ctx, clone) //nolint:errcheck // status errors retried next reconcile
+	return ctrl.Result{RequeueAfter: 30 * time.Second}
+}
+
+// requestedCloneType returns the clone type from spec.options, defaulting to
+// FullClone when unset.
+func (r *VMCloneReconciler) requestedCloneType(clone *infrav1beta1.VMClone) infrav1beta1.CloneType {
+	if clone.Spec.Options != nil && clone.Spec.Options.Type != "" {
+		return clone.Spec.Options.Type
+	}
+	return infrav1beta1.CloneTypeFullClone
+}
+
+// classJSON best-effort marshals the referenced VMClass override to JSON, or
+// returns "" when no class override is referenced or the lookup/marshal fails.
+func (r *VMCloneReconciler) classJSON(ctx context.Context, clone *infrav1beta1.VMClone) string {
+	if clone.Spec.Target.ClassRef == nil || clone.Spec.Target.ClassRef.Name == "" {
+		return ""
+	}
+	vmClass := &infrav1beta1.VMClass{}
+	key := client.ObjectKey{Namespace: clone.Namespace, Name: clone.Spec.Target.ClassRef.Name}
+	if err := r.Get(ctx, key, vmClass); err != nil {
+		return ""
+	}
+	data, err := json.Marshal(vmClass.Spec)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// placementJSON best-effort marshals the target placement reference to JSON,
+// or returns "" when no placement is referenced or marshal fails.
+func (r *VMCloneReconciler) placementJSON(_ context.Context, clone *infrav1beta1.VMClone) string {
+	if clone.Spec.Target.PlacementRef == nil || clone.Spec.Target.PlacementRef.Name == "" {
+		return ""
+	}
+	data, err := json.Marshal(clone.Spec.Target.PlacementRef)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// customizeJSON best-effort marshals the spec.customization to JSON, or
+// returns "" when no customization is present or marshal fails.
+func (r *VMCloneReconciler) customizeJSON(_ context.Context, clone *infrav1beta1.VMClone) string {
+	if clone.Spec.Customization == nil {
+		return ""
+	}
+	data, err := json.Marshal(clone.Spec.Customization)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// getProviderInstance resolves a Provider CR to a remote provider implementation.
+func (r *VMCloneReconciler) getProviderInstance(ctx context.Context, provider *infrav1beta1.Provider) (contracts.Provider, error) {
+	if r.RemoteResolver == nil {
+		return nil, fmt.Errorf("no remote resolver available")
+	}
+	return r.RemoteResolver.GetProvider(ctx, provider)
+}
+
+// updateStatus persists the VMClone status subresource.
+func (r *VMCloneReconciler) updateStatus(ctx context.Context, clone *infrav1beta1.VMClone) error {
+	if err := r.Status().Update(ctx, clone); err != nil {
+		logging.FromContext(ctx).Error(err, "Failed to update VMClone status")
+		return err
+	}
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *VMCloneReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&infrav1beta1.VMClone{}).
+		Complete(r)
+}

--- a/internal/controller/vmclone_controller_test.go
+++ b/internal/controller/vmclone_controller_test.go
@@ -1,0 +1,424 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+)
+
+// clonerProvider is a contracts.Provider that ALSO implements contracts.Cloner
+// (and optionally contracts.CapabilityReporter). It records the CloneRequest it
+// received so tests can assert on it. It embeds stubProvider so it satisfies the
+// full Provider interface with no boilerplate.
+type clonerProvider struct {
+	stubProvider
+
+	cloneResp contracts.CloneResponse
+	cloneErr  error
+	lastClone *contracts.CloneRequest
+	cloneCnt  int
+
+	// capability reporting (optional). reportCaps gates whether this fake is
+	// treated as a CapabilityReporter — when false the fake still has the
+	// method but tests use clonerProviderNoCaps instead.
+	caps    contracts.Capabilities
+	capsErr error
+}
+
+func (p *clonerProvider) Clone(_ context.Context, req contracts.CloneRequest) (contracts.CloneResponse, error) {
+	p.cloneCnt++
+	r := req
+	p.lastClone = &r
+	return p.cloneResp, p.cloneErr
+}
+
+func (p *clonerProvider) GetCapabilities(_ context.Context) (contracts.Capabilities, error) {
+	if p.capsErr != nil {
+		return contracts.Capabilities{}, p.capsErr
+	}
+	return p.caps, nil
+}
+
+// clonerProviderNoCaps is a Cloner that does NOT implement CapabilityReporter
+// (fail-open path for linked clones).
+type clonerProviderNoCaps struct {
+	stubProvider
+	cloneResp contracts.CloneResponse
+	cloneCnt  int
+}
+
+func (p *clonerProviderNoCaps) Clone(_ context.Context, _ contracts.CloneRequest) (contracts.CloneResponse, error) {
+	p.cloneCnt++
+	return p.cloneResp, nil
+}
+
+// nonClonerProvider is a plain Provider that is NOT a Cloner.
+type nonClonerProvider struct{ stubProvider }
+
+var (
+	_ contracts.Provider           = (*clonerProvider)(nil)
+	_ contracts.Cloner             = (*clonerProvider)(nil)
+	_ contracts.CapabilityReporter = (*clonerProvider)(nil)
+	_ contracts.Provider           = (*clonerProviderNoCaps)(nil)
+	_ contracts.Cloner             = (*clonerProviderNoCaps)(nil)
+)
+
+func cloneTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, infrav1beta1.AddToScheme(s))
+	return s
+}
+
+// runningProvider returns a Provider CR whose runtime is Running (so the
+// resolver path is satisfied — though we inject a stub resolver anyway).
+func runningProvider(ns, name string) *infrav1beta1.Provider {
+	return &infrav1beta1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status: infrav1beta1.ProviderStatus{
+			Runtime: &infrav1beta1.ProviderRuntimeStatus{Phase: "Running", Endpoint: "localhost:50051"},
+		},
+	}
+}
+
+// sourceVMWithID returns a provisioned source VM (Status.ID set).
+func sourceVMWithID(ns, name, provName, id string) *infrav1beta1.VirtualMachine {
+	vm := &infrav1beta1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: infrav1beta1.VirtualMachineSpec{
+			ProviderRef: infrav1beta1.ObjectRef{Name: provName},
+			ClassRef:    infrav1beta1.ObjectRef{Name: "src-class"},
+		},
+	}
+	vm.Status.ID = id
+	return vm
+}
+
+func newCloneReconciler(s *runtime.Scheme, resolver ProviderResolver, objs ...client.Object) *VMCloneReconciler {
+	fc := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(
+			&infrav1beta1.VMClone{},
+			&infrav1beta1.VirtualMachine{},
+		).
+		Build()
+	return &VMCloneReconciler{
+		Client:         fc,
+		Scheme:         s,
+		RemoteResolver: resolver,
+		Recorder:       record.NewFakeRecorder(20),
+	}
+}
+
+func reconcileTwice(t *testing.T, r *VMCloneReconciler, key client.ObjectKey) {
+	t.Helper()
+	// First reconcile adds the finalizer and requeues; subsequent reconciles
+	// drive the phases. Reconcile a few times so async-free fakes settle.
+	for i := 0; i < 4; i++ {
+		_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+		require.NoError(t, err)
+	}
+}
+
+// TestVMClone_HappyPath: source VM with Status.ID → synchronous clone → target
+// VM CR created with Status.ID set, adopted label, clone provenance, plus
+// VMClone TargetRef + Phase=Ready.
+func TestVMClone_HappyPath(t *testing.T) {
+	s := cloneTestScheme(t)
+	ns := "default"
+
+	prov := runningProvider(ns, "prov-1")
+	src := sourceVMWithID(ns, "src-vm", "prov-1", "vm-source-123")
+	clone := &infrav1beta1.VMClone{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-1", Namespace: ns},
+		Spec: infrav1beta1.VMCloneSpec{
+			Source: infrav1beta1.CloneSource{VMRef: &infrav1beta1.LocalObjectReference{Name: "src-vm"}},
+			Target: infrav1beta1.VMCloneTarget{
+				Name:   "clone-target",
+				Labels: map[string]string{"app": "demo"},
+			},
+		},
+	}
+
+	cp := &clonerProvider{
+		caps:      contracts.Capabilities{SupportsLinkedClones: true},
+		cloneResp: contracts.CloneResponse{TargetVmID: "vm-clone-999"}, // synchronous (no TaskRef)
+	}
+	r := newCloneReconciler(s, &stubResolver{provider: cp}, prov, src, clone)
+
+	reconcileTwice(t, r, client.ObjectKeyFromObject(clone))
+
+	// VMClone is Ready with a TargetRef.
+	got := &infrav1beta1.VMClone{}
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(clone), got))
+	assert.Equal(t, infrav1beta1.ClonePhaseReady, got.Status.Phase)
+	require.NotNil(t, got.Status.TargetRef)
+	assert.Equal(t, "clone-target", got.Status.TargetRef.Name)
+	assert.Equal(t, infrav1beta1.CloneTypeFullClone, got.Status.ActualCloneType)
+	ready := readyCondition(got.Status.Conditions, infrav1beta1.VMCloneConditionReady)
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionTrue, ready.Status)
+
+	// The Clone RPC was called with the source VM's provider ID + target name.
+	require.Equal(t, 1, cp.cloneCnt)
+	require.NotNil(t, cp.lastClone)
+	assert.Equal(t, "vm-source-123", cp.lastClone.SourceVmID)
+	assert.Equal(t, "clone-target", cp.lastClone.TargetName)
+	assert.False(t, cp.lastClone.Linked)
+
+	// Target VM CR exists, has Status.ID seeded, adopted label, provenance.
+	target := &infrav1beta1.VirtualMachine{}
+	require.NoError(t, r.Get(context.Background(),
+		client.ObjectKey{Namespace: ns, Name: "clone-target"}, target))
+	assert.Equal(t, "vm-clone-999", target.Status.ID)
+	assert.Equal(t, AdoptedLabelValue, target.Labels[AdoptedLabel])
+	assert.Equal(t, "demo", target.Labels["app"])
+	assert.Equal(t, "src-vm", target.Annotations[CloneAnnotationClonedFrom])
+	assert.Equal(t, "clone-1", target.Annotations[CloneAnnotationClone])
+	assert.Equal(t, "prov-1", target.Spec.ProviderRef.Name)
+	// ClassRef inherited from the source VM (no target ClassRef override).
+	assert.Equal(t, "src-class", target.Spec.ClassRef.Name)
+}
+
+// TestVMClone_Idempotent_NoDoubleCreate: a second reconcile after Ready does not
+// call Clone again or recreate the target VM.
+func TestVMClone_Idempotent_NoDoubleCreate(t *testing.T) {
+	s := cloneTestScheme(t)
+	ns := "default"
+
+	prov := runningProvider(ns, "prov-1")
+	src := sourceVMWithID(ns, "src-vm", "prov-1", "vm-source-123")
+	clone := &infrav1beta1.VMClone{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-1", Namespace: ns},
+		Spec: infrav1beta1.VMCloneSpec{
+			Source: infrav1beta1.CloneSource{VMRef: &infrav1beta1.LocalObjectReference{Name: "src-vm"}},
+			Target: infrav1beta1.VMCloneTarget{Name: "clone-target"},
+		},
+	}
+	cp := &clonerProvider{cloneResp: contracts.CloneResponse{TargetVmID: "vm-clone-999"}}
+	r := newCloneReconciler(s, &stubResolver{provider: cp}, prov, src, clone)
+
+	// Many reconciles; Clone must only ever be invoked once.
+	for i := 0; i < 8; i++ {
+		_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(clone)})
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, cp.cloneCnt, "Clone must be called exactly once")
+}
+
+// TestVMClone_LinkedBlockedWhenUnsupported: type=LinkedClone with a provider
+// reporting !SupportsLinkedClones → Failed, no Clone call.
+func TestVMClone_LinkedBlockedWhenUnsupported(t *testing.T) {
+	s := cloneTestScheme(t)
+	ns := "default"
+
+	prov := runningProvider(ns, "prov-1")
+	src := sourceVMWithID(ns, "src-vm", "prov-1", "vm-source-123")
+	linked := infrav1beta1.CloneTypeLinkedClone
+	clone := &infrav1beta1.VMClone{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-linked", Namespace: ns},
+		Spec: infrav1beta1.VMCloneSpec{
+			Source:  infrav1beta1.CloneSource{VMRef: &infrav1beta1.LocalObjectReference{Name: "src-vm"}},
+			Target:  infrav1beta1.VMCloneTarget{Name: "clone-target"},
+			Options: &infrav1beta1.CloneOptions{Type: linked},
+		},
+	}
+	cp := &clonerProvider{caps: contracts.Capabilities{SupportsLinkedClones: false}}
+	r := newCloneReconciler(s, &stubResolver{provider: cp}, prov, src, clone)
+
+	reconcileTwice(t, r, client.ObjectKeyFromObject(clone))
+
+	got := &infrav1beta1.VMClone{}
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(clone), got))
+	assert.Equal(t, infrav1beta1.ClonePhaseFailed, got.Status.Phase)
+	assert.Equal(t, 0, cp.cloneCnt, "Clone must not be called when linked clones are unsupported")
+	ready := readyCondition(got.Status.Conditions, infrav1beta1.VMCloneConditionReady)
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, cloneReasonLinkedUnsupported, ready.Reason)
+}
+
+// TestVMClone_LinkedFailsOpen_NonReporter: type=LinkedClone with a provider that
+// is NOT a CapabilityReporter → proceeds (fail open), clone happens.
+func TestVMClone_LinkedFailsOpen_NonReporter(t *testing.T) {
+	s := cloneTestScheme(t)
+	ns := "default"
+
+	prov := runningProvider(ns, "prov-1")
+	src := sourceVMWithID(ns, "src-vm", "prov-1", "vm-source-123")
+	linked := infrav1beta1.CloneTypeLinkedClone
+	clone := &infrav1beta1.VMClone{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-linked-open", Namespace: ns},
+		Spec: infrav1beta1.VMCloneSpec{
+			Source:  infrav1beta1.CloneSource{VMRef: &infrav1beta1.LocalObjectReference{Name: "src-vm"}},
+			Target:  infrav1beta1.VMCloneTarget{Name: "clone-target"},
+			Options: &infrav1beta1.CloneOptions{Type: linked},
+		},
+	}
+	cp := &clonerProviderNoCaps{cloneResp: contracts.CloneResponse{TargetVmID: "vm-clone-777"}}
+	r := newCloneReconciler(s, &stubResolver{provider: cp}, prov, src, clone)
+
+	reconcileTwice(t, r, client.ObjectKeyFromObject(clone))
+
+	got := &infrav1beta1.VMClone{}
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(clone), got))
+	assert.Equal(t, infrav1beta1.ClonePhaseReady, got.Status.Phase)
+	assert.Equal(t, 1, cp.cloneCnt, "fail-open: clone must proceed for non-CapabilityReporter providers")
+	assert.Equal(t, infrav1beta1.CloneTypeLinkedClone, got.Status.ActualCloneType)
+}
+
+// TestVMClone_NonVMRefSource_Failed: a snapshotRef source (no vmRef) → Failed.
+func TestVMClone_NonVMRefSource_Failed(t *testing.T) {
+	s := cloneTestScheme(t)
+	ns := "default"
+
+	clone := &infrav1beta1.VMClone{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-snap", Namespace: ns},
+		Spec: infrav1beta1.VMCloneSpec{
+			Source: infrav1beta1.CloneSource{SnapshotRef: &infrav1beta1.LocalObjectReference{Name: "snap-1"}},
+			Target: infrav1beta1.VMCloneTarget{Name: "clone-target"},
+		},
+	}
+	cp := &clonerProvider{}
+	r := newCloneReconciler(s, &stubResolver{provider: cp}, clone)
+
+	reconcileTwice(t, r, client.ObjectKeyFromObject(clone))
+
+	got := &infrav1beta1.VMClone{}
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(clone), got))
+	assert.Equal(t, infrav1beta1.ClonePhaseFailed, got.Status.Phase)
+	assert.Equal(t, 0, cp.cloneCnt)
+	ready := readyCondition(got.Status.Conditions, infrav1beta1.VMCloneConditionReady)
+	require.NotNil(t, ready)
+	assert.Equal(t, cloneReasonUnsupportedSource, ready.Reason)
+}
+
+// TestVMClone_NonClonerProvider_Failed: provider does not implement Cloner → Failed.
+func TestVMClone_NonClonerProvider_Failed(t *testing.T) {
+	s := cloneTestScheme(t)
+	ns := "default"
+
+	prov := runningProvider(ns, "prov-1")
+	src := sourceVMWithID(ns, "src-vm", "prov-1", "vm-source-123")
+	clone := &infrav1beta1.VMClone{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-noclone", Namespace: ns},
+		Spec: infrav1beta1.VMCloneSpec{
+			Source: infrav1beta1.CloneSource{VMRef: &infrav1beta1.LocalObjectReference{Name: "src-vm"}},
+			Target: infrav1beta1.VMCloneTarget{Name: "clone-target"},
+		},
+	}
+	r := newCloneReconciler(s, &stubResolver{provider: &nonClonerProvider{}}, prov, src, clone)
+
+	reconcileTwice(t, r, client.ObjectKeyFromObject(clone))
+
+	got := &infrav1beta1.VMClone{}
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(clone), got))
+	assert.Equal(t, infrav1beta1.ClonePhaseFailed, got.Status.Phase)
+	ready := readyCondition(got.Status.Conditions, infrav1beta1.VMCloneConditionReady)
+	require.NotNil(t, ready)
+	assert.Equal(t, infrav1beta1.VMCloneReasonUnsupported, ready.Reason)
+}
+
+// TestVMClone_SourceMissing_Pending: source VM does not exist → Pending, requeue.
+func TestVMClone_SourceMissing_Pending(t *testing.T) {
+	s := cloneTestScheme(t)
+	ns := "default"
+
+	clone := &infrav1beta1.VMClone{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-nosrc", Namespace: ns},
+		Spec: infrav1beta1.VMCloneSpec{
+			Source: infrav1beta1.CloneSource{VMRef: &infrav1beta1.LocalObjectReference{Name: "ghost"}},
+			Target: infrav1beta1.VMCloneTarget{Name: "clone-target"},
+		},
+	}
+	cp := &clonerProvider{}
+	r := newCloneReconciler(s, &stubResolver{provider: cp}, clone)
+
+	// First reconcile: add finalizer. Second: source missing → Pending + requeue.
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(clone)})
+	require.NoError(t, err)
+	res, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(clone)})
+	require.NoError(t, err)
+	assert.True(t, res.RequeueAfter > 0, "expected a requeue while waiting for the source VM")
+
+	got := &infrav1beta1.VMClone{}
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(clone), got))
+	assert.Equal(t, infrav1beta1.ClonePhasePending, got.Status.Phase)
+	assert.Equal(t, 0, cp.cloneCnt)
+}
+
+// TestVMClone_DeletionDoesNotDeleteTarget: deleting a VMClone removes its
+// finalizer but leaves the produced target VM intact.
+func TestVMClone_DeletionDoesNotDeleteTarget(t *testing.T) {
+	s := cloneTestScheme(t)
+	ns := "default"
+
+	now := metav1.Now()
+	target := &infrav1beta1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "clone-target", Namespace: ns},
+		Spec: infrav1beta1.VirtualMachineSpec{
+			ProviderRef: infrav1beta1.ObjectRef{Name: "prov-1"},
+			ClassRef:    infrav1beta1.ObjectRef{Name: "src-class"},
+		},
+	}
+	clone := &infrav1beta1.VMClone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "clone-del",
+			Namespace:         ns,
+			Finalizers:        []string{vmCloneFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: infrav1beta1.VMCloneSpec{
+			Source: infrav1beta1.CloneSource{VMRef: &infrav1beta1.LocalObjectReference{Name: "src-vm"}},
+			Target: infrav1beta1.VMCloneTarget{Name: "clone-target"},
+		},
+		Status: infrav1beta1.VMCloneStatus{
+			Phase:     infrav1beta1.ClonePhaseReady,
+			TargetRef: &infrav1beta1.LocalObjectReference{Name: "clone-target"},
+		},
+	}
+	r := newCloneReconciler(s, &stubResolver{}, target, clone)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(clone)})
+	require.NoError(t, err)
+
+	// VMClone finalizer removed → object can be GC'd (fake returns NotFound).
+	got := &infrav1beta1.VMClone{}
+	err = r.Get(context.Background(), client.ObjectKeyFromObject(clone), got)
+	if err == nil {
+		assert.NotContains(t, got.Finalizers, vmCloneFinalizer)
+	}
+
+	// Target VM must still exist.
+	stillThere := &infrav1beta1.VirtualMachine{}
+	assert.NoError(t, r.Get(context.Background(),
+		client.ObjectKey{Namespace: ns, Name: "clone-target"}, stillThere))
+}

--- a/internal/controller/vmset_controller.go
+++ b/internal/controller/vmset_controller.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/obs/logging"
+	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
+	"github.com/projectbeskar/virtrigaud/internal/util/k8s"
+)
+
+const (
+	// errReasonGetVMSet is the metrics.RecordError reason for a failed VMSet
+	// Get in the reconcile entry path.
+	errReasonGetVMSet = "get-vmset"
+
+	// vmSetConditionReady is the Ready condition type reported on a VMSet.
+	vmSetConditionReady = "Ready"
+	// vmSetReasonNotImplemented is the Ready=False reason set by the
+	// not-yet-active VMSet stub controller (issue #179).
+	vmSetReasonNotImplemented = "ControllerNotImplemented"
+	// vmSetNotImplementedMessage is the human-readable message reported by the
+	// VMSet stub controller.
+	vmSetNotImplementedMessage = "VMSet has no active controller in this release (#179)"
+)
+
+// VMSetReconciler is a not-yet-active stub for the VMSet resource. It reports a
+// Ready=False / ControllerNotImplemented condition so operators get a clear
+// signal that VMSet has no functional controller in this release, and does
+// nothing else (issue #179).
+type VMSetReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmsets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=infra.virtrigaud.io,resources=vmsets/status,verbs=get;update;patch
+
+// Reconcile sets the not-implemented condition on the VMSet and returns.
+//
+// Named return values (`result`, `retErr`) are required by the deferred
+// outcome-inference block — do not change the signature without updating it.
+func (r *VMSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
+	timer := metrics.NewReconcileTimer("VMSet")
+	defer func() {
+		outcome := metrics.OutcomeSuccess
+		switch {
+		case retErr != nil:
+			outcome = metrics.OutcomeError
+		case result.Requeue || result.RequeueAfter > 0:
+			outcome = metrics.OutcomeRequeue
+		}
+		timer.Finish(outcome)
+	}()
+
+	ctx = logging.WithCorrelationID(ctx, fmt.Sprintf("vmset-%s/%s", req.Namespace, req.Name))
+	logger := logging.FromContext(ctx)
+
+	vmSet := &infrav1beta1.VMSet{}
+	if err := r.Get(ctx, req.NamespacedName, vmSet); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Failed to get VMSet")
+		metrics.RecordError(errReasonGetVMSet, metrics.ComponentManager)
+		return ctrl.Result{}, err
+	}
+
+	// Idempotent: only write status when the condition is not already set as
+	// expected, to avoid a reconcile loop on our own status updates.
+	existing := k8s.GetCondition(vmSet.Status.Conditions, vmSetConditionReady)
+	if existing != nil &&
+		existing.Status == metav1.ConditionFalse &&
+		existing.Reason == vmSetReasonNotImplemented &&
+		vmSet.Status.ObservedGeneration == vmSet.Generation {
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("VMSet has no active controller; reporting ControllerNotImplemented")
+	vmSet.Status.ObservedGeneration = vmSet.Generation
+	k8s.SetCondition(&vmSet.Status.Conditions, vmSetConditionReady,
+		metav1.ConditionFalse, vmSetReasonNotImplemented, vmSetNotImplementedMessage)
+	if err := r.Status().Update(ctx, vmSet); err != nil {
+		logger.Error(err, "Failed to update VMSet status")
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *VMSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&infrav1beta1.VMSet{}).
+		Complete(r)
+}

--- a/internal/controller/vmset_controller_test.go
+++ b/internal/controller/vmset_controller_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+)
+
+// TestVMSetStub_SetsControllerNotImplemented verifies the VMSet stub controller
+// reports Ready=False / ControllerNotImplemented and does nothing else.
+func TestVMSetStub_SetsControllerNotImplemented(t *testing.T) {
+	s := cloneTestScheme(t)
+	vmSet := &infrav1beta1.VMSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "set-1", Namespace: "default"},
+	}
+	fc := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(vmSet).
+		WithStatusSubresource(&infrav1beta1.VMSet{}).
+		Build()
+	r := &VMSetReconciler{Client: fc, Scheme: s}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(vmSet),
+	})
+	require.NoError(t, err)
+
+	got := &infrav1beta1.VMSet{}
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(vmSet), got))
+	ready := readyCondition(got.Status.Conditions, vmSetConditionReady)
+	require.NotNil(t, ready, "expected Ready condition to be set")
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, vmSetReasonNotImplemented, ready.Reason)
+	assert.Equal(t, vmSetNotImplementedMessage, ready.Message)
+	assert.Equal(t, got.Generation, got.Status.ObservedGeneration)
+}

--- a/internal/providers/contracts/clone.go
+++ b/internal/providers/contracts/clone.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contracts
+
+import "context"
+
+// CloneRequest contains all information needed to clone an existing VM into a
+// new one. It is the manager-side, transport-agnostic mirror of the
+// provider.v1 CloneRequest message (issue #179).
+type CloneRequest struct {
+	// SourceVmID is the provider-specific identifier of the VM to clone from.
+	SourceVmID string
+	// TargetName is the desired name of the cloned VM.
+	TargetName string
+	// Linked requests a copy-on-write linked clone when true. Best-effort:
+	// providers that cannot honor it fall back to a full clone unless the
+	// caller has already gated on SupportsLinkedClones.
+	Linked bool
+	// ClassJSON is a JSON-encoded VMClass override for the target VM, or
+	// empty to inherit the source VM's resources.
+	ClassJSON string
+	// PlacementJSON is a JSON-encoded placement hint for the target VM, or
+	// empty to let the provider choose.
+	PlacementJSON string
+	// CustomizeJSON is a JSON-encoded customization spec (hostname, network,
+	// cloud-init, sysprep, ...), or empty for no customization.
+	CustomizeJSON string
+}
+
+// CloneResponse contains the result of a clone operation.
+type CloneResponse struct {
+	// TargetVmID is the provider-specific identifier of the newly cloned VM.
+	TargetVmID string
+	// TaskRef references an async operation if the clone is not synchronous.
+	TaskRef string
+}
+
+// Cloner is an optional capability of a Provider: it clones an existing VM
+// into a new one. The manager gRPC client implements it; callers type-assert a
+// Provider to Cloner to invoke a clone without widening the core Provider
+// interface, so in-process provider implementations and test fakes that do not
+// support cloning are unaffected (issue #179). This mirrors the
+// CapabilityReporter pattern.
+type Cloner interface {
+	// Clone clones SourceVmID into a new VM named TargetName. Returns the new
+	// VM's provider identifier and, when the operation is asynchronous, a
+	// TaskRef the caller can poll via IsTaskComplete.
+	Clone(ctx context.Context, req CloneRequest) (CloneResponse, error)
+}

--- a/internal/transport/grpc/client.go
+++ b/internal/transport/grpc/client.go
@@ -39,6 +39,15 @@ import (
 	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
 )
 
+// Compile-time assertions that the gRPC Client satisfies the core Provider
+// interface plus the optional capability interfaces it advertises via
+// type-assertion (issues #176, #179).
+var (
+	_ contracts.Provider           = (*Client)(nil)
+	_ contracts.CapabilityReporter = (*Client)(nil)
+	_ contracts.Cloner             = (*Client)(nil)
+)
+
 // Client wraps a gRPC provider client and implements the contracts.Provider interface
 type Client struct {
 	conn   *grpc.ClientConn
@@ -446,6 +455,42 @@ func (c *Client) GetCapabilities(ctx context.Context) (contracts.Capabilities, e
 		SupportedImportFormats:      resp.SupportedImportFormats,
 		SupportsExportCompression:   resp.SupportsExportCompression,
 	}, nil
+}
+
+// Clone implements contracts.Cloner. It clones an existing VM over gRPC so the
+// VMClone controller can produce a target VM on the source provider (issue
+// #179). Clone is exposed as an optional capability (type-asserted from
+// contracts.Provider), mirroring GetCapabilities, so providers that do not
+// support cloning are unaffected.
+func (c *Client) Clone(ctx context.Context, req contracts.CloneRequest) (contracts.CloneResponse, error) {
+	// Clone can be a long-running provider operation; use the same generous
+	// timeout as Create. The returned TaskRef lets the caller poll for
+	// completion regardless.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	resp, err := c.client.Clone(ctx, &providerv1.CloneRequest{
+		SourceVmId:    req.SourceVmID,
+		TargetName:    req.TargetName,
+		Linked:        req.Linked,
+		ClassJson:     req.ClassJSON,
+		PlacementJson: req.PlacementJSON,
+		CustomizeJson: req.CustomizeJSON,
+	})
+	if err != nil {
+		return contracts.CloneResponse{}, c.mapGRPCError("clone", err)
+	}
+
+	result := contracts.CloneResponse{
+		TargetVmID: resp.TargetVmId,
+	}
+
+	if resp.Task != nil {
+		result.TaskRef = resp.Task.Id
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
+	}
+
+	return result, nil
 }
 
 // Create implements contracts.Provider.


### PR DESCRIPTION
## What

Give the `VMClone` CRD a real controller, mark `VMSet` not-yet-active, and document `VMPlacementPolicy` as reference-only (#179). These three CRDs previously shipped without any controller.

### VMClone controller (MVP)
- **Scope:** `source.vmRef` only, **same-provider** clone, **Full** + **Linked** clones.
- Wires the `Clone` RPC into the manager via a narrow `contracts.Cloner` interface + `(*Client).Clone` — mirroring the `CapabilityReporter` (#176) pattern, so the core `Provider` interface and in-process/mock providers are untouched.
- Resolves the source VM → its `Status.ID` + provider; intrinsic **linked-clone capability pre-check** (fails open if the provider isn't a `CapabilityReporter`); idempotent clone; async task polling.
- On success, binds a **target `VirtualMachine` CR**: creates it with `virtrigaud.io/adopted=true` + clone provenance annotations, then seeds its `Status.ID` with the provider's cloned VM ID.
- Deleting a VMClone **never** deletes the produced VM.

### VirtualMachine double-create guard (correctness fix)
The VM controller decided to create purely on `Status.ID == ""`. A freshly-bound adopted/cloned VM CR briefly has an empty `Status.ID`, during which the controller would create a **second** VM on the provider. The create path now skips VMs labeled `virtrigaud.io/adopted=true` while `Status.ID` is empty (requeues instead). **Normal VMs are unchanged** — proven by a negative-control test. This also hardens the pre-existing VM-adoption race.

### VMSet + VMPlacementPolicy
- `VMSet`: not-yet-active **stub** reconciler that reports `Ready=False / ControllerNotImplemented` (no silent inertness).
- `VMPlacementPolicy`: documented as a **reference-only** policy object (referenced by `VirtualMachine.spec.placementRef`); no standalone controller.

## Provider parity note

vSphere and Proxmox implement `Clone`; **libvirt's `Clone` returns `Unimplemented`** (#153), so a libvirt clone surfaces a clear `Phase=Failed/ProviderError` — honest, not a silent no-op.

## Verification

- `make fmt` clean · `make lint` **0 issues** · `make build` OK · `make test` (full envtest) **all packages pass** · `go vet` clean.
- New unit tests: VMClone happy-path (target VM created with `Status.ID` seeded + adopted label + provenance), idempotency (Clone called exactly once), linked-blocked + linked-fail-open, non-vmRef source, non-Cloner provider, source-missing pending, deletion-preserves-target; VMSet stub condition; **Part B guard** (adopted VM → no provider `Create`) + non-adopted control.
- **Lab validation:** unit-only so far. A real end-to-end clone requires a vSphere/Proxmox provider (libvirt `Clone` is Unimplemented), so live validation on the production vSphere is deferred — see "Risk" below.

## Risk

- **No breaking changes.** Additive only: new `VMClone.status.targetVMID` field, new RBAC for `vmclones`/`vmsets`, two new controllers.
- The VM-controller guard is the only change to an existing hot path; it is narrowly scoped to adopted-labeled VMs with empty `Status.ID` and covered by a negative-control test, so non-adopted VMs are byte-for-byte unchanged.
- Failed clones are **terminal** (recreate the VMClone to retry) — deliberate: a partial provider-side clone makes blind auto-retry unsafe.

## Impact

- [ ] Breaking change
- [x] Requires cluster rollout (CRD `targetVMID` field, new RBAC, two new controllers)
- [ ] Config change only
- [ ] Documentation only

Closes #179.
