### PR TITLE
fix(vsphere): keep vCenter session alive + real-probe reconnect (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-07 17:00] - vSphere provider: keep vCenter session alive + real-probe reconnect (#190)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/vsphere/server.go`: the vSphere provider established a govmomi session once at startup and never kept it warm, so after a long idle period (no managed vSphere VMs ⇒ no API traffic) the server-side vCenter session expired and the next operation failed with `NotAuthenticated`. Worse, `Validate` gated its reconnect on the cached `client.Valid()` (no round-trip), so it reported OK while operations failed. Two-part fix:
+  - **Keepalive handler** (`session/keepalive.NewHandlerSOAP`) installed in `createVSphereClient`, probing every `vSphereKeepAliveInterval` (5m, well under vCenter's 30m default) and re-logging-in on a failed probe — so the session never idles out.
+  - **`Validate` now probes the live session** (`methods.GetCurrentTime`) instead of trusting `client.Valid()`, and reconnects with a fresh login on failure. Since the manager calls `Validate` before operations, this is the safety net.
+
+### Added
+- `internal/providers/vsphere/session_test.go`: hermetic govmomi-`simulator` tests — keepalive handler is installed on the round-tripper, and `Validate` reconnects + reports OK after the session is dropped.
+
+### Why
+Observed on the lab: the `vsphere-prod` provider ran ~8 days idle (no managed vSphere VMs), then a clone `Create` failed `NotAuthenticated` while `Validate` returned OK; a pod restart was the only recovery. This makes the provider self-heal.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (vSphere provider only; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-07 10:00] - Fix VMClone target-VM bind race (Status.ID seed) (#179 follow-up)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/vsphere/server.go
+++ b/internal/providers/vsphere/server.go
@@ -35,8 +35,10 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/session/keepalive"
 	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
@@ -143,6 +145,11 @@ func loadCredentialsFromFiles(config *Config) error {
 	return nil
 }
 
+// vSphereKeepAliveInterval is how often the keepalive handler probes vCenter to
+// keep the session from idling out. It must be comfortably below the vCenter
+// session timeout (default 30 minutes); 5 minutes leaves wide margin (#190).
+const vSphereKeepAliveInterval = 5 * time.Minute
+
 // createVSphereClient establishes an authenticated govmomi session against the vCenter
 // SOAP API described by config and returns a connected govmomi.Client together with a
 // Finder configured to search the default datacenter.
@@ -190,8 +197,30 @@ func createVSphereClient(config *Config) (*govmomi.Client, *find.Finder, error) 
 		SessionManager: session.NewManager(vimClient),
 	}
 
-	// Login to vSphere with explicit credentials (proper govmomi authentication method)
 	userInfo := url.UserPassword(config.Username, config.Password)
+
+	// Keep the vCenter session warm so it does not silently expire during long
+	// idle periods. When no VirtRigaud-managed vSphere VMs exist there is no API
+	// traffic, the server-side session times out, and the next operation fails
+	// with NotAuthenticated even though the cached client looks valid (#190).
+	//
+	// The keepalive goroutine is started by the Login below (HandlerSOAP starts
+	// its ticker on a Login round-trip) and probes every vSphereKeepAliveInterval.
+	// On a failed probe it re-logs-in and returns nil so the goroutine keeps
+	// running; Start() is idempotent, so the re-login round-trip is safe. It
+	// returns an error — which permanently stops the goroutine — only when the
+	// re-login itself fails, in which case Validate's real-probe reconnect is the
+	// safety net.
+	vimClient.RoundTripper = keepalive.NewHandlerSOAP(vimClient.RoundTripper, vSphereKeepAliveInterval, func() error {
+		ctx := context.Background()
+		if _, err := methods.GetCurrentTime(ctx, vimClient); err != nil {
+			return client.Login(ctx, userInfo)
+		}
+		return nil
+	})
+
+	// Login to vSphere with explicit credentials (proper govmomi authentication
+	// method). This also starts the keepalive ticker configured above.
 	if err := client.Login(context.Background(), userInfo); err != nil {
 		return nil, nil, fmt.Errorf("failed to login to vSphere: %w", err)
 	}
@@ -339,14 +368,19 @@ func (p *Provider) Validate(ctx context.Context, req *providerv1.ValidateRequest
 		}, nil
 	}
 
-	// Test the connection by checking if the session is valid
-	if !p.client.Valid() {
-		// Try to reconnect
-		client, finder, err := createVSphereClient(p.config)
-		if err != nil {
+	// Probe the live session rather than trusting the cached client.Valid(),
+	// which returns true even after the server-side session has expired during a
+	// long idle — the exact failure mode where Validate reported OK while the
+	// next operation hit NotAuthenticated (#190). GetCurrentTime round-trips to
+	// vCenter; on failure, reconnect with a fresh login. Because the manager
+	// calls Validate before operations, this real probe is the safety net that
+	// complements the keepalive handler in createVSphereClient.
+	if _, err := methods.GetCurrentTime(ctx, p.client.Client); err != nil {
+		client, finder, rerr := createVSphereClient(p.config)
+		if rerr != nil {
 			return &providerv1.ValidateResponse{
 				Ok:      false,
-				Message: fmt.Sprintf("Failed to connect to vSphere: %v", err),
+				Message: fmt.Sprintf("Failed to connect to vSphere: %v", rerr),
 			}, nil
 		}
 		p.client = client

--- a/internal/providers/vsphere/session_test.go
+++ b/internal/providers/vsphere/session_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/session/keepalive"
+	"github.com/vmware/govmomi/simulator"
+
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// newSimConfig spins up an in-memory vCenter simulator and returns a Config that
+// points createVSphereClient at it, plus a cleanup func.
+func newSimConfig(t *testing.T) (*Config, func()) {
+	t.Helper()
+	model := simulator.VPX()
+	require.NoError(t, model.Create())
+	server := model.Service.NewServer()
+
+	u := server.URL // includes embedded user:pass
+	pw, _ := u.User.Password()
+	cfg := &Config{
+		Endpoint:           (&url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path}).String(),
+		Username:           u.User.Username(),
+		Password:           pw,
+		InsecureSkipVerify: true,
+	}
+	cleanup := func() {
+		server.Close()
+		model.Remove()
+	}
+	return cfg, cleanup
+}
+
+// TestCreateVSphereClient_InstallsKeepAlive verifies the govmomi client logs in
+// against vCenter and that a keepalive handler is installed on the round-tripper,
+// so the session is kept warm and does not idle out (#190).
+func TestCreateVSphereClient_InstallsKeepAlive(t *testing.T) {
+	cfg, cleanup := newSimConfig(t)
+	defer cleanup()
+
+	client, finder, err := createVSphereClient(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NotNil(t, finder)
+	defer func() { _ = client.Logout(context.Background()) }()
+
+	_, ok := client.RoundTripper.(*keepalive.HandlerSOAP)
+	assert.True(t, ok, "expected keepalive.HandlerSOAP installed on the vim25 round-tripper (#190)")
+}
+
+// TestValidate_ReconnectsAfterSessionLoss verifies Validate probes the live
+// session (GetCurrentTime) rather than trusting the cached client.Valid(), and
+// reconnects when the session is gone — returning Ok instead of letting the next
+// operation hit NotAuthenticated (#190).
+func TestValidate_ReconnectsAfterSessionLoss(t *testing.T) {
+	cfg, cleanup := newSimConfig(t)
+	defer cleanup()
+
+	client, finder, err := createVSphereClient(cfg)
+	require.NoError(t, err)
+
+	p := &Provider{client: client, finder: finder, config: cfg, logger: slog.Default()}
+
+	// Healthy session → Ok.
+	resp, err := p.Validate(context.Background(), &providerv1.ValidateRequest{})
+	require.NoError(t, err)
+	assert.True(t, resp.Ok, "validate should be Ok on a live session")
+
+	// Drop the session server-side; Validate must reconnect and still report Ok
+	// (the pre-fix code trusted the cached Valid() and would not have).
+	require.NoError(t, client.Logout(context.Background()))
+
+	resp, err = p.Validate(context.Background(), &providerv1.ValidateRequest{})
+	require.NoError(t, err)
+	assert.True(t, resp.Ok, "validate should reconnect after session loss and report Ok")
+
+	// The provider must now hold a usable session (a fresh probe succeeds).
+	require.NotNil(t, p.client)
+	_, err = p.Validate(context.Background(), &providerv1.ValidateRequest{})
+	require.NoError(t, err)
+	_ = p.client.Logout(context.Background())
+}


### PR DESCRIPTION
## What

Fix the vSphere provider's idle vCenter session expiry (#190).

- **Keepalive handler** (`session/keepalive.NewHandlerSOAP`) in `createVSphereClient`: probes every 5m (well under vCenter's 30m default) and re-logs-in on a failed probe, so the session is kept warm and never idles out. The handler's ticker is started by the existing Login; `Start()` is idempotent so the re-login round-trip inside the probe is safe.
- **`Validate` now probes the live session** (`methods.GetCurrentTime`) instead of trusting the cached `client.Valid()` (which does not round-trip), and reconnects with a fresh login on failure. The manager calls `Validate` before operations, so this is the safety net.

## Why

Observed on the lab: `vsphere-prod` ran ~8 days idle (no VirtRigaud-managed vSphere VMs ⇒ no API traffic), the server-side session expired, and a clone `Create` failed `NotAuthenticated` — while `Validate` returned OK (cached `Valid()`, 4µs, no round-trip). Only a pod restart recovered it. This makes the provider self-heal.

## Verification

- `make fmt`/`lint` (0 issues)/`build` clean; `go vet` clean.
- New **hermetic** tests (`internal/providers/vsphere/session_test.go`) using the govmomi `simulator`: (1) the keepalive handler is installed on the round-tripper after login; (2) `Validate` reconnects and reports OK after the session is dropped server-side (the simulator enforces sessions, so the reconnect path is genuinely exercised — the pre-fix cached `Valid()` would not have).
- **Lab validation** will be done at the `v0.3.8-rc1` stage (deploy + confirm provider connects, keepalive runs, a clone succeeds). The re-auth logic itself is proven hermetically here.

## Risk

- vSphere-provider-only; no CRD/proto/manager change. No behavior change on the active path — only adds session-keepalive + a real liveness probe in `Validate`. Bundling for **v0.3.8**.

Closes #190.
