### PR TITLE
feat(libvirt): SSH ControlMaster connection multiplexing (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-08 05:45] - libvirt provider: SSH ControlMaster connection multiplexing (#194)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/libvirt/sshhostkey.go`: SSH **ControlMaster** connection multiplexing for the libvirt provider. A burst of `virsh`/`scp` invocations now reuses a single SSH connection (`ControlMaster=auto`, `ControlPath=/tmp/virtrigaud-ssh-%C`, `ControlPersist=60s`) instead of opening a fresh handshake per command — eliminating at the source the connection churn that can trip the libvirt host's sshd `MaxStartups`/fail2ban (the symptom #191 retries client-side). Wired into both `virsh` SSH branches (`virsh.go`), the `scp` disk-copy path (`server.go`), and the `~/.ssh/config` stanza used by libvirt's own `qemu+ssh://` transport. ON by default; escape hatch `LIBVIRT_SSH_DISABLE_MULTIPLEXING=true` reverts to one connection per command. The control socket lives under `/tmp` (writable in the provider container, wiped on restart, so no stale sockets survive), and `%C` keeps the path under the AF_UNIX limit.
+- `internal/providers/libvirt/sshmultiplex_test.go`: tests for the env escape hatch, the option builder (enabled/disabled), and the config-stanza multiplex lines.
+
+### Why
+Follow-up to #191 (which added client-side retry/backoff). Multiplexing removes the churn rather than just tolerating its symptom: steady-state, many `virsh` calls share one connection, so the host's per-source connection-rate limits are far less likely to trip.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (libvirt provider only; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-07 17:05] - libvirt provider: retry transient SSH connection failures (#191)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -761,6 +761,8 @@ func (s *Server) copyDiskToRemote(ctx context.Context, virshProvider *VirshProvi
 		return "", fmt.Errorf("libvirt scp host-key verification pre-flight failed: %w", err)
 	}
 	hostKeyOpts := virshProvider.hostKey.sshHostKeyOptions()
+	// Share the SSH connection with the virsh path via ControlMaster (#194).
+	hostKeyOpts = append(hostKeyOpts, sshMultiplexOptions()...)
 
 	// Run scp LOCALLY on the pod to copy to remote host
 	var cmd *exec.Cmd

--- a/internal/providers/libvirt/sshhostkey.go
+++ b/internal/providers/libvirt/sshhostkey.go
@@ -69,7 +69,55 @@ const (
 	// helper selects between.
 	strictYes       = "yes"
 	strictAcceptNew = "accept-new"
+
+	// EnvDisableSSHMultiplexing is the escape hatch that turns OFF SSH
+	// connection multiplexing (ControlMaster). Multiplexing is ON by default
+	// (#194) so a burst of `virsh`/`scp` invocations reuses a single SSH
+	// connection instead of opening a fresh handshake per command — the churn
+	// that can trip the libvirt host's sshd MaxStartups / fail2ban (the same
+	// symptom #191 retries client-side). Set to the literal "true"
+	// (case-insensitive, trimmed) to revert to one connection per command;
+	// any other value keeps multiplexing on. Settable per-Provider via
+	// spec.runtime.env, mirroring the other libvirt escape hatches.
+	EnvDisableSSHMultiplexing = "LIBVIRT_SSH_DISABLE_MULTIPLEXING"
+
+	// sshControlPath is the ssh ControlMaster socket path. `%C` is a short,
+	// fixed-length hash of (local host, remote host, port, user), keeping the
+	// path well under the AF_UNIX sun_path limit and unique per destination. It
+	// lives under /tmp — writable in the provider container and wiped on pod
+	// restart, so no stale control sockets survive a restart.
+	sshControlPath = "/tmp/virtrigaud-ssh-%C"
+
+	// sshControlPersist keeps the background master connection open this long
+	// after the last multiplexed session, so subsequent commands (and the next
+	// reconcile burst) reuse it instead of re-handshaking.
+	sshControlPersist = "60s"
 )
+
+// sshMultiplexingEnabled reports whether SSH ControlMaster connection sharing is
+// active. It is ON by default and disabled only by the explicit, greppable
+// escape hatch EnvDisableSSHMultiplexing=true (#194).
+func sshMultiplexingEnabled() bool {
+	return !strings.EqualFold(strings.TrimSpace(os.Getenv(EnvDisableSSHMultiplexing)), "true")
+}
+
+// sshMultiplexOptions returns the `ssh`/`scp` `-o key=value` flag pairs that
+// enable ControlMaster connection sharing, laid out as alternating
+// ["-o","k=v",...] so they spread directly into an argv builder. It returns nil
+// when multiplexing is disabled (EnvDisableSSHMultiplexing=true) so callers fall
+// back to a fresh connection per command. Reusing one connection across many
+// virsh/scp invocations collapses the SSH handshake churn that can trip the
+// host's MaxStartups/fail2ban (#191/#194). Independent of the host-key policy.
+func sshMultiplexOptions() []string {
+	if !sshMultiplexingEnabled() {
+		return nil
+	}
+	return []string{
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + sshControlPath,
+		"-o", "ControlPersist=" + sshControlPersist,
+	}
+}
 
 // hostKeyPolicy captures the resolved SSH host-key verification posture for a
 // single provider process. It is computed once (resolveHostKeyPolicy) and then
@@ -128,13 +176,22 @@ func (p hostKeyPolicy) sshHostKeyOptions() []string {
 // any ssh invocation that reads the config (notably libvirt's own qemu+ssh://
 // transport) honours the same host-key policy as the explicit-argv paths.
 func (p hostKeyPolicy) sshConfigStanza() string {
-	return fmt.Sprintf(`Host *
+	stanza := fmt.Sprintf(`Host *
     StrictHostKeyChecking %s
     PasswordAuthentication yes
     PubkeyAuthentication no
     UserKnownHostsFile %s
     LogLevel ERROR
 `, p.strictHostKeyChecking(), p.knownHostsFile())
+	// Mirror the explicit-argv ControlMaster options into the config so that
+	// libvirt's own qemu+ssh:// transport also shares one connection (#194).
+	if sshMultiplexingEnabled() {
+		stanza += fmt.Sprintf(`    ControlMaster auto
+    ControlPath %s
+    ControlPersist %s
+`, sshControlPath, sshControlPersist)
+	}
+	return stanza
 }
 
 // applyURIHostKeyOptions sets the host-key-related query parameters on the

--- a/internal/providers/libvirt/sshmultiplex_test.go
+++ b/internal/providers/libvirt/sshmultiplex_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSSHMultiplexingEnabled_EnvParsing verifies multiplexing is ON by default
+// and disabled ONLY by the literal word "true" (case-insensitive, trimmed),
+// mirroring the other libvirt escape-hatch env semantics (#194).
+func TestSSHMultiplexingEnabled_EnvParsing(t *testing.T) {
+	cases := []struct {
+		name     string
+		envSet   bool
+		envValue string
+		want     bool
+	}{
+		{"unset (default on)", false, "", true},
+		{"empty", true, "", true},
+		{"true disables", true, "true", false},
+		{"TRUE disables", true, "TRUE", false},
+		{"  true  trimmed disables", true, "  true  ", false},
+		{"false keeps on", true, "false", true},
+		{"1 keeps on", true, "1", true},
+		{"yes keeps on", true, "yes", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envSet {
+				t.Setenv(EnvDisableSSHMultiplexing, tc.envValue)
+			} else {
+				t.Setenv(EnvDisableSSHMultiplexing, "")
+			}
+			assert.Equal(t, tc.want, sshMultiplexingEnabled())
+		})
+	}
+}
+
+// TestSSHMultiplexOptions_Enabled verifies the ControlMaster option triplet is
+// emitted (as alternating -o k=v pairs) when multiplexing is on (#194).
+func TestSSHMultiplexOptions_Enabled(t *testing.T) {
+	t.Setenv(EnvDisableSSHMultiplexing, "")
+	opts := sshMultiplexOptions()
+	joined := strings.Join(opts, " ")
+	assert.Contains(t, joined, "ControlMaster=auto")
+	assert.Contains(t, joined, "ControlPath=/tmp/virtrigaud-ssh-%C")
+	assert.Contains(t, joined, "ControlPersist=60s")
+	// Laid out as alternating -o pairs so it spreads into an argv builder.
+	assert.Equal(t, 6, len(opts), "expected three -o k=v pairs")
+	for i := 0; i < len(opts); i += 2 {
+		assert.Equal(t, "-o", opts[i])
+	}
+}
+
+// TestSSHMultiplexOptions_Disabled verifies the escape hatch yields no options,
+// so callers fall back to one SSH connection per command (#194).
+func TestSSHMultiplexOptions_Disabled(t *testing.T) {
+	t.Setenv(EnvDisableSSHMultiplexing, "true")
+	assert.Empty(t, sshMultiplexOptions())
+}
+
+// TestSSHConfigStanza_Multiplexing verifies the ControlMaster lines are present
+// in the ssh config stanza (used by libvirt's qemu+ssh:// transport) when
+// multiplexing is on, and absent when disabled (#194).
+func TestSSHConfigStanza_Multiplexing(t *testing.T) {
+	p := hostKeyPolicy{}
+
+	t.Setenv(EnvDisableSSHMultiplexing, "")
+	on := p.sshConfigStanza()
+	assert.Contains(t, on, "ControlMaster auto")
+	assert.Contains(t, on, "ControlPath /tmp/virtrigaud-ssh-%C")
+	assert.Contains(t, on, "ControlPersist 60s")
+
+	t.Setenv(EnvDisableSSHMultiplexing, "true")
+	off := p.sshConfigStanza()
+	assert.NotContains(t, off, "ControlMaster")
+	// Host-key directives remain regardless of multiplexing.
+	assert.Contains(t, off, "StrictHostKeyChecking")
+}

--- a/internal/providers/libvirt/virsh.go
+++ b/internal/providers/libvirt/virsh.go
@@ -374,8 +374,10 @@ func (v *VirshProvider) runVirshCommandOnce(ctx context.Context, args ...string)
 				"-o", "PubkeyAuthentication=no",
 				"-o", "LogLevel=ERROR",
 			}
-			// Host-key options come from the centralized policy (#149/ADR-0004).
+			// Host-key options come from the centralized policy (#149/ADR-0004);
+			// ControlMaster multiplexing reuses one connection (#194).
 			sshArgs = append(sshArgs, v.hostKey.sshHostKeyOptions()...)
+			sshArgs = append(sshArgs, sshMultiplexOptions()...)
 			sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host))
 			sshArgs = append(sshArgs, directArgs...)
 
@@ -406,8 +408,10 @@ func (v *VirshProvider) runVirshCommandOnce(ctx context.Context, args ...string)
 				"-o", "PubkeyAuthentication=no",
 				"-o", "LogLevel=ERROR",
 			}
-			// Host-key options come from the centralized policy (#149/ADR-0004).
+			// Host-key options come from the centralized policy (#149/ADR-0004);
+			// ControlMaster multiplexing reuses one connection (#194).
 			sshArgs = append(sshArgs, v.hostKey.sshHostKeyOptions()...)
+			sshArgs = append(sshArgs, sshMultiplexOptions()...)
 			sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host), "virsh")
 			sshArgs = append(sshArgs, args...)
 


### PR DESCRIPTION
## What

Follow-up to #191: add **SSH ControlMaster connection multiplexing** to the libvirt provider so a burst of `virsh`/`scp` invocations reuses **one** SSH connection instead of opening a fresh handshake per command.

- `ControlMaster=auto`, `ControlPath=/tmp/virtrigaud-ssh-%C`, `ControlPersist=60s`, added centrally in `sshhostkey.go` and wired into:
  - both `virsh` SSH branches (`virsh.go`)
  - the `scp` disk-copy path (`server.go`)
  - the `~/.ssh/config` stanza used by libvirt's own `qemu+ssh://` transport
- **ON by default**; escape hatch **`LIBVIRT_SSH_DISABLE_MULTIPLEXING=true`** reverts to one connection per command.
- Control socket lives under `/tmp` (writable in the provider container, wiped on pod restart → no stale sockets survive a restart); `%C` keeps the path under the AF_UNIX `sun_path` limit and unique per destination.

## Why

#191 made the provider **tolerate** transient SSH refusals (retry/backoff). This **removes the cause**: steady-state, many `virsh` calls share a single connection, so the libvirt host's per-source connection-rate limits (`MaxStartups`/fail2ban) are far less likely to trip. The two changes are complementary — multiplexing reduces churn; retry covers the residual.

## Verification

- libvirt is excluded from default `make` targets, so run directly: `go build ./internal/providers/libvirt/` OK · `go vet` clean · `golangci-lint run ./internal/providers/libvirt/...` **0 issues** · `go test ./internal/providers/libvirt/` passes · whole-repo `go build ./...` OK.
- New tests (`sshmultiplex_test.go`): env escape-hatch parsing (on by default; off only on literal `true`), the option builder (enabled → 3 `-o` pairs; disabled → none), and the config-stanza multiplex lines.
- **Lab validation:** to be done on an **isolated** libvirt provider on vr1 (per the production-safety rule — the only libvirt provider serves 13 live VMs). The change is default-on but fully reversible via the env flag and falls back gracefully (ssh re-creates the master / uses a direct connection if a socket is stale).

## Risk

- libvirt-provider-only; no CRD/proto/manager change. Behavior change is confined to how SSH connections are established (reused vs. per-command); host-key policy, auth, and the #191 retry are unchanged. Reversible at runtime via `LIBVIRT_SSH_DISABLE_MULTIPLEXING=true`.

Closes #194.
