### PR TITLE
fix(libvirt): retry transient SSH connection failures (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-07 17:05] - libvirt provider: retry transient SSH connection failures (#191)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/libvirt/virsh.go`: the libvirt provider runs every `virsh` command as a fresh `sshpass -e ssh` process, so a burst of operations opens a burst of SSH handshakes. When the libvirt host throttles connections (sshd `MaxStartups`, fail2ban) it closes the connection during key exchange, surfacing as `kex_exchange_identification: Connection closed by remote host` and tripping the provider circuit breaker. `runVirshCommand` now retries **only** transient SSH *connection* failures (classified from stderr: `kex_exchange_identification`, connection refused/reset/timed-out, no-route-to-host, transient DNS) with bounded exponential backoff (3 attempts), honoring context cancellation. Real virsh errors (e.g. "domain not found") and the success path return on the first attempt — behavior is unchanged except under host-side SSH throttling.
+
+### Added
+- `internal/providers/libvirt/virsh_retry_test.go`: tests for the transient-error classifier (transient connect errors vs. real virsh errors) and the retry loop (retries-then-succeeds, real-error-no-retry, attempt exhaustion, context-cancel).
+
+### Why
+Recurring on the lab (`I1`): host `172.16.56.8` repeatedly closed SSH connections during migration/clone E2E windows, making managed VMs appear unreachable. This makes a momentary host-side refusal recoverable instead of fatal. **The root cause is partly host-side** — operators must still tune `MaxStartups`/fail2ban on the libvirt host; connection multiplexing (ControlMaster) is tracked as a follow-up.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (libvirt provider only; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-07 17:00] - vSphere provider: keep vCenter session alive + real-probe reconnect (#190)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/virsh.go
+++ b/internal/providers/libvirt/virsh.go
@@ -261,9 +261,93 @@ type VirshResult struct {
 	Duration time.Duration
 }
 
-// runVirshCommand executes a virsh command with proper environment and error handling
-// Special case: if first arg is "!", execute the remaining args as a direct command (not virsh)
+// sshConnectMaxAttempts and sshConnectBaseBackoff bound the retry of a
+// virsh-over-SSH command when the SSH *connection* (not the virsh command)
+// fails transiently — e.g. the host throttles/refuses connections under
+// MaxStartups/fail2ban, surfacing as `kex_exchange_identification` (#191).
+// They are package vars (not consts) only so tests can shrink the backoff.
+var (
+	sshConnectMaxAttempts = 3
+	sshConnectBaseBackoff = 1 * time.Second
+)
+
+// transientSSHConnectError reports whether stderr indicates a transient SSH
+// *connection* failure — the host refused or closed the connection before the
+// remote command ran. These are safe to retry because the virsh command never
+// executed, so a retry cannot duplicate a side effect. Real virsh errors (e.g.
+// "domain not found") never match and are returned immediately (#191).
+func transientSSHConnectError(stderr string) bool {
+	s := strings.ToLower(stderr)
+	for _, m := range []string{
+		"kex_exchange_identification",      // host closed conn during key exchange (MaxStartups/fail2ban)
+		"connection closed by remote host", // host dropped the connection pre-auth
+		"connection reset by peer",
+		"connection refused",
+		"connection timed out",
+		"no route to host",
+		"ssh: connect to host",                 // generic ssh connect failure
+		"temporary failure in name resolution", // transient DNS
+	} {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// runVirshCommand executes a virsh command, transparently retrying ONLY
+// transient SSH-connection failures (see transientSSHConnectError) with bounded
+// exponential backoff. Real virsh errors and the success path return on the
+// first attempt, so behavior is unchanged except under host-side SSH throttling
+// (#191). Retries stop early if the context is cancelled.
+//
+// Special case: if the first arg is "!", the remaining args run as a direct
+// command (not through virsh).
 func (v *VirshProvider) runVirshCommand(ctx context.Context, args ...string) (*VirshResult, error) {
+	return retryOnTransientSSH(ctx, func() (*VirshResult, error) {
+		return v.runVirshCommandOnce(ctx, args...)
+	})
+}
+
+// retryOnTransientSSH invokes attempt up to sshConnectMaxAttempts times, retrying
+// (with exponential backoff, honoring ctx) ONLY when the attempt's result stderr
+// indicates a transient SSH connection failure. Any other error — including a
+// real virsh command error — and the success path return immediately (#191).
+func retryOnTransientSSH(ctx context.Context, attempt func() (*VirshResult, error)) (*VirshResult, error) {
+	var result *VirshResult
+	var err error
+	backoff := sshConnectBaseBackoff
+
+	for n := 1; n <= sshConnectMaxAttempts; n++ {
+		result, err = attempt()
+		if err == nil {
+			return result, nil
+		}
+
+		stderr := ""
+		if result != nil {
+			stderr = result.Stderr
+		}
+		if n == sshConnectMaxAttempts || !transientSSHConnectError(stderr) {
+			return result, err
+		}
+
+		log.Printf("WARN Transient SSH connection failure (attempt %d/%d), retrying in %v: %s",
+			n, sshConnectMaxAttempts, backoff, strings.TrimSpace(stderr))
+		select {
+		case <-ctx.Done():
+			return result, err
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+	return result, err
+}
+
+// runVirshCommandOnce executes a virsh command once with proper environment and
+// error handling. Special case: if first arg is "!", execute the remaining args
+// as a direct command (not virsh).
+func (v *VirshProvider) runVirshCommandOnce(ctx context.Context, args ...string) (*VirshResult, error) {
 	start := time.Now()
 
 	var cmd *exec.Cmd

--- a/internal/providers/libvirt/virsh_retry_test.go
+++ b/internal/providers/libvirt/virsh_retry_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransientSSHConnectError(t *testing.T) {
+	cases := []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		{"kex_exchange_identification", "kex_exchange_identification: Connection closed by remote host", true},
+		{"connection refused", "ssh: connect to host 10.0.0.1 port 22: Connection refused", true},
+		{"connection reset", "client_loop: send disconnect: Connection reset by peer", true},
+		{"connection timed out", "ssh: connect to host h port 22: Connection timed out", true},
+		{"no route to host", "ssh: connect to host h port 22: No route to host", true},
+		{"dns transient", "ssh: Could not resolve hostname h: Temporary failure in name resolution", true},
+		{"case-insensitive", "KEX_EXCHANGE_IDENTIFICATION: Connection Closed By Remote Host", true},
+		// Real virsh errors must NOT be treated as transient.
+		{"domain not found", "error: failed to get domain 'vm1'\nerror: Domain not found", false},
+		{"permission denied", "Permission denied, please try again.", false},
+		{"empty", "", false},
+		{"generic virsh error", "error: invalid argument: could not find capabilities", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, transientSSHConnectError(tc.stderr))
+		})
+	}
+}
+
+// withFastBackoff shrinks the retry backoff for the duration of a test.
+func withFastBackoff(t *testing.T) {
+	t.Helper()
+	orig := sshConnectBaseBackoff
+	sshConnectBaseBackoff = time.Millisecond
+	t.Cleanup(func() { sshConnectBaseBackoff = orig })
+}
+
+func TestRetryOnTransientSSH_RetriesThenSucceeds(t *testing.T) {
+	withFastBackoff(t)
+	calls := 0
+	res, err := retryOnTransientSSH(context.Background(), func() (*VirshResult, error) {
+		calls++
+		if calls < 3 {
+			return &VirshResult{Stderr: "kex_exchange_identification: Connection closed by remote host"},
+				&VirshError{Stderr: "kex_exchange_identification: Connection closed by remote host"}
+		}
+		return &VirshResult{Stdout: "ok"}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", res.Stdout)
+	assert.Equal(t, 3, calls, "should retry transient failures until success")
+}
+
+func TestRetryOnTransientSSH_RealErrorNoRetry(t *testing.T) {
+	withFastBackoff(t)
+	calls := 0
+	_, err := retryOnTransientSSH(context.Background(), func() (*VirshResult, error) {
+		calls++
+		return &VirshResult{Stderr: "error: Domain not found"},
+			&VirshError{Stderr: "error: Domain not found"}
+	})
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "real virsh errors must not be retried")
+}
+
+func TestRetryOnTransientSSH_ExhaustsAttempts(t *testing.T) {
+	withFastBackoff(t)
+	calls := 0
+	_, err := retryOnTransientSSH(context.Background(), func() (*VirshResult, error) {
+		calls++
+		return &VirshResult{Stderr: "kex_exchange_identification: Connection closed by remote host"},
+			&VirshError{Stderr: "kex_exchange_identification: Connection closed by remote host"}
+	})
+	require.Error(t, err)
+	assert.Equal(t, sshConnectMaxAttempts, calls, "should give up after the bounded number of attempts")
+}
+
+func TestRetryOnTransientSSH_ContextCancelStops(t *testing.T) {
+	withFastBackoff(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	calls := 0
+	_, err := retryOnTransientSSH(ctx, func() (*VirshResult, error) {
+		calls++
+		return &VirshResult{Stderr: "kex_exchange_identification: Connection closed by remote host"},
+			&VirshError{Stderr: "kex_exchange_identification: Connection closed by remote host"}
+	})
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "a cancelled context must stop retries after the first attempt")
+}


### PR DESCRIPTION
## What

Make the libvirt provider resilient to transient SSH **connection** failures (#191).

`runVirshCommand` (which runs each `virsh` over a fresh `sshpass -e ssh`) now retries — with bounded exponential backoff (3 attempts, context-aware) — **only** when the failure is a transient SSH *connection* error classified from stderr:

- `kex_exchange_identification: Connection closed by remote host` (host throttling — `MaxStartups`/fail2ban)
- connection refused / reset / timed out, no route to host, transient DNS

Real virsh errors (e.g. "domain not found") and the success path return on the **first** attempt, so behavior is unchanged except under host-side SSH throttling. The retry loop is extracted into a small `retryOnTransientSSH` helper for testability.

## Why

Recurring on the lab (`I1`): host `172.16.56.8` repeatedly closed SSH connections during the migration (#177) and clone (#179) E2E windows, tripping the provider circuit breaker and making managed VMs appear unreachable (management-plane only). This makes a momentary refusal recoverable.

**Scope note (agreed):** retry/backoff only. The true root cause is partly host-side — operators must tune `MaxStartups`/fail2ban on the libvirt host. SSH **ControlMaster multiplexing** (reuse one connection for many `virsh` calls, eliminating the churn at the source) is tracked as a separate follow-up.

## Verification

- libvirt is excluded from `make`'s default targets, so run directly: `go build ./internal/providers/libvirt/` OK · `go vet` clean · `golangci-lint run ./internal/providers/libvirt/...` **0 issues** · `go test ./internal/providers/libvirt/` passes.
- New tests (`virsh_retry_test.go`): the transient classifier (transient connect errors vs. real virsh errors, case-insensitive) and the retry loop (retries-then-succeeds, real-error-no-retry, attempt exhaustion, context-cancel-stops).
- **Lab validation** at the `v0.3.8-rc1` stage on an isolated provider (per the production-safety rule for the libvirt path that serves the 13 live VMs).

## Risk

- libvirt-provider-only; no CRD/proto/manager change. Success and real-error paths are byte-for-byte unchanged (single attempt). Only adds retries for transient connection refusals. Bundling for **v0.3.8**.

Closes #191.
