### PR TITLE
feat(providers): capability parity quick wins (#198, #199, #200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-08 07:30] - Capability parity quick wins: vSphere memory snapshots, libvirt export compression, Proxmox disk export/import (#198, #199, #200)
+**Author:** @wrkode (William Rizzo)
+
+### Changed
+- `internal/providers/vsphere/server.go`: advertise `SupportsMemorySnapshots=true` (#200). The snapshot path already honors `req.IncludeMemory` (passes `memory` to `CreateSnapshot`); only the capability flag was understated. Memory snapshots require the VM to be powered on.
+- `internal/providers/libvirt/provider_virsh.go` + `server.go`: honor `req.Compress` in `ExportDisk` via `qemu-img -c` for qcow2 targets (forcing a convert pass when compression is requested for an unchanged format), and advertise `SupportsExportCompression=true` (#199). Default (`Compress=false`) export is byte-for-byte unchanged; raw targets are unaffected (qemu-img ignores `-c` for raw).
+- `sdk/provider/capabilities/capabilities.go`: the capability `Manager`/`Builder` could not express disk migration — `Manager.GetCapabilities` omitted the disk-export/import/compression fields entirely. Added `DiskExport(formats…)`, `DiskImport(formats…)`, `ExportCompression()` builder methods + the `Manager` mapping (#198). This is the reusable fix so any builder-based provider can advertise disk migration.
+- `internal/providers/proxmox/capabilities.go`: advertise `SupportsDiskExport`/`SupportsDiskImport` (+ formats `qcow2`/`raw`/`vmdk`) to match the implemented `ExportDisk`/`ImportDisk`/`GetDiskInfo` RPCs (#198). `SupportsExportCompression` left false (the Proxmox export path does not compress today).
+
+### Added
+- Tests: `sdk/provider/capabilities/capabilities_test.go` (disk-migration builder + mapping); updated vSphere/libvirt/Proxmox capability tests.
+
+### Why
+Part of the provider-capability-parity roadmap (umbrella #204). Each was a VirtRigaud reporting/wiring gap, not a hypervisor limitation. These corrections are load-bearing once `--enforce-provider-capabilities` (#176) is enabled — without them, capability gating would wrongly block Proxmox disk migration and under-report vSphere/libvirt support.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (provider images; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-08 06:10] - CI/release: unify supply-chain verification format + close Node-20 action backlog (#172, #134)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/provider_virsh.go
+++ b/internal/providers/libvirt/provider_virsh.go
@@ -1689,8 +1689,14 @@ func (p *Provider) ExportDisk(ctx context.Context, req contracts.ExportDiskReque
 		log.Printf("INFO Exporting from snapshot: %s", req.SnapshotId)
 	}
 
-	// Check if format conversion is needed
-	needsConversion := (targetFormat != diskInfo.Format)
+	// Conversion is needed when the export format differs from the source, OR
+	// when compression is requested for a compressible target (qcow2): qemu-img
+	// applies `-c` only during a convert pass, so we force one to honor
+	// req.Compress even when the format is unchanged (#199). Raw cannot be
+	// compressed, so compression of a raw target is a no-op (qemu-img ignores
+	// `-c` for raw) and does not force a conversion.
+	needsConversion := (targetFormat != diskInfo.Format) ||
+		(req.Compress && targetFormat == "qcow2")
 
 	var uploadPath string
 	var cleanup func()
@@ -1707,7 +1713,7 @@ func (p *Provider) ExportDisk(ctx context.Context, req contracts.ExportDiskReque
 			DestinationPath:   tempPath,
 			SourceFormat:      diskutil.SupportedFormat(diskInfo.Format),
 			DestinationFormat: diskutil.SupportedFormat(targetFormat),
-			Compression:       false, // No compression for migration (faster)
+			Compression:       req.Compress, // honor the caller's request (#199); diskutil applies it only to compressible formats (qcow2)
 		})
 		if err != nil {
 			return contracts.ExportDiskResponse{}, fmt.Errorf("failed to convert disk format: %w", err)
@@ -2054,4 +2060,3 @@ func (p *Provider) ListVMs(ctx context.Context) ([]contracts.VMInfo, error) {
 
 	return vmInfos, nil
 }
-

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -463,7 +463,7 @@ func (s *Server) GetCapabilities(ctx context.Context, req *providerv1.GetCapabil
 		SupportsDiskImport:          true, // ImportDisk wired (pvc:///file:// sources)
 		SupportedExportFormats:      []string{"qcow2", "raw"},
 		SupportedImportFormats:      []string{"qcow2", "raw", "vmdk"},
-		SupportsExportCompression:   false, // Export path does not compress (migration favours speed)
+		SupportsExportCompression:   true, // ExportDisk honors req.Compress via qemu-img -c for qcow2 (#199); default (Compress=false) is uncompressed for speed
 	}, nil
 }
 

--- a/internal/providers/libvirt/server_test.go
+++ b/internal/providers/libvirt/server_test.go
@@ -95,7 +95,7 @@ func TestServer_GetCapabilities_DiskMigration(t *testing.T) {
 	assert.True(t, caps.SupportsDiskImport, "ImportDisk is wired over gRPC")
 	assert.Equal(t, []string{"qcow2", "raw"}, caps.SupportedExportFormats)
 	assert.Equal(t, []string{"qcow2", "raw", "vmdk"}, caps.SupportedImportFormats)
-	assert.False(t, caps.SupportsExportCompression, "export path does not compress")
+	assert.True(t, caps.SupportsExportCompression, "ExportDisk honors req.Compress via qemu-img -c for qcow2 (#199)")
 }
 
 // fakeDiskProvider is a minimal contracts.Provider used to exercise the Server's

--- a/internal/providers/proxmox/capabilities.go
+++ b/internal/providers/proxmox/capabilities.go
@@ -28,6 +28,13 @@ func GetProviderCapabilities() *capabilities.Manager {
 		OnlineReconfigure().
 		OnlineDiskExpansion().
 		ImageImport().
+		// Disk export/import RPCs are implemented (ExportDisk/ImportDisk/
+		// GetDiskInfo accept qcow2/raw/vmdk); advertise them so capability
+		// gating (#176) doesn't wrongly block Proxmox disk migration (#198).
+		// ExportCompression is intentionally NOT advertised — the export path
+		// does not compress today.
+		DiskExport("qcow2", "raw", "vmdk").
+		DiskImport("qcow2", "raw", "vmdk").
 		DiskTypes("raw", "qcow2").
 		NetworkTypes("bridge", "vlan").
 		Build()

--- a/internal/providers/proxmox/provider_test.go
+++ b/internal/providers/proxmox/provider_test.go
@@ -232,6 +232,13 @@ func TestProxmoxProvider_GetCapabilities(t *testing.T) {
 	assert.Contains(t, resp.SupportedDiskTypes, "raw")
 	assert.Contains(t, resp.SupportedDiskTypes, "qcow2")
 	assert.Contains(t, resp.SupportedNetworkTypes, "bridge")
+	// Disk export/import are now advertised to match the implemented RPCs (#198).
+	assert.True(t, resp.SupportsDiskExport, "Proxmox implements ExportDisk")
+	assert.True(t, resp.SupportsDiskImport, "Proxmox implements ImportDisk")
+	assert.Contains(t, resp.SupportedExportFormats, "qcow2")
+	assert.Contains(t, resp.SupportedImportFormats, "vmdk")
+	// Export does not compress today, so it must NOT be advertised.
+	assert.False(t, resp.SupportsExportCompression)
 }
 
 // Helper functions

--- a/internal/providers/vsphere/capabilities_test.go
+++ b/internal/providers/vsphere/capabilities_test.go
@@ -48,5 +48,7 @@ func TestGetCapabilities_DiskMigration(t *testing.T) {
 	// Sanity: existing flags remain unchanged.
 	assert.True(t, caps.SupportsSnapshots)
 	assert.True(t, caps.SupportsLinkedClones)
-	assert.False(t, caps.SupportsMemorySnapshots)
+	// vSphere captures RAM-inclusive snapshots via CreateSnapshot(memory=true) when the
+	// VM is powered on; SnapshotCreate already honours req.IncludeMemory (issue #200).
+	assert.True(t, caps.SupportsMemorySnapshots)
 }

--- a/internal/providers/vsphere/server.go
+++ b/internal/providers/vsphere/server.go
@@ -398,7 +398,8 @@ func (p *Provider) Validate(ctx context.Context, req *providerv1.ValidateRequest
 //
 //   - Online reconfiguration of CPU and memory (hot-add must be enabled on the VM)
 //   - Online disk expansion
-//   - Snapshots (disk-only; memory snapshots are not captured by default)
+//   - Snapshots (disk-only by default; RAM-inclusive snapshots are supported when
+//     the VM is powered on and the request sets IncludeMemory)
 //   - Linked clones (delta-disk backed clones sharing a parent disk)
 //   - Image import from external sources
 //   - Disk types: thin, thick, eager-zeroed
@@ -408,7 +409,7 @@ func (p *Provider) GetCapabilities(ctx context.Context, req *providerv1.GetCapab
 		SupportsReconfigureOnline:   true,
 		SupportsDiskExpansionOnline: true,
 		SupportsSnapshots:           true,
-		SupportsMemorySnapshots:     false, // vSphere snapshots don't include memory by default
+		SupportsMemorySnapshots:     true, // vSphere captures RAM-inclusive snapshots via CreateSnapshot(memory=true); requires the VM to be powered on
 		SupportsLinkedClones:        true,
 		SupportsImageImport:         true,
 		SupportedDiskTypes:          []string{"thin", "thick", "eager-zeroed"},
@@ -1527,8 +1528,8 @@ func (p *Provider) TaskStatus(ctx context.Context, req *providerv1.TaskStatusReq
 // "snapshot-<unix-timestamp>" is generated automatically.
 //
 // Memory: req.IncludeMemory controls whether the VM's in-memory state is captured.
-// Note that GetCapabilities reports SupportsMemorySnapshots: false, so callers should
-// generally pass false.
+// GetCapabilities reports SupportsMemorySnapshots: true; capturing memory requires the
+// VM to be powered on (vSphere rejects memory snapshots of a powered-off VM).
 //
 // Quiesce: filesystem quiescing (which requires VMware Tools and guest coordination) is
 // always disabled in this implementation. The SnapshotCreateResponse.SnapshotId contains

--- a/sdk/provider/capabilities/capabilities.go
+++ b/sdk/provider/capabilities/capabilities.go
@@ -44,6 +44,9 @@ const (
 	CapabilityMemorySnapshots     Capability = "memory_snapshots"
 	CapabilityLinkedClones        Capability = "linked_clones"
 	CapabilityImageImport         Capability = "image_import"
+	CapabilityDiskExport          Capability = "disk_export"
+	CapabilityDiskImport          Capability = "disk_import"
+	CapabilityExportCompression   Capability = "export_compression"
 	CapabilityTaskStatus          Capability = "task_status"
 
 	// Provider-specific capabilities
@@ -77,9 +80,11 @@ const (
 
 // Manager manages provider capabilities.
 type Manager struct {
-	capabilities          map[Capability]bool
-	supportedDiskTypes    []string
-	supportedNetworkTypes []string
+	capabilities           map[Capability]bool
+	supportedDiskTypes     []string
+	supportedNetworkTypes  []string
+	supportedExportFormats []string
+	supportedImportFormats []string
 }
 
 // NewManager creates a new capability manager.
@@ -118,6 +123,18 @@ func (m *Manager) SetSupportedNetworkTypes(types []string) *Manager {
 	return m
 }
 
+// SetSupportedExportFormats sets the supported disk-export formats.
+func (m *Manager) SetSupportedExportFormats(types []string) *Manager {
+	m.supportedExportFormats = types
+	return m
+}
+
+// SetSupportedImportFormats sets the supported disk-import formats.
+func (m *Manager) SetSupportedImportFormats(types []string) *Manager {
+	m.supportedImportFormats = types
+	return m
+}
+
 // GetCapabilities returns the capabilities response for gRPC.
 func (m *Manager) GetCapabilities(ctx context.Context, req *providerv1.GetCapabilitiesRequest) (*providerv1.GetCapabilitiesResponse, error) {
 	return &providerv1.GetCapabilitiesResponse{
@@ -129,6 +146,11 @@ func (m *Manager) GetCapabilities(ctx context.Context, req *providerv1.GetCapabi
 		SupportsImageImport:         m.HasCapability(CapabilityImageImport),
 		SupportedDiskTypes:          m.supportedDiskTypes,
 		SupportedNetworkTypes:       m.supportedNetworkTypes,
+		SupportsDiskExport:          m.HasCapability(CapabilityDiskExport),
+		SupportsDiskImport:          m.HasCapability(CapabilityDiskImport),
+		SupportsExportCompression:   m.HasCapability(CapabilityExportCompression),
+		SupportedExportFormats:      m.supportedExportFormats,
+		SupportedImportFormats:      m.supportedImportFormats,
 	}, nil
 }
 
@@ -258,6 +280,32 @@ func (b *Builder) OnlineDiskExpansion() *Builder {
 // TaskStatus adds task status checking capabilities.
 func (b *Builder) TaskStatus() *Builder {
 	b.manager.AddCapability(CapabilityTaskStatus)
+	return b
+}
+
+// DiskExport adds disk-export capability and, optionally, the supported export
+// formats (e.g. "qcow2", "raw", "vmdk").
+func (b *Builder) DiskExport(formats ...string) *Builder {
+	b.manager.AddCapability(CapabilityDiskExport)
+	if len(formats) > 0 {
+		b.manager.SetSupportedExportFormats(formats)
+	}
+	return b
+}
+
+// DiskImport adds disk-import capability and, optionally, the supported import
+// formats (e.g. "qcow2", "raw", "vmdk").
+func (b *Builder) DiskImport(formats ...string) *Builder {
+	b.manager.AddCapability(CapabilityDiskImport)
+	if len(formats) > 0 {
+		b.manager.SetSupportedImportFormats(formats)
+	}
+	return b
+}
+
+// ExportCompression marks that disk export can be compressed.
+func (b *Builder) ExportCompression() *Builder {
+	b.manager.AddCapability(CapabilityExportCompression)
 	return b
 }
 

--- a/sdk/provider/capabilities/capabilities_test.go
+++ b/sdk/provider/capabilities/capabilities_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capabilities
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestBuilder_DiskMigrationCapabilities verifies the disk export/import +
+// compression builder methods surface on the gRPC GetCapabilitiesResponse (#198).
+// Before this, the Manager mapping omitted these fields entirely, so any provider
+// using the builder (e.g. Proxmox) could not advertise disk migration even when
+// the RPCs were implemented.
+func TestBuilder_DiskMigrationCapabilities(t *testing.T) {
+	m := NewBuilder().
+		Core().
+		DiskExport("qcow2", "raw", "vmdk").
+		DiskImport("qcow2", "raw").
+		ExportCompression().
+		Build()
+
+	resp, err := m.GetCapabilities(context.Background(), &providerv1.GetCapabilitiesRequest{})
+	if err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+	if !resp.SupportsDiskExport {
+		t.Error("SupportsDiskExport should be true")
+	}
+	if !resp.SupportsDiskImport {
+		t.Error("SupportsDiskImport should be true")
+	}
+	if !resp.SupportsExportCompression {
+		t.Error("SupportsExportCompression should be true")
+	}
+	if want := []string{"qcow2", "raw", "vmdk"}; !reflect.DeepEqual(resp.SupportedExportFormats, want) {
+		t.Errorf("SupportedExportFormats = %v, want %v", resp.SupportedExportFormats, want)
+	}
+	if want := []string{"qcow2", "raw"}; !reflect.DeepEqual(resp.SupportedImportFormats, want) {
+		t.Errorf("SupportedImportFormats = %v, want %v", resp.SupportedImportFormats, want)
+	}
+}
+
+// TestBuilder_DiskMigrationDefaultsFalse verifies the new flags default to false
+// when not advertised, so a provider that does not support disk migration is not
+// over-reported.
+func TestBuilder_DiskMigrationDefaultsFalse(t *testing.T) {
+	m := NewBuilder().Core().Snapshots().Build()
+	resp, err := m.GetCapabilities(context.Background(), &providerv1.GetCapabilitiesRequest{})
+	if err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+	if resp.SupportsDiskExport || resp.SupportsDiskImport || resp.SupportsExportCompression {
+		t.Error("disk export/import/compression should default to false when not advertised")
+	}
+	if len(resp.SupportedExportFormats) != 0 || len(resp.SupportedImportFormats) != 0 {
+		t.Error("export/import format lists should be empty when not advertised")
+	}
+}


### PR DESCRIPTION
## What

Three capability-parity **quick wins** from the roadmap (umbrella #204). Each was a VirtRigaud reporting/wiring gap — **none is a hypervisor limitation** — and each is load-bearing once `--enforce-provider-capabilities` (#176) is enabled.

### #200 — vSphere memory snapshots
Advertise `SupportsMemorySnapshots=true`. The snapshot path **already** honors `req.IncludeMemory` (passes `memory` to govmomi's `CreateSnapshot`); only the capability flag was understated. (Conditional: requires the VM powered on — vSphere rejects memory snapshots of a powered-off VM.)

### #199 — libvirt export compression
Honor `req.Compress` in `ExportDisk` via `qemu-img -c` for qcow2 targets (force a convert pass when compression is requested for an otherwise-unchanged format), and advertise `SupportsExportCompression=true`.
- **Default (`Compress=false`) export is byte-for-byte unchanged** — favours speed.
- `raw` targets unaffected (qemu-img ignores `-c` for raw; `diskutil` already guards this).

### #198 — Proxmox disk export/import (+ SDK fix)
The SDK capability **`Manager`/`Builder` couldn't express disk migration** — `Manager.GetCapabilities` omitted the export/import/compression fields entirely, so any builder-based provider (Proxmox) under-reported even with the RPCs implemented.
- `sdk/provider/capabilities`: added `DiskExport(formats…)`, `DiskImport(formats…)`, `ExportCompression()` builder methods + the `Manager` mapping (the reusable fix).
- `proxmox/capabilities.go`: advertise `SupportsDiskExport`/`SupportsDiskImport` (+ `qcow2`/`raw`/`vmdk`) to match the implemented `ExportDisk`/`ImportDisk`/`GetDiskInfo` RPCs. `SupportsExportCompression` left **false** (Proxmox export doesn't compress today — honest).

## Verification

- SDK module (separate): `go build ./...` + `go test ./provider/capabilities/...` pass (new tests).
- Main: `make fmt` clean · `make lint` **0 issues** · `make build` · full `make test` pass · libvirt lint+tests direct (excluded from `make`) pass.
- Updated vSphere/libvirt/Proxmox capability tests assert the new flags.

## Risk / validation

- Provider-only; no CRD/proto/manager change. The only behavior change is libvirt export honoring `Compress` **when requested** (default path unchanged); #200/#198 are advertisement-accuracy.
- **Lab validation** for the libvirt compression path will be done on an isolated provider (per the prod-safety rule). #198/#200 are advertisement-only (no runtime behavior change).

Closes #198
Closes #199
Closes #200
Part of #204.
