### PR TITLE
fix(libvirt): full clone copies resolved disk path, not a guessed pool-volume name (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-08 11:05] - Fix libvirt full clone: copy the resolved disk path, not a guessed pool-volume name (#153)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/libvirt/clone.go`: full clone (`FullClone`) no longer assumes the source disk is a libvirt storage volume named `<vmid>-disk` in the `default` pool. That assumption failed in the field with `error: Storage volume not found: no storage vol with matching path '<vmid>-disk'`, because the provider's create path does not name disks that way. Full clone now copies the **real disk path** resolved from the live domain (`domblklist`) via `qemu-img convert -O qcow2` on the libvirt host — the same naming-agnostic, path-based approach the linked-clone branch already used. `qemu-img convert` also flattens any backing chain, so the full copy is genuinely independent of the source (and of the base image the source may overlay).
+
+### Changed
+- `internal/providers/libvirt/clone.go`: extracted the post-create ownership/permission/SELinux/pool-refresh steps into a shared `finalizeClonedDisk` helper used by both full and linked clone; added `createFullCopy`; removed the `virsh vol-clone` path.
+
+### Why
+libvirt clone E2E validation on a real host (isolated test provider, fresh source VM) showed **linked clone succeeds** but **full clone fails** for exactly this reason. Full clone is the default clone type, so this made the common case unusable; the path-based copy mirrors the proven linked-clone path.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (libvirt provider image; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- UEFI sources are still not fully handled: the domain-XML rewrite does not yet re-point the per-VM `<nvram>` varstore, so cloning a UEFI domain can collide on the NVRAM path. Use BIOS sources until that follow-up lands; tracked for #153 follow-up.
+
 ## [2026-06-08 10:10] - Implement libvirt Clone RPC: qcow2 full + linked clones (#153)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/clone.go
+++ b/internal/providers/libvirt/clone.go
@@ -129,13 +129,9 @@ func (p *Provider) Clone(ctx context.Context, req contracts.CloneRequest) (contr
 			return contracts.CloneResponse{}, err
 		}
 	} else {
-		sourceVolumeName := fmt.Sprintf("%s-disk", req.SourceVmID)
-		if _, err := storageProvider.CloneVolume(ctx, clonePoolName, sourceVolumeName, targetVolumeName); err != nil {
-			return contracts.CloneResponse{}, fmt.Errorf("full clone of volume %q: %w", sourceVolumeName, err)
+		if err := p.createFullCopy(ctx, srcDiskPath, targetDiskPath); err != nil {
+			return contracts.CloneResponse{}, err
 		}
-		// vol-clone may emit the file at a slightly different path; trust the
-		// pool convention used elsewhere in this provider.
-		targetDiskPath = filepath.Join(poolInfo.Path, fmt.Sprintf("%s.qcow2", targetVolumeName))
 	}
 
 	// 4. Define the target domain by cloning the source XML and rewriting the
@@ -223,24 +219,62 @@ func (p *Provider) createLinkedOverlay(ctx context.Context, srcDiskPath, srcDisk
 		return fmt.Errorf("create linked-clone overlay: %w, output: %s", err, res.Stderr)
 	}
 
-	// Fix ownership/permissions/SELinux so libvirt-qemu can open the overlay,
-	// matching StorageProvider.CreateVolume. Failures are non-fatal (the host
-	// may not use these mechanisms).
-	if _, e := p.virshProvider.runVirshCommand(ctx, "!", "sudo", "chown", "libvirt-qemu:kvm", targetDiskPath); e != nil {
-		log.Printf("WARN Failed to set overlay ownership: %v", e)
-	}
-	if _, e := p.virshProvider.runVirshCommand(ctx, "!", "sudo", "chmod", "777", targetDiskPath); e != nil {
-		log.Printf("WARN Failed to set overlay permissions: %v", e)
-	}
-	if _, e := p.virshProvider.runVirshCommand(ctx, "!", "sudo", "restorecon", targetDiskPath); e != nil {
-		log.Printf("WARN Failed to restore overlay SELinux context: %v", e)
+	p.finalizeClonedDisk(ctx, targetDiskPath)
+	return nil
+}
+
+// createFullCopy creates an independent qcow2 copy of the source disk at
+// targetDiskPath. Unlike a linked overlay, the result has no ongoing dependency
+// on the source: qemu-img convert reads through any backing chain the source
+// disk may have (e.g. a provider-created overlay on a base image) and writes a
+// standalone, flattened qcow2.
+//
+// The copy is performed on the libvirt host (the disk lives there) by the real
+// disk PATH resolved from the live domain (domblklist), NOT by a guessed
+// "<vmid>-disk" pool-volume name. The earlier vol-clone approach assumed the
+// provider names every disk "<vmid>-disk" inside the default pool; that does
+// not hold for VMs whose disk is a plain file or follows a different naming
+// convention, so full clone failed with "storage volume not found". Operating
+// on the resolved path mirrors the linked-clone path and is naming-agnostic
+// (issue #153, surfaced by libvirt clone E2E validation).
+func (p *Provider) createFullCopy(ctx context.Context, srcDiskPath, targetDiskPath string) error {
+	log.Printf("INFO Creating full-clone copy %s from %s", targetDiskPath, srcDiskPath)
+
+	// qemu-img convert -O qcow2 <src> <target>. The source format is
+	// auto-probed by qemu-img (do not force -f, which would break if the
+	// resolved format is wrong); convert flattens any backing chain.
+	res, err := p.virshProvider.runVirshCommand(ctx, "!",
+		"qemu-img", "convert",
+		"-O", "qcow2",
+		srcDiskPath,
+		targetDiskPath,
+	)
+	if err != nil {
+		return fmt.Errorf("create full-clone copy: %w, output: %s", err, res.Stderr)
 	}
 
-	// Refresh the pool so the new overlay is visible to subsequent vol lookups.
-	if _, e := p.virshProvider.runVirshCommand(ctx, "pool-refresh", clonePoolName); e != nil {
-		log.Printf("WARN Failed to refresh pool after overlay create: %v", e)
-	}
+	p.finalizeClonedDisk(ctx, targetDiskPath)
 	return nil
+}
+
+// finalizeClonedDisk fixes ownership/permissions/SELinux on a freshly created
+// clone disk so libvirt-qemu can open it, and refreshes the pool so the new
+// volume is visible to subsequent lookups. It mirrors StorageProvider.Create-
+// Volume's handling. Every step is best-effort: the host may not use these
+// mechanisms (e.g. no SELinux), so failures are logged, not fatal.
+func (p *Provider) finalizeClonedDisk(ctx context.Context, targetDiskPath string) {
+	if _, e := p.virshProvider.runVirshCommand(ctx, "!", "sudo", "chown", "libvirt-qemu:kvm", targetDiskPath); e != nil {
+		log.Printf("WARN Failed to set clone disk ownership: %v", e)
+	}
+	if _, e := p.virshProvider.runVirshCommand(ctx, "!", "sudo", "chmod", "777", targetDiskPath); e != nil {
+		log.Printf("WARN Failed to set clone disk permissions: %v", e)
+	}
+	if _, e := p.virshProvider.runVirshCommand(ctx, "!", "sudo", "restorecon", targetDiskPath); e != nil {
+		log.Printf("WARN Failed to restore clone disk SELinux context: %v", e)
+	}
+	if _, e := p.virshProvider.runVirshCommand(ctx, "pool-refresh", clonePoolName); e != nil {
+		log.Printf("WARN Failed to refresh pool after clone disk create: %v", e)
+	}
 }
 
 // rewriteDomainXMLForClone produces a new domain XML from the source domain XML


### PR DESCRIPTION
## What

Fixes the libvirt **full clone** path (the default clone type), surfaced by clone E2E validation on a real host.

After #206 merged, I ran a real libvirt `VMClone` E2E on an **isolated** test provider (a second libvirt Provider pointed at the same host, 0 managed VMs — the 13-VM production provider untouched) with a fresh BIOS source VM:

| Mode | Before this PR |
|---|---|
| LinkedClone | ✅ Ready, boots from overlay |
| FullClone | ❌ `error: Storage volume not found: no storage vol with matching path 'ce2e-src-disk'` |

### Root cause
The full-clone branch assumed the source disk is a libvirt storage **volume named `<vmid>-disk`** in the `default` pool and ran `virsh vol-clone`. The provider's create path actually writes the disk to `<pool>/<vmid>-disk.qcow2`, so the volume key includes the `.qcow2` extension and the name lookup misses. (The linked-clone branch was already robust — it used the real disk path from `domblklist`.)

### Fix
Full clone now copies the **resolved disk path** (from the live domain's `domblklist`, exactly what the linked path uses) via `qemu-img convert -O qcow2` on the libvirt host — naming-agnostic. `qemu-img convert` also flattens any backing chain, so the result is genuinely independent of the source and of any base image the source overlays (a stronger guarantee than `vol-clone`). Shared the post-create ownership/permission/SELinux/pool-refresh steps into `finalizeClonedDisk`; removed the `vol-clone` path.

## Verification

- `make fmt` clean · `make build` OK · `make test` pass · `golangci-lint run ./internal/providers/libvirt/... ./internal/diskutil/...` **0 issues** · `go test ./internal/providers/libvirt/... ./internal/diskutil/...` pass.
- **Lab re-validation** (isolated provider, dev image built from this branch): both clones reach `Ready` and boot:
  ```
  NAME          ID            POWER   ADOPTED   READY
  ce2e-full     ce2e-full     On      true      True   # FullClone (qemu-img convert)
  ce2e-linked   ce2e-linked   On      true      True   # LinkedClone (overlay)
  ce2e-src      ce2e-src      Off     <none>    True   # source (stable backing)
  ```
  Provider log: `qemu-img convert -O qcow2 /var/lib/libvirt/images/ce2e-src-disk.qcow2 /var/lib/libvirt/images/ce2e-full-disk.qcow2` → success.

## Known follow-up (not in this PR)

- **UEFI sources**: the domain-XML rewrite does not yet re-point the per-VM `<nvram>` varstore, so cloning a UEFI domain can collide on the NVRAM path. Use BIOS sources until that lands. I'll file/track this as a #153 follow-up.

## Risk

libvirt-provider-only; no CRD/proto/manager change. Strictly fixes a broken default path (full clone never worked on a real host before); linked clone behavior unchanged.

Closes #153
