### PR TITLE
fix(controller): VMClone target-VM bind race — Status.ID seed (#179 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-07 10:00] - Fix VMClone target-VM bind race (Status.ID seed) (#179 follow-up)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/controller/vmclone_controller.go`: make the clone target-VM binding conflict-tolerant and idempotent. A live vSphere clone E2E found that the target VM's `Status.ID` seed (`Status().Update`) loses a race with the VirtualMachine controller — which reconciles the freshly-created adopted target VM immediately and bumps its resourceVersion — so the update failed with a conflict and the recovery path (`Target VM already exists → finalizeReady`) marked the clone `Ready` **without** re-seeding `Status.ID`, leaving the cloned VM orphaned (unmanaged) forever. The fix: persist `Status.TargetVMID` before binding; seed `Status.ID` via `RetryOnConflict` re-Getting the latest object; only finalize `Ready` once `Status.ID` is confirmed; resume binding off the persisted `TargetVMID` (never re-clone); poll the async task before binding; and refuse a pre-existing foreign VM with the target name instead of finalizing over it.
+
+### Why
+The MVP clone controller (#188) passed unit tests but the fake client did not reproduce the concurrent write from the VirtualMachine controller. The real vSphere clone succeeded (one VM, no double-create — the guard held) but the target VM CR was left with an empty `Status.ID`, so the cloned VM was never managed. This makes the bind step robust against the inherent controller-vs-controller race.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager only; no CRD/RBAC change)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-07 09:00] - VMClone controller (MVP), VMSet stub, VMPlacementPolicy reference-only, VM double-create guard (#179)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/controller/vmclone_controller.go
+++ b/internal/controller/vmclone_controller.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -228,24 +229,34 @@ func (r *VMCloneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 		}
 	}
 
-	// Idempotency: if we already produced a target VM, or one with the target
-	// name already exists, do not clone again — move straight to binding.
-	if clone.Status.TargetRef != nil && clone.Status.TargetRef.Name != "" {
+	// A clone task is still in flight (async clone): wait for it, then bind.
+	// Checked before TargetVMID so async clones don't bind before the provider
+	// has finished cloning.
+	if clone.Status.TaskRef != "" {
+		return r.pollCloneTask(ctx, clone, sourceVM, providerInstance, targetNamespace, linked)
+	}
+
+	// Idempotency. Once the Clone RPC has returned a target VM ID (persisted in
+	// status by startClone before it binds, and after any task completes), the
+	// clone itself is done — resume binding rather than re-cloning. bindTargetVM
+	// is idempotent and conflict-tolerant, so re-entering here after a partial
+	// bind (e.g. a Status.ID write that lost a race with the VirtualMachine
+	// controller) completes the binding instead of leaving the clone orphaned.
+	if clone.Status.TargetVMID != "" {
 		return r.bindTargetVM(ctx, clone, sourceVM, targetNamespace, clone.Status.TargetVMID, linked)
 	}
+
+	// No clone issued yet. Refuse if a VM with the target name already exists
+	// and was NOT produced by this clone (no recorded TargetVMID) — cloning
+	// over a foreign VM would be destructive.
 	existing := &infrav1beta1.VirtualMachine{}
 	existingKey := client.ObjectKey{Namespace: targetNamespace, Name: clone.Spec.Target.Name}
 	if err := r.Get(ctx, existingKey, existing); err == nil {
-		logger.Info("Target VM already exists, binding without re-clone", "vm", existingKey.Name)
-		return r.finalizeReady(ctx, clone, existing)
+		return r.markFailed(ctx, clone, infrav1beta1.VMCloneReasonProviderError,
+			fmt.Sprintf("target VM %q already exists and was not created by this clone", existingKey.Name)), nil
 	} else if !errors.IsNotFound(err) {
 		logger.Error(err, "Failed to check for existing target VM", "vm", existingKey.Name)
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-
-	// If a clone task is already in flight, poll it.
-	if clone.Status.TaskRef != "" {
-		return r.pollCloneTask(ctx, clone, sourceVM, providerInstance, targetNamespace, linked)
 	}
 
 	// Issue the clone.
@@ -303,15 +314,22 @@ func (r *VMCloneReconciler) startClone(
 	clone.Status.TargetVMID = resp.TargetVmID
 	clone.Status.TaskRef = resp.TaskRef
 
+	// Persist the target VM ID BEFORE attempting to bind. The bind step writes
+	// the target VM's Status.ID and can lose a race with the VirtualMachine
+	// controller, which reconciles the freshly-created adopted target VM
+	// immediately. If that happens and we requeue, this persisted TargetVMID is
+	// what lets the next reconcile resume binding (via the idempotency check)
+	// instead of issuing a second clone.
+	if err := r.updateStatus(ctx, clone); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Synchronous clone (no task): bind the target VM immediately.
 	if resp.TaskRef == "" {
 		logger.Info("Clone completed synchronously", "target_vm_id", resp.TargetVmID)
 		return r.bindTargetVM(ctx, clone, sourceVM, targetNamespace, resp.TargetVmID, linked)
 	}
 
-	if err := r.updateStatus(ctx, clone); err != nil {
-		return ctrl.Result{}, err
-	}
 	logger.Info("Clone task started", "task_ref", resp.TaskRef)
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 }
@@ -341,14 +359,27 @@ func (r *VMCloneReconciler) pollCloneTask(
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	// Persist the cleared task ref before binding so a bind retry resumes via
+	// the TargetVMID idempotency path rather than re-polling a finished task.
 	clone.Status.TaskRef = ""
+	if err := r.updateStatus(ctx, clone); err != nil {
+		return ctrl.Result{}, err
+	}
 	return r.bindTargetVM(ctx, clone, sourceVM, targetNamespace, clone.Status.TargetVMID, linked)
 }
 
-// bindTargetVM creates (idempotently) the target VirtualMachine CR for a
-// completed clone and seeds its Status.ID with the provider-reported target VM
+// bindTargetVM ensures the target VirtualMachine CR exists for a completed
+// clone and that its Status.ID is seeded with the provider-reported target VM
 // ID. The adopted label plus the seeded Status.ID together stop the
 // VirtualMachine controller from creating a second VM (issue #179).
+//
+// It is idempotent and conflict-tolerant: it may run multiple times for the
+// same clone (the VirtualMachine controller reconciles the freshly-created,
+// adopted target VM immediately and bumps its resourceVersion, which would race
+// a naive Status().Update). The Status.ID seed therefore re-Gets the latest
+// object and retries on conflict, and the clone is only finalized Ready once
+// Status.ID is confirmed set — so a lost race resumes and completes the binding
+// instead of leaving the cloned VM orphaned.
 func (r *VMCloneReconciler) bindTargetVM(
 	ctx context.Context,
 	clone *infrav1beta1.VMClone,
@@ -366,19 +397,56 @@ func (r *VMCloneReconciler) bindTargetVM(
 	}
 
 	vmKey := client.ObjectKey{Namespace: targetNamespace, Name: clone.Spec.Target.Name}
+
+	// Ensure the target VM CR exists (idempotent across requeues).
 	targetVM := &infrav1beta1.VirtualMachine{}
-	err := r.Get(ctx, vmKey, targetVM)
-	switch {
-	case err == nil:
-		// Already created on a previous reconcile — finalize.
-		logger.Info("Target VM CR already exists", "vm", vmKey.Name)
-		return r.finalizeReady(ctx, clone, targetVM)
-	case !errors.IsNotFound(err):
+	switch err := r.Get(ctx, vmKey, targetVM); {
+	case errors.IsNotFound(err):
+		targetVM = r.buildTargetVM(clone, sourceVM, targetNamespace)
+		if createErr := r.Create(ctx, targetVM); createErr != nil && !errors.IsAlreadyExists(createErr) {
+			logger.Error(createErr, "Failed to create target VM CR", "vm", vmKey.Name)
+			return r.markFailed(ctx, clone, infrav1beta1.VMCloneReasonProviderError,
+				fmt.Sprintf("failed to create target VM: %v", createErr)), nil
+		}
+		r.Recorder.Event(clone, "Normal", infrav1beta1.VMCloneReasonCompleted,
+			fmt.Sprintf("Created target VM %q", vmKey.Name))
+	case err != nil:
 		logger.Error(err, "Failed to get target VM CR", "vm", vmKey.Name)
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Build the target VM CR.
+	// Seed Status.ID out-of-band (the status subresource is not persisted on
+	// Create) so the VirtualMachine controller adopts the already-cloned VM
+	// rather than creating a second one. Re-Get + retry on conflict because the
+	// VirtualMachine controller writes this same object concurrently.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &infrav1beta1.VirtualMachine{}
+		if getErr := r.Get(ctx, vmKey, latest); getErr != nil {
+			return getErr
+		}
+		if latest.Status.ID == targetVMID {
+			return nil
+		}
+		latest.Status.ID = targetVMID
+		return r.Status().Update(ctx, latest)
+	}); err != nil {
+		logger.Error(err, "Failed to seed Status.ID on target VM CR; will retry", "vm", vmKey.Name)
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	logger.Info("Target VM bound to cloned VM", "vm", vmKey.Name, "vm_id", targetVMID)
+	return r.finalizeReady(ctx, clone, targetVM)
+}
+
+// buildTargetVM constructs the target VirtualMachine CR for a clone: it carries
+// the adopted label and clone provenance annotations, inherits the source VM's
+// provider and class (unless the clone overrides the class), and copies the
+// requested networks/placement. Status.ID is seeded separately by bindTargetVM.
+func (r *VMCloneReconciler) buildTargetVM(
+	clone *infrav1beta1.VMClone,
+	sourceVM *infrav1beta1.VirtualMachine,
+	targetNamespace string,
+) *infrav1beta1.VirtualMachine {
 	labels := map[string]string{}
 	for k, v := range clone.Spec.Target.Labels {
 		labels[k] = v
@@ -398,7 +466,7 @@ func (r *VMCloneReconciler) bindTargetVM(
 		classRef = infrav1beta1.ObjectRef{Name: clone.Spec.Target.ClassRef.Name}
 	}
 
-	targetVM = &infrav1beta1.VirtualMachine{
+	targetVM := &infrav1beta1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        clone.Spec.Target.Name,
 			Namespace:   targetNamespace,
@@ -416,35 +484,7 @@ func (r *VMCloneReconciler) bindTargetVM(
 	if clone.Spec.Target.PlacementRef != nil && clone.Spec.Target.PlacementRef.Name != "" {
 		targetVM.Spec.PlacementRef = &infrav1beta1.LocalObjectReference{Name: clone.Spec.Target.PlacementRef.Name}
 	}
-
-	if err := r.Create(ctx, targetVM); err != nil {
-		if errors.IsAlreadyExists(err) {
-			// Lost a race — re-fetch and finalize.
-			if getErr := r.Get(ctx, vmKey, targetVM); getErr != nil {
-				logger.Error(getErr, "Failed to re-fetch target VM after AlreadyExists", "vm", vmKey.Name)
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-			}
-			return r.finalizeReady(ctx, clone, targetVM)
-		}
-		logger.Error(err, "Failed to create target VM CR", "vm", vmKey.Name)
-		return r.markFailed(ctx, clone, infrav1beta1.VMCloneReasonProviderError,
-			fmt.Sprintf("failed to create target VM: %v", err)), nil
-	}
-
-	// Seed Status.ID out-of-band (the status subresource is not persisted on
-	// Create). This is what prevents the VirtualMachine controller from
-	// creating a second VM for the already-cloned target.
-	targetVM.Status.ID = targetVMID
-	if err := r.Status().Update(ctx, targetVM); err != nil {
-		logger.Error(err, "Failed to set Status.ID on target VM CR", "vm", vmKey.Name)
-		// The VM CR exists; retry the status write on the next reconcile.
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-	}
-
-	logger.Info("Created target VM CR and seeded Status.ID", "vm", vmKey.Name, "vm_id", targetVMID)
-	r.Recorder.Event(clone, "Normal", infrav1beta1.VMCloneReasonCompleted,
-		fmt.Sprintf("Created target VM %q", vmKey.Name))
-	return r.finalizeReady(ctx, clone, targetVM)
+	return targetVM
 }
 
 // finalizeReady marks the VMClone Ready and records the target reference.

--- a/internal/controller/vmclone_controller_test.go
+++ b/internal/controller/vmclone_controller_test.go
@@ -375,6 +375,73 @@ func TestVMClone_SourceMissing_Pending(t *testing.T) {
 	assert.Equal(t, 0, cp.cloneCnt)
 }
 
+// TestVMClone_ResumeSeedsStatusIDOnExistingTarget is the regression test for the
+// bind race found during lab E2E (PR #188 follow-up): a prior reconcile cloned
+// the VM (TargetVMID persisted) and created the adopted target VM CR, but the
+// Status.ID seed lost a race with the VirtualMachine controller and never landed
+// — leaving the cloned VM orphaned (empty Status.ID, waiting forever) while the
+// clone falsely reported Ready. On a subsequent reconcile, bindTargetVM must
+// re-seed Status.ID from the persisted TargetVMID WITHOUT issuing a second
+// clone, then finalize Ready.
+func TestVMClone_ResumeSeedsStatusIDOnExistingTarget(t *testing.T) {
+	s := cloneTestScheme(t)
+	ns := "default"
+
+	prov := runningProvider(ns, "prov-1")
+	src := sourceVMWithID(ns, "src-vm", "prov-1", "vm-source-123")
+
+	// The partial-bind state: target VM CR exists (adopted) but Status.ID empty.
+	target := &infrav1beta1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "clone-target",
+			Namespace: ns,
+			Labels:    map[string]string{AdoptedLabel: AdoptedLabelValue},
+		},
+		Spec: infrav1beta1.VirtualMachineSpec{
+			ProviderRef: infrav1beta1.ObjectRef{Name: "prov-1"},
+			ClassRef:    infrav1beta1.ObjectRef{Name: "src-class"},
+		},
+	}
+
+	// The clone already issued (TargetVMID persisted), not yet Ready.
+	clone := &infrav1beta1.VMClone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "clone-resume",
+			Namespace:  ns,
+			Finalizers: []string{vmCloneFinalizer},
+		},
+		Spec: infrav1beta1.VMCloneSpec{
+			Source: infrav1beta1.CloneSource{VMRef: &infrav1beta1.LocalObjectReference{Name: "src-vm"}},
+			Target: infrav1beta1.VMCloneTarget{Name: "clone-target"},
+		},
+		Status: infrav1beta1.VMCloneStatus{
+			Phase:      infrav1beta1.ClonePhaseCloning,
+			TargetVMID: "vm-clone-999",
+		},
+	}
+
+	cp := &clonerProvider{cloneResp: contracts.CloneResponse{TargetVmID: "vm-clone-999"}}
+	r := newCloneReconciler(s, &stubResolver{provider: cp}, prov, src, target, clone)
+
+	reconcileTwice(t, r, client.ObjectKeyFromObject(clone))
+
+	// Must NOT re-clone when a target VM ID is already recorded.
+	assert.Equal(t, 0, cp.cloneCnt, "must not re-clone when TargetVMID is already set")
+
+	// Status.ID must now be seeded on the pre-existing target VM.
+	gotTarget := &infrav1beta1.VirtualMachine{}
+	require.NoError(t, r.Get(context.Background(),
+		client.ObjectKey{Namespace: ns, Name: "clone-target"}, gotTarget))
+	assert.Equal(t, "vm-clone-999", gotTarget.Status.ID, "Status.ID must be seeded on resume (no orphan)")
+
+	// And the clone finalizes Ready with a TargetRef.
+	got := &infrav1beta1.VMClone{}
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(clone), got))
+	assert.Equal(t, infrav1beta1.ClonePhaseReady, got.Status.Phase)
+	require.NotNil(t, got.Status.TargetRef)
+	assert.Equal(t, "clone-target", got.Status.TargetRef.Name)
+}
+
 // TestVMClone_DeletionDoesNotDeleteTarget: deleting a VMClone removes its
 // finalizer but leaves the produced target VM intact.
 func TestVMClone_DeletionDoesNotDeleteTarget(t *testing.T) {


### PR DESCRIPTION
## What

Follow-up to #188. Make the VMClone controller's **target-VM binding** conflict-tolerant and idempotent so a cloned VM is never left orphaned (unmanaged).

## The bug (found by a live vSphere clone E2E)

Running a real FullClone on vSphere with the merged #188 code:

- The clone itself worked — exactly one VM created (`vm-7002`), the Part B double-create guard held. ✅
- But seeding the target VM CR's `Status.ID` (`Status().Update`) **lost a race** with the VirtualMachine controller, which reconciles the freshly-created adopted target VM immediately and bumps its `resourceVersion`:
  ```
  Failed to set Status.ID on target VM CR ... the object has been modified; please apply your changes to the latest version
  ```
- The recovery path (`Target VM already exists → finalizeReady`) then marked the clone **`Ready` without re-seeding `Status.ID`** → the cloned VM was orphaned forever (`Status.ID` empty, VirtualMachine controller stuck "waiting for adoption/clone controller to set it").

Unit tests passed because the fake client doesn't reproduce the concurrent write from the VirtualMachine controller.

## The fix

`internal/controller/vmclone_controller.go`:
- **Persist `Status.TargetVMID` before binding** — so a bind retry resumes instead of re-cloning.
- **Seed `Status.ID` via `RetryOnConflict`**, re-Getting the latest target VM each attempt (handles the controller-vs-controller race).
- **Finalize `Ready` only once `Status.ID` is confirmed set** — no more false-Ready with an orphaned VM.
- **Resume off the persisted `TargetVMID`** (idempotency) so a re-entry never issues a second clone; **poll the async task before binding**; **refuse a pre-existing foreign VM** with the target name instead of finalizing over it.
- Adds `TestVMClone_ResumeSeedsStatusIDOnExistingTarget` reproducing the orphaned-target recovery path.

## Verification

- `make fmt` clean · `make lint` **0 issues** · `make build` OK · full `make test` passes · new regression test green.
- **Lab E2E on production vSphere (vr1):** built a dev manager image, cloned a throwaway source VM (`ubuntu-24-04` template). The race still occurs (log shows the brief "waiting" state) but the conflict-tolerant retry wins:
  ```
  Target VM bound to cloned VM ... vm_id=vm-7003
  ```
  Target VM reached `Ready (ReconcileSuccess)` — **managed, not orphaned** — with exactly one clone on vSphere and no double-create. All test resources cleaned up; manager reverted to v0.3.7.

## Risk

- **No breaking changes.** Manager-only; no CRD/RBAC/proto change. Pure robustness improvement to the bind step.

Relates to #179 (follow-up to #188).
