### PR TITLE
feat(libvirt): implement ImagePrepare RPC — import image into storage pool (#154, PR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-08 11:08] - Implement libvirt ImagePrepare RPC: import image into storage pool (#154)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/libvirt/image.go`: real `ImagePrepare` logic for the libvirt provider. Resolves the target pool (request `StorageHint` → `source.libvirt.storagePool` → `default`), places the prepared template at `<poolPath>/<targetName>.qcow2`, and is idempotent — a re-run with the target already present is a cheap no-op (host `stat` probe). Source resolution: `source.libvirt.path` (host-local image) is converted into the pool directly; `source.libvirt.url` is downloaded **on the libvirt host** via `curl` (not streamed through the provider pod), converted with `qemu-img convert -O qcow2`, then the temp file is removed. Optional checksum verification (md5/sha1/sha256/sha512) runs on the host before commit; a mismatch removes the target and fails. Neither path nor url returns an `InvalidSpec` error rather than a fabricated success. Ownership/permissions/SELinux/pool-refresh reuse the existing `finalizeClonedDisk` helper.
+- `internal/providers/libvirt/image_test.go`: host-independent unit tests for image-JSON parsing (rich `v1beta1` `source.libvirt` shape vs flat `contracts.VMImage` shape vs empty/unparseable), target-pool precedence, target-path construction, checksum-tool selection, and the nil-provider / missing-target-name / no-source guard paths.
+
+### Changed
+- `internal/providers/libvirt/server.go`: replaced the `ImagePrepare` `Unimplemented` stub with a thin RPC wrapper that casts to `*Provider`, guards `virshProvider`, delegates to `Provider.imagePrepare`, and returns a `TaskResponse` with an empty `Task` (libvirt is synchronous). Flipped `GetCapabilities.SupportsImageImport` from `false` to `true`. Dropped the now-unused `sdk/provider/errors` import.
+- `internal/providers/libvirt/server_test.go`: replaced `TestServer_ImagePrepare_ReturnsUnimplemented` with a nil-provider guard test; flipped the `SupportsImageImport` assertion in `TestServer_GetCapabilities_HonestFlags` to expect `true`.
+
+### Why
+PR-1 of the image-prepare vertical slice (#154); libvirt was the last true provider-RPC gap among the production providers. Provider-only here — the manager-side transport client and VM/VMImage controller wiring land in later PRs (PR-4/PR-5).
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (libvirt provider image; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- `ImagePrepare` is not yet invoked by any controller (transport client + VM controller wiring are PR-4/PR-5). This PR is validatable by calling the RPC directly via gRPC. Synchronous (empty `TaskRef`).
+
 ## [2026-06-08 11:05] - Fix libvirt full clone: copy the resolved disk path, not a guessed pool-volume name (#153)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/image.go
+++ b/internal/providers/libvirt/image.go
@@ -1,0 +1,387 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"path/filepath"
+	"strings"
+
+	"github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+)
+
+// defaultStoragePool is the libvirt storage pool used for image preparation when
+// the caller supplies neither a storage hint nor a source-level storage pool.
+// It mirrors clonePoolName / ImportDisk's "default" fallback.
+const defaultStoragePool = "default"
+
+// defaultChecksumType is the checksum algorithm assumed when the image source
+// requests verification (non-empty checksum) but omits the algorithm. It matches
+// the v1beta1 LibvirtImageSource kubebuilder default.
+const defaultChecksumType = "sha256"
+
+// libvirtImageSource is the normalized, provider-internal view of a VMImage's
+// libvirt source, decoupled from the two on-the-wire JSON shapes ImagePrepare may
+// receive (see parseLibvirtImageSource). All fields are optional; the caller is
+// responsible for enforcing that at least one of Path/URL is set.
+type libvirtImageSource struct {
+	// Path is an image file already present on the libvirt host. When set, no
+	// download is performed — the file is converted into the pool directly.
+	Path string
+	// URL is an HTTP(S)/FTP location to download on the libvirt host before
+	// converting into the pool. Used only when Path is empty.
+	URL string
+	// Format is the source image format (informational; the target is always
+	// qcow2). Defaults to "qcow2" when unset.
+	Format string
+	// Checksum is the expected checksum of the source image; empty disables
+	// verification.
+	Checksum string
+	// ChecksumType is the checksum algorithm (md5/sha1/sha256/sha512); defaults
+	// to sha256 when a Checksum is set but the algorithm is omitted.
+	ChecksumType string
+	// StoragePool is the libvirt pool to import into; overridden by the request's
+	// StorageHint when that is set, and falls back to defaultStoragePool.
+	StoragePool string
+}
+
+// rawVMImageSpec mirrors the subset of v1beta1.VMImageSpec the libvirt provider
+// consumes. It is parsed first because it is the only serialized shape that
+// carries source.libvirt.storagePool. Unmarshalling into v1beta1 types directly
+// is avoided to keep this parser tolerant of partial/loosely-typed JSON.
+type rawVMImageSpec struct {
+	Source struct {
+		Libvirt *struct {
+			Path         string `json:"path"`
+			URL          string `json:"url"`
+			Format       string `json:"format"`
+			Checksum     string `json:"checksum"`
+			ChecksumType string `json:"checksumType"`
+			StoragePool  string `json:"storagePool"`
+		} `json:"libvirt"`
+	} `json:"source"`
+}
+
+// parseLibvirtImageSource normalizes the JSON-encoded image spec carried by
+// ImagePrepareRequest.ImageJson into a libvirtImageSource.
+//
+// The controller wiring that calls ImagePrepare lands in a later PR (#154 is a
+// vertical slice; this is PR-1), so the exact serialized shape is not yet pinned.
+// Two shapes are therefore accepted, in priority order:
+//
+//  1. The rich v1beta1.VMImageSpec shape with a nested
+//     source.libvirt.{path,url,format,checksum,checksumType,storagePool}. This is
+//     the ONLY shape that can express a storage pool, so it is tried first.
+//  2. The flat, provider-agnostic contracts.VMImage shape
+//     ({Path,URL,Format,Checksum,ChecksumType}) that Create already round-trips
+//     (server.go Create unmarshals ImageJson into contracts.VMImage). It has no
+//     storage pool; the pool then comes from the request StorageHint or the
+//     default.
+//
+// Whichever shape yields a usable source (a Path or URL) wins. An empty or
+// unparseable ImageJson, or one with neither path nor url, returns an empty
+// source — the caller turns that into an InvalidSpec error so a no-op is never
+// reported as success.
+func parseLibvirtImageSource(imageJSON string) libvirtImageSource {
+	var src libvirtImageSource
+	if strings.TrimSpace(imageJSON) == "" {
+		return src
+	}
+
+	// Shape 1: rich v1beta1 spec with nested source.libvirt.
+	var spec rawVMImageSpec
+	if err := json.Unmarshal([]byte(imageJSON), &spec); err == nil && spec.Source.Libvirt != nil {
+		lv := spec.Source.Libvirt
+		if lv.Path != "" || lv.URL != "" {
+			return libvirtImageSource{
+				Path:         lv.Path,
+				URL:          lv.URL,
+				Format:       lv.Format,
+				Checksum:     lv.Checksum,
+				ChecksumType: lv.ChecksumType,
+				StoragePool:  lv.StoragePool,
+			}
+		}
+	}
+
+	// Shape 2: flat contracts.VMImage (Go field names, no JSON tags).
+	var img contracts.VMImage
+	if err := json.Unmarshal([]byte(imageJSON), &img); err == nil {
+		if img.Path != "" || img.URL != "" {
+			return libvirtImageSource{
+				Path:         img.Path,
+				URL:          img.URL,
+				Format:       img.Format,
+				Checksum:     img.Checksum,
+				ChecksumType: img.ChecksumType,
+				// contracts.VMImage carries no storage pool.
+			}
+		}
+	}
+
+	return src
+}
+
+// resolveTargetPool selects the libvirt storage pool to import into, in priority
+// order: the request StorageHint, then source.libvirt.storagePool, then the
+// provider default. This mirrors ImportDisk's hint-or-default behavior while
+// additionally honoring the image's own pool preference.
+func resolveTargetPool(storageHint, sourcePool string) string {
+	switch {
+	case storageHint != "":
+		return storageHint
+	case sourcePool != "":
+		return sourcePool
+	default:
+		return defaultStoragePool
+	}
+}
+
+// targetImagePath builds the absolute path of the prepared template inside the
+// pool directory: <poolPath>/<targetName>.qcow2. The target is always qcow2
+// regardless of the source format (qemu-img convert -O qcow2).
+func targetImagePath(poolPath, targetName string) string {
+	return filepath.Join(poolPath, fmt.Sprintf("%s.qcow2", targetName))
+}
+
+// checksumTool maps a checksum algorithm to its coreutils binary
+// (md5sum/sha1sum/sha256sum/sha512sum). An empty or unknown algorithm falls back
+// to the sha256 default. The boolean reports whether the algorithm was
+// recognized, so callers can reject an explicitly-bad algorithm rather than
+// silently verifying with the wrong tool.
+func checksumTool(checksumType string) (tool string, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(checksumType)) {
+	case "", defaultChecksumType:
+		return "sha256sum", true
+	case "md5":
+		return "md5sum", true
+	case "sha1":
+		return "sha1sum", true
+	case "sha512":
+		return "sha512sum", true
+	default:
+		return "sha256sum", false
+	}
+}
+
+// imagePrepare performs the libvirt-side work behind the ImagePrepare RPC:
+// resolve the target pool/path, no-op if the target already exists, otherwise
+// register (convert) the source image into the pool as <targetName>.qcow2,
+// optionally verifying the source checksum.
+//
+// It is synchronous (virsh/qemu-img are blocking), so it returns no task
+// reference; the gRPC layer maps a nil error to a TaskResponse with an empty
+// Task, which the controller treats as "completed synchronously".
+func (p *Provider) imagePrepare(ctx context.Context, imageJSON, targetName, storageHint string) error {
+	if p.virshProvider == nil {
+		return contracts.NewRetryableError("virsh provider not initialized", nil)
+	}
+	if strings.TrimSpace(targetName) == "" {
+		return contracts.NewInvalidSpecError("ImagePrepare target name is required", nil)
+	}
+
+	src := parseLibvirtImageSource(imageJSON)
+	if src.Path == "" && src.URL == "" {
+		return contracts.NewInvalidSpecError(
+			"ImagePrepare requires a libvirt image source with a path or url "+
+				"(source.libvirt.path / source.libvirt.url)", nil)
+	}
+
+	poolName := resolveTargetPool(storageHint, src.StoragePool)
+
+	storageProvider := NewStorageProvider(p.virshProvider)
+	poolInfo, err := storageProvider.GetPoolInfo(ctx, poolName)
+	if err != nil {
+		return fmt.Errorf("get storage pool %q info: %w", poolName, err)
+	}
+	if poolInfo.Path == "" {
+		return contracts.NewInvalidSpecError(
+			fmt.Sprintf("storage pool %q has no filesystem path; cannot place image", poolName), nil)
+	}
+
+	targetPath := targetImagePath(poolInfo.Path, targetName)
+
+	// Idempotency (load-bearing): a re-run must be a cheap no-op. Probe the
+	// target file on the libvirt host directly; if it exists, the image is
+	// already prepared and we return without re-downloading/converting.
+	if p.targetImageExists(ctx, targetPath) {
+		log.Printf("INFO ImagePrepare: target image %q already exists in pool %q; nothing to do",
+			targetPath, poolName)
+		return nil
+	}
+
+	log.Printf("INFO ImagePrepare: preparing image %q into pool %q (path=%q url=%q)",
+		targetName, poolName, src.Path, src.URL)
+
+	if src.Path != "" {
+		// Source already on the libvirt host: convert it into the pool as the
+		// named template. No download needed.
+		if err := p.verifyChecksum(ctx, src.Path, src.Checksum, src.ChecksumType); err != nil {
+			return err
+		}
+		if err := p.convertIntoPool(ctx, src.Path, targetPath); err != nil {
+			return err
+		}
+		p.finalizeClonedDisk(ctx, targetPath)
+		log.Printf("INFO ImagePrepare: prepared image %q at %q from host path", targetName, targetPath)
+		return nil
+	}
+
+	// URL source: download ON THE LIBVIRT HOST (not through the provider pod) to
+	// avoid streaming GBs through the pod, then convert and clean up the temp
+	// file. Mirrors ImportDisk/clone host-exec ("!") convention.
+	//
+	// Stage the download in the POOL DIRECTORY (disk-backed, sized for images),
+	// not /tmp: /tmp is frequently tmpfs (RAM) on the libvirt host, so a multi-GB
+	// image could exhaust host memory. The leading dot keeps the partial file
+	// from being treated as a pool volume on refresh; the deferred cleanup
+	// removes it regardless of outcome.
+	tmpPath := filepath.Join(poolInfo.Path, fmt.Sprintf(".virtrigaud-imageprepare-%s.download", targetName))
+	if err := p.downloadOnHost(ctx, src.URL, tmpPath); err != nil {
+		return err
+	}
+	defer p.removeHostFile(ctx, tmpPath)
+
+	if err := p.verifyChecksum(ctx, tmpPath, src.Checksum, src.ChecksumType); err != nil {
+		return err
+	}
+	if err := p.convertIntoPool(ctx, tmpPath, targetPath); err != nil {
+		return err
+	}
+	p.finalizeClonedDisk(ctx, targetPath)
+	log.Printf("INFO ImagePrepare: prepared image %q at %q from url", targetName, targetPath)
+	return nil
+}
+
+// targetImageExists reports whether the prepared image already exists on the
+// libvirt host. It stats the path over the host-exec ("!") channel; any non-nil
+// error (missing file, transient probe failure) is treated as "does not exist"
+// so preparation proceeds rather than skipping work on a false negative.
+func (p *Provider) targetImageExists(ctx context.Context, targetPath string) bool {
+	res, err := p.virshProvider.runVirshCommand(ctx, "!", "stat", "-c", "%s", targetPath)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(res.Stdout) != ""
+}
+
+// downloadOnHost fetches url to dstPath on the libvirt host using curl. The
+// download runs on the host (not the provider pod) so large images never transit
+// the pod. curl flags: -f (fail on HTTP errors), -s (silent), -S (still show
+// errors), -L (follow redirects).
+func (p *Provider) downloadOnHost(ctx context.Context, url, dstPath string) error {
+	log.Printf("INFO ImagePrepare: downloading %q to %q on libvirt host", url, dstPath)
+	res, err := p.virshProvider.runVirshCommand(ctx, "!", "curl", "-fsSL", url, "-o", dstPath)
+	if err != nil {
+		stderr := ""
+		if res != nil {
+			stderr = res.Stderr
+		}
+		return contracts.NewRetryableError(
+			fmt.Sprintf("download image from %q on libvirt host: %s", url, strings.TrimSpace(stderr)), err)
+	}
+	return nil
+}
+
+// convertIntoPool registers srcPath into the pool by converting it to a
+// standalone qcow2 at targetPath via qemu-img convert. The source format is
+// auto-probed (no -f), matching createFullCopy, so VMDK/raw/qcow2 sources all
+// work. On failure the partial target is removed so a retry starts clean.
+func (p *Provider) convertIntoPool(ctx context.Context, srcPath, targetPath string) error {
+	log.Printf("INFO ImagePrepare: converting %q -> %q (qcow2)", srcPath, targetPath)
+	res, err := p.virshProvider.runVirshCommand(ctx, "!",
+		"qemu-img", "convert", "-O", "qcow2", srcPath, targetPath)
+	if err != nil {
+		stderr := ""
+		if res != nil {
+			stderr = res.Stderr
+		}
+		p.removeHostFile(ctx, targetPath)
+		return fmt.Errorf("convert image into pool (%q -> %q): %w, output: %s",
+			srcPath, targetPath, err, strings.TrimSpace(stderr))
+	}
+	return nil
+}
+
+// verifyChecksum verifies that path hashes to expected using the requested
+// algorithm. An empty expected checksum disables verification (no-op). On a
+// mismatch it returns an InvalidSpec error; the caller is responsible for
+// cleaning up any target it created. The checksum is computed on the libvirt host
+// (where the file lives), reusing ImportDisk's sha256sum pattern generalized to
+// the requested algorithm.
+func (p *Provider) verifyChecksum(ctx context.Context, path, expected, checksumType string) error {
+	if strings.TrimSpace(expected) == "" {
+		return nil
+	}
+	tool, known := checksumTool(checksumType)
+	if !known {
+		return contracts.NewInvalidSpecError(
+			fmt.Sprintf("unsupported checksum type %q (want md5/sha1/sha256/sha512)", checksumType), nil)
+	}
+
+	log.Printf("INFO ImagePrepare: verifying %s of %q", tool, path)
+	res, err := p.virshProvider.runVirshCommand(ctx, "!", tool, path)
+	if err != nil {
+		stderr := ""
+		if res != nil {
+			stderr = res.Stderr
+		}
+		return contracts.NewRetryableError(
+			fmt.Sprintf("compute %s of %q: %s", tool, path, strings.TrimSpace(stderr)), err)
+	}
+
+	// coreutils *sum output: "<hex>  <path>".
+	fields := strings.Fields(res.Stdout)
+	if len(fields) == 0 {
+		return contracts.NewRetryableError(
+			fmt.Sprintf("compute %s of %q: empty output", tool, path), nil)
+	}
+	got := fields[0]
+	if !strings.EqualFold(got, strings.TrimSpace(expected)) {
+		return contracts.NewInvalidSpecError(
+			fmt.Sprintf("checksum mismatch for %q: expected %s, got %s", path, expected, got), nil)
+	}
+	log.Printf("INFO ImagePrepare: checksum OK for %q", path)
+	return nil
+}
+
+// removeHostFile best-effort removes a file on the libvirt host (a downloaded
+// temp file, or a partial target after a failed convert). Failures are logged,
+// not returned, since this is cleanup.
+func (p *Provider) removeHostFile(ctx context.Context, path string) {
+	if _, err := p.virshProvider.runVirshCommand(ctx, "!", "rm", "-f", path); err != nil {
+		log.Printf("WARN ImagePrepare: failed to remove host file %q: %v", path, err)
+	}
+}
+
+// Compile-time assertion that the v1beta1 image source shape this provider parses
+// stays in sync with the API: if LibvirtImageSource loses one of these fields,
+// the build breaks here, prompting parseLibvirtImageSource to be revisited.
+var _ = func() v1beta1.LibvirtImageSource {
+	return v1beta1.LibvirtImageSource{
+		Path:         "",
+		URL:          "",
+		Format:       "",
+		Checksum:     "",
+		ChecksumType: "",
+		StoragePool:  "",
+	}
+}

--- a/internal/providers/libvirt/image_test.go
+++ b/internal/providers/libvirt/image_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestParseLibvirtImageSource_RichSpec verifies the rich v1beta1.VMImageSpec
+// shape (nested source.libvirt) is parsed including the storage pool, which only
+// this shape can express.
+func TestParseLibvirtImageSource_RichSpec(t *testing.T) {
+	imageJSON := `{
+		"source": {
+			"libvirt": {
+				"url": "https://images.example.com/jammy.qcow2",
+				"format": "qcow2",
+				"checksum": "abc123",
+				"checksumType": "sha512",
+				"storagePool": "vmpool"
+			}
+		}
+	}`
+
+	src := parseLibvirtImageSource(imageJSON)
+
+	assert.Equal(t, "", src.Path)
+	assert.Equal(t, "https://images.example.com/jammy.qcow2", src.URL)
+	assert.Equal(t, "qcow2", src.Format)
+	assert.Equal(t, "abc123", src.Checksum)
+	assert.Equal(t, "sha512", src.ChecksumType)
+	assert.Equal(t, "vmpool", src.StoragePool)
+}
+
+// TestParseLibvirtImageSource_RichSpecPath verifies the path branch of the rich
+// spec (host-local image, no download).
+func TestParseLibvirtImageSource_RichSpecPath(t *testing.T) {
+	imageJSON := `{"source":{"libvirt":{"path":"/var/lib/libvirt/images/base.qcow2"}}}`
+
+	src := parseLibvirtImageSource(imageJSON)
+
+	assert.Equal(t, "/var/lib/libvirt/images/base.qcow2", src.Path)
+	assert.Equal(t, "", src.URL)
+	assert.Equal(t, "", src.StoragePool)
+}
+
+// TestParseLibvirtImageSource_FlatContractsVMImage verifies the fallback flat
+// contracts.VMImage shape (Go field names, no storage pool) is parsed when no
+// nested source.libvirt is present. This is the shape Create already round-trips.
+func TestParseLibvirtImageSource_FlatContractsVMImage(t *testing.T) {
+	img := contracts.VMImage{
+		Path:         "/srv/templates/rocky.qcow2",
+		Format:       "qcow2",
+		Checksum:     "deadbeef",
+		ChecksumType: "sha256",
+	}
+	raw, err := json.Marshal(img)
+	require.NoError(t, err)
+
+	src := parseLibvirtImageSource(string(raw))
+
+	assert.Equal(t, "/srv/templates/rocky.qcow2", src.Path)
+	assert.Equal(t, "qcow2", src.Format)
+	assert.Equal(t, "deadbeef", src.Checksum)
+	assert.Equal(t, "sha256", src.ChecksumType)
+	// Flat shape cannot carry a storage pool.
+	assert.Equal(t, "", src.StoragePool)
+}
+
+// TestParseLibvirtImageSource_FlatURL verifies the flat shape's URL field parses.
+func TestParseLibvirtImageSource_FlatURL(t *testing.T) {
+	img := contracts.VMImage{URL: "https://example.com/img.qcow2"}
+	raw, err := json.Marshal(img)
+	require.NoError(t, err)
+
+	src := parseLibvirtImageSource(string(raw))
+
+	assert.Equal(t, "https://example.com/img.qcow2", src.URL)
+	assert.Equal(t, "", src.Path)
+}
+
+// TestParseLibvirtImageSource_RichSpecWins verifies that when a payload carries
+// both a usable nested source.libvirt and flat-shaped fields, the rich shape wins
+// (it is tried first and is the only one expressing a storage pool).
+func TestParseLibvirtImageSource_RichSpecWins(t *testing.T) {
+	// Hand-built payload that satisfies both unmarshals; the rich source.libvirt
+	// has a url+pool, the flat Path is set too. Rich must win.
+	imageJSON := `{
+		"source":{"libvirt":{"url":"https://rich/url.qcow2","storagePool":"richpool"}},
+		"Path":"/flat/path.qcow2"
+	}`
+
+	src := parseLibvirtImageSource(imageJSON)
+
+	assert.Equal(t, "https://rich/url.qcow2", src.URL)
+	assert.Equal(t, "richpool", src.StoragePool)
+	assert.Equal(t, "", src.Path, "rich source.libvirt should win over the flat Path field")
+}
+
+// TestParseLibvirtImageSource_Empty verifies empty / whitespace input yields an
+// empty source (the caller turns this into an InvalidSpec error).
+func TestParseLibvirtImageSource_Empty(t *testing.T) {
+	for _, in := range []string{"", "   ", "{}", `{"source":{}}`, `{"source":{"libvirt":{}}}`} {
+		src := parseLibvirtImageSource(in)
+		assert.Equal(t, "", src.Path, "input %q", in)
+		assert.Equal(t, "", src.URL, "input %q", in)
+	}
+}
+
+// TestParseLibvirtImageSource_Unparseable verifies malformed JSON yields an empty
+// source rather than panicking.
+func TestParseLibvirtImageSource_Unparseable(t *testing.T) {
+	src := parseLibvirtImageSource(`{not json`)
+	assert.Equal(t, "", src.Path)
+	assert.Equal(t, "", src.URL)
+}
+
+// TestResolveTargetPool covers the storage-pool precedence: StorageHint over
+// source pool over the provider default.
+func TestResolveTargetPool(t *testing.T) {
+	tests := []struct {
+		name        string
+		storageHint string
+		sourcePool  string
+		want        string
+	}{
+		{"hint wins over source", "hintpool", "srcpool", "hintpool"},
+		{"hint wins over empty source", "hintpool", "", "hintpool"},
+		{"source used when no hint", "", "srcpool", "srcpool"},
+		{"default when neither", "", "", defaultStoragePool},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveTargetPool(tt.storageHint, tt.sourcePool))
+		})
+	}
+}
+
+// TestTargetImagePath verifies the target file is <poolPath>/<targetName>.qcow2.
+func TestTargetImagePath(t *testing.T) {
+	assert.Equal(t,
+		"/var/lib/libvirt/images/fedora-tmpl.qcow2",
+		targetImagePath("/var/lib/libvirt/images", "fedora-tmpl"))
+	// Trailing slash on the pool path is normalized by filepath.Join.
+	assert.Equal(t,
+		"/pool/jammy.qcow2",
+		targetImagePath("/pool/", "jammy"))
+}
+
+// TestChecksumTool verifies algorithm-to-binary mapping, the sha256 default, and
+// rejection of an unknown algorithm.
+func TestChecksumTool(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantTool string
+		wantOK   bool
+	}{
+		{"", "sha256sum", true},
+		{"sha256", "sha256sum", true},
+		{"SHA256", "sha256sum", true},
+		{"md5", "md5sum", true},
+		{"sha1", "sha1sum", true},
+		{"sha512", "sha512sum", true},
+		{"  sha512  ", "sha512sum", true},
+		{"crc32", "sha256sum", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			tool, ok := checksumTool(tt.in)
+			assert.Equal(t, tt.wantTool, tool)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+// TestImagePrepare_NilVirshProvider verifies the guard fires before any host
+// interaction when the inner virsh provider is missing.
+func TestImagePrepare_NilVirshProvider(t *testing.T) {
+	p := &Provider{}
+	err := p.imagePrepare(context.Background(),
+		`{"source":{"libvirt":{"url":"https://x/y.qcow2"}}}`, "tmpl", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not initialized")
+}
+
+// TestImagePrepare_MissingTargetName verifies the target-name guard, which fires
+// before any host interaction (so it is host-independent).
+func TestImagePrepare_MissingTargetName(t *testing.T) {
+	// A non-nil virshProvider is required to pass the first guard; an empty one is
+	// sufficient because the target-name check short-circuits before any command
+	// runs.
+	p := &Provider{virshProvider: &VirshProvider{}}
+	err := p.imagePrepare(context.Background(),
+		`{"source":{"libvirt":{"url":"https://x/y.qcow2"}}}`, "  ", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target name is required")
+}
+
+// TestImagePrepare_NoSource verifies the InvalidSpec path when the image spec has
+// neither a path nor a url. This fires before any host interaction.
+func TestImagePrepare_NoSource(t *testing.T) {
+	p := &Provider{virshProvider: &VirshProvider{}}
+	err := p.imagePrepare(context.Background(), `{"source":{"libvirt":{}}}`, "tmpl", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path or url")
+
+	// Empty image JSON is likewise rejected (no fabricated success).
+	err = p.imagePrepare(context.Background(), "", "tmpl", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path or url")
+}
+
+// TestServer_ImagePrepare_NilProvider_Direct mirrors the server-layer nil guard
+// at the RPC boundary (complements TestServer_ImagePrepare_NilProvider in
+// server_test.go by exercising a populated request).
+func TestServer_ImagePrepare_NilProvider_Direct(t *testing.T) {
+	s := &Server{}
+	resp, err := s.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
+		ImageJson:   `{"source":{"libvirt":{"url":"https://x/y.qcow2"}}}`,
+		TargetName:  "tmpl",
+		StorageHint: "pool",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "not initialized")
+}

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
 	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
-	"github.com/projectbeskar/virtrigaud/sdk/provider/errors"
 )
 
 // Server implements the providerv1.ProviderServer interface for Libvirt
@@ -458,15 +457,33 @@ func (s *Server) Clone(ctx context.Context, req *providerv1.CloneRequest) (*prov
 	return result, nil
 }
 
-// ImagePrepare prepares/imports a VM image.
+// ImagePrepare prepares/imports a VM image into a libvirt storage pool, making it
+// available as a named template (<target_name>.qcow2) for subsequent VM creation
+// (issue #154).
 //
-// Not yet implemented for libvirt: a real implementation must download and/or
-// convert the image into a storage pool. Until that exists, this returns
-// Unimplemented rather than a synthetic task reference so callers are not given
-// a fabricated success for work that never happened.
-// Tracked in https://github.com/projectbeskar/virtrigaud/issues/154.
+// The request carries a JSON-encoded VMImage spec (req.ImageJson) describing the
+// source, a target template name, and an optional storage hint. The source may be
+// a path already present on the libvirt host or a URL to download on the host. The
+// image is converted into the resolved pool as a standalone qcow2; an existing
+// target is treated as an idempotent no-op (see Provider.imagePrepare).
+//
+// libvirt/qemu-img are synchronous, so this returns a TaskResponse with an empty
+// Task (no TaskRef); the controller treats an empty TaskRef as "completed
+// synchronously".
 func (s *Server) ImagePrepare(ctx context.Context, req *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
-	return nil, errors.NewUnimplemented("ImagePrepare operation is not implemented for libvirt (https://github.com/projectbeskar/virtrigaud/issues/154)")
+	log.Printf("INFO ImagePrepare: target=%q storageHint=%q", req.TargetName, req.StorageHint)
+
+	libvirtProvider, ok := s.provider.(*Provider)
+	if !ok || libvirtProvider == nil || libvirtProvider.virshProvider == nil {
+		return nil, fmt.Errorf("libvirt provider not initialized")
+	}
+
+	if err := libvirtProvider.imagePrepare(ctx, req.ImageJson, req.TargetName, req.StorageHint); err != nil {
+		return nil, fmt.Errorf("failed to prepare image: %w", err)
+	}
+
+	// Synchronous: no task reference. An empty Task signals "completed".
+	return &providerv1.TaskResponse{}, nil
 }
 
 // GetCapabilities returns the capabilities of the Libvirt provider
@@ -477,7 +494,7 @@ func (s *Server) GetCapabilities(ctx context.Context, req *providerv1.GetCapabil
 		SupportsSnapshots:           true,  // Libvirt supports snapshots (storage-dependent)
 		SupportsMemorySnapshots:     false, // Memory snapshots not always supported
 		SupportsLinkedClones:        true,  // Clone RPC implemented: qcow2 overlay (linked) + vol-clone (full) (issue #153)
-		SupportsImageImport:         false, // ImagePrepare RPC not implemented yet (issue #154)
+		SupportsImageImport:         true,  // ImagePrepare RPC implemented: import/convert image into a storage pool (issue #154)
 		SupportedDiskTypes:          []string{"qcow2", "raw", "vmdk"},
 		SupportedNetworkTypes:       []string{"virtio", "e1000", "rtl8139"},
 		SupportsDiskExport:          true, // ExportDisk wired to virsh impl (issue #177)

--- a/internal/providers/libvirt/server_test.go
+++ b/internal/providers/libvirt/server_test.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
 	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
@@ -47,10 +45,13 @@ func TestServer_Clone_NilProvider(t *testing.T) {
 	assert.Contains(t, err.Error(), "not initialized")
 }
 
-// TestServer_ImagePrepare_ReturnsUnimplemented verifies that the libvirt
-// ImagePrepare RPC returns a gRPC Unimplemented status rather than a fabricated
-// task reference. ImagePrepare is not implemented for libvirt (issue #154).
-func TestServer_ImagePrepare_ReturnsUnimplemented(t *testing.T) {
+// TestServer_ImagePrepare_NilProvider verifies that the libvirt ImagePrepare RPC
+// fails cleanly when no provider is wired, rather than panicking. ImagePrepare is
+// now implemented (issue #154); the previous Unimplemented contract no longer
+// applies. The convert/download path requires a live libvirt host and is covered
+// by integration tests plus the host-independent unit tests in image_test.go;
+// here we only assert the nil-provider guard.
+func TestServer_ImagePrepare_NilProvider(t *testing.T) {
 	s := &Server{}
 
 	resp, err := s.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
@@ -59,8 +60,7 @@ func TestServer_ImagePrepare_ReturnsUnimplemented(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Equal(t, codes.Unimplemented, status.Code(err),
-		"ImagePrepare must report Unimplemented so callers do not treat a no-op as success")
+	assert.Contains(t, err.Error(), "not initialized")
 }
 
 // TestServer_GetCapabilities_HonestFlags verifies that the libvirt provider
@@ -76,8 +76,8 @@ func TestServer_GetCapabilities_HonestFlags(t *testing.T) {
 	require.NotNil(t, caps)
 	assert.True(t, caps.SupportsLinkedClones,
 		"libvirt advertises linked clones now that Clone is implemented (issue #153)")
-	assert.False(t, caps.SupportsImageImport,
-		"libvirt must not advertise image import while ImagePrepare is unimplemented (issue #154)")
+	assert.True(t, caps.SupportsImageImport,
+		"libvirt advertises image import now that ImagePrepare is implemented (issue #154)")
 	assert.True(t, caps.SupportsSnapshots,
 		"libvirt snapshots are implemented and must remain advertised")
 }


### PR DESCRIPTION
## What

**PR-1 of the image-prepare vertical slice (#154).** Implements the libvirt provider's `ImagePrepare` gRPC RPC — the last true *provider-RPC* gap among the production providers — replacing the `Unimplemented` stub.

`ImagePrepare` imports/converts a VM image into a libvirt storage pool as a named template (`<poolPath>/<target_name>.qcow2`):
- **Target pool**: `StorageHint` → `source.libvirt.storagePool` → `default`.
- **Path source** (host-local image): `qemu-img convert -O qcow2` into the pool directly.
- **URL source**: downloads **on the libvirt host** via `curl` (never streamed through the provider pod), staged in the **pool directory** (disk-backed — *not* `/tmp`, which is frequently tmpfs and could OOM the host on a multi-GB image), then converts and removes the temp file.
- **Idempotent**: re-run with the target already present is a cheap no-op (host `stat` probe) — re-reconcile never re-downloads.
- **Checksum** (optional, md5/sha1/sha256/sha512) verified on the host before commit; mismatch removes the target and fails.
- **Neither path nor url → `InvalidSpec`** (never a fabricated success).
- Reuses the `finalizeClonedDisk` helper (chown/chmod/restorecon/pool-refresh) from #153.

Flips `GetCapabilities.SupportsImageImport=true`. Synchronous → empty `TaskRef` (the future controller treats that as "completed").

## Scope boundary

**Provider-only.** No proto / CRD / controller / transport changes. The manager-side wiring that *invokes* this RPC lands in later PRs:
- PR-4: `contracts.ImagePreparer` + `*grpc.Client.PrepareImage`.
- PR-5: VirtualMachine controller `EnsureImageOnProvider` + VMImage controller as status owner (+ ADR).

So this RPC is **not yet reachable through a CR** — it's validated by calling gRPC directly (below). Design: lazy/VM-create-driven prepare; `VMImageStatus` already carries `ProviderStatus`/`AvailableOn` (no CRD change needed).

## Verification

- libvirt is excluded from `make`, so run directly: `go build ./...` OK · `golangci-lint run ./internal/providers/libvirt/...` **0 issues** · `go test ./internal/providers/libvirt/...` pass · `make build`/`make test` (manager side) green · no generated-manifest drift.
- Host-independent unit tests: image-JSON parsing (rich `v1beta1` `source.libvirt` shape vs flat `contracts.VMImage` shape vs empty/unparseable), target-pool precedence, target-path construction, checksum-tool mapping, and all guard paths (nil provider, missing target, no source).
- **Lab**: direct gRPC `ImagePrepare` against an isolated libvirt provider (see PR comment once validated).

## Risk

libvirt-provider-only; the path was previously `Unimplemented` (unused), so no regression surface. URL download requires host egress + pool free space (flagged). vSphere's `SupportsImageImport=true` is currently dishonest (its RPC is a stub) — PR-2 fixes that separately.

Part of #154.
