### PR TITLE
chore(ci): unify supply-chain verification format + close Node-20 backlog (#172, #134)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,15 @@
 #     reviewed individually; minor + patch bumps batch into a single PR
 #     per ecosystem to reduce review overhead.
 #   - The Node.js 20 deprecation in GitHub Actions has a 2026-09-16
-#     hard removal date. Actions still on Node 20 (per PROJECT_CONTEXT.md
-#     Risks-Watching) include: actions/setup-go (v5 → latest v6+),
-#     docker/login-action (v3 → v4+), docker/metadata-action (v5 → v6+),
-#     docker/setup-buildx-action (v3 → v4+). These have newer majors on
-#     Node 24; Dependabot should propose those bumps on its weekly run.
+#     hard removal date.
+#     RESOLVED 2026-06-08 (#134): the four originally-outstanding actions are
+#     now on their Node-24 majors across all workflows —
+#     actions/setup-go (v6.4.0), docker/login-action (v4.2.0),
+#     docker/metadata-action (v6.1.0), docker/setup-buildx-action (v4.1.0).
+#     Remaining Node-20 holdouts are tracked separately and deliberately
+#     deferred: actions/checkout v4 (pinned for #102/K4 — see #137) and
+#     codecov-action v5 (#140). Dependabot keeps these current within their
+#     majors on the weekly run.
 #   - SHA-pinning caveat: our workflows use commit-SHA pinning with a
 #     trailing version comment (e.g. `actions/setup-go@<sha>  # v5`).
 #     Dependabot may be conservative about major bumps with SHA pins.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,14 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          # Pin a legacy-default cosign (#172): cosign v3.0 flips signing output
+          # to the new Sigstore-bundle (OCI 1.1 referrer) format, while
+          # slsa-github-generator still writes SLSA provenance to the legacy
+          # `.att` tag — so no single cosign version verifies signature + SBOM +
+          # SLSA with default flags. v2.6.3 emits legacy `.sig`/`.att` tags that
+          # match the SLSA generator, so any cosign >= 2.2 verifies all three.
+          cosign-release: 'v2.6.3'
 
       - name: Sign multi-arch manifest (index + per-arch children)
         run: |
@@ -539,6 +547,14 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+        with:
+          # Pin a legacy-default cosign (#172): cosign v3.0 flips signing output
+          # to the new Sigstore-bundle (OCI 1.1 referrer) format, while
+          # slsa-github-generator still writes SLSA provenance to the legacy
+          # `.att` tag — so no single cosign version verifies signature + SBOM +
+          # SLSA with default flags. v2.6.3 emits legacy `.sig`/`.att` tags that
+          # match the SLSA generator, so any cosign >= 2.2 verifies all three.
+          cosign-release: 'v2.6.3'
 
       - name: Resolve manifest index digest
         id: index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-08 06:10] - CI/release: unify supply-chain verification format + close Node-20 action backlog (#172, #134)
+**Author:** @wrkode (William Rizzo)
+
+### Changed
+- `.github/workflows/release.yml`: pin both `Install Cosign` steps to `cosign-release: v2.6.3` (#172). cosign v3.0 flipped signing output to the new Sigstore-bundle (OCI 1.1 referrer) format, while `slsa-github-generator` still writes SLSA provenance to the legacy `.att` tag — so no single cosign version verified signature + SBOM + SLSA with default flags. v2.6.3 emits legacy `.sig`/`.att` tags that match the SLSA generator, restoring **single-cosign-version (any >= 2.2) verification of all three artifacts**. Verification-ergonomics only — all artifacts were already individually present and cryptographically valid.
+- `.github/dependabot.yml`: documented #134 resolution — the four originally-outstanding Node-20 actions (`actions/setup-go`, `docker/login-action`, `docker/metadata-action`, `docker/setup-buildx-action`) are now on their Node-24 majors across all workflows; remaining holdouts (`actions/checkout` v4 #137/K4, `codecov-action` v5 #140) are tracked + deferred.
+
+### Why
+Closes #172 (verification ergonomics) and #134 (Node-20 GitHub Actions deprecation, hard-deadlined 2026-09-16). The cosign change is the prerequisite for documenting a single, universally-verifiable supply-chain check.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] CI / release-workflow change only (takes effect on the next release; v0.3.8 shipped as-is)
+- [ ] Documentation only
+
 ## [2026-06-08 05:45] - libvirt provider: SSH ControlMaster connection multiplexing (#194)
 **Author:** @wrkode (William Rizzo)
 


### PR DESCRIPTION
## What

Two CI/release hygiene items in one PR (both `.github/`-only, no code/runtime change):

### #172 — unify supply-chain verification format
Pin **both** `Install Cosign` steps in `release.yml` to `cosign-release: 'v2.6.3'`.

- **Problem:** `cosign-installer@v4.1.2` with no `cosign-release` pin resolves to **cosign v3.0.6**, which writes `sign`/`attest` output in the **new Sigstore-bundle (OCI 1.1 referrer)** format. Meanwhile `slsa-github-generator` writes SLSA provenance to the **legacy `.att` tag**. Result: no single cosign version verifies signature + SBOM + SLSA with default flags (each artifact is valid, but discovery is split by format).
- **Fix:** v2.6.3 emits legacy `.sig`/`.att` tags that match the SLSA generator → **any cosign ≥ 2.2 verifies all three** with default flags. Verification-ergonomics only; no security regression (all artifacts were already signed + present).
- Takes effect on the **next release** (v0.3.8 shipped as-is, posture identical to v0.3.6/v0.3.7).

### #134 — Node-20 GitHub Actions deprecation backlog
The four originally-outstanding actions are **already on their Node-24 majors** across all workflows (bumped by Dependabot since the issue was filed):

| Action | Now |
|---|---|
| `actions/setup-go` | v6.4.0 |
| `docker/login-action` | v4.2.0 |
| `docker/metadata-action` | v6.1.0 |
| `docker/setup-buildx-action` | v4.1.0 |

This PR documents the resolution in `dependabot.yml`. Remaining Node-20 holdouts are tracked + deliberately deferred elsewhere: `actions/checkout` v4 (pinned for #102/K4 → **#137**) and `codecov-action` v5 (**#140**).

## Verification

- `release.yml` and `dependabot.yml` parse as valid YAML; only `release.yml` references `cosign-installer` (no dev-image signing path needs the same pin).
- The cosign-format change is inherently **release-time** — it will be validated on the next release run by running a single `cosign verify` + two `cosign verify-attestation` (`spdxjson`, `slsaprovenance`) against each published index by digest (the issue's acceptance check).

## Follow-up

The unified-verification **instructions** live on the website (not main-repo `docs/`); I'll update them to the single-cosign-version flow in a small website follow-up once this lands.

Closes #172
Closes #134
