### PR TITLE
feat(vsphere): implement ImagePrepare — OVA/OVF URL import as template (#154, PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-08 11:14] - Implement vSphere ImagePrepare: OVA/OVF URL import as template (#154)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/vsphere/image.go`: real `ImagePrepare` for the vSphere provider. Parses the image source from `ImageJson` (rich `v1beta1` `source.vsphere` shape — the only one able to carry `ovaURL`/`contentLibrary` — falling back to the flat `contracts.VMImage` `TemplateName`). Handles three source kinds in precedence order behind an idempotency gate: (1) if a template/VM named `target_name` already exists, return success without importing; (2) `source.vsphere.templateName` → verify the template exists (`finder.VirtualMachine`), no import, honest `NotFound` if missing; (3) `source.vsphere.contentLibrary` → verify the library item exists via vAPI (`vapi/rest` + `vapi/library`), then return a clear `InvalidSpec` (deploy-to-template is out of scope for this PR); (4) `source.vsphere.ovaURL` → the real import: resolve placement (resource pool from `DefaultCluster`, datastore from `storage_hint`→`DefaultDatastore`→`DefaultStoragePod`, folder from `DefaultFolder`→datacenter VM folder), download the OVA/OVF to a temp file, optionally verify its checksum (md5/sha1/sha256/sha512; sha256 default), import via govmomi `ovf/importer` (descriptor → `CreateImportSpec` → `ImportVApp` NFC lease → upload → complete) with thin disk provisioning, then `MarkAsTemplate`. Mid-import failures best-effort `Destroy` the partial VM so a retry starts clean.
+- `internal/providers/vsphere/image.go`: `findOVADescriptorName` resolves the OVF descriptor's **exact** entry name inside the OVA tar, skipping macOS **AppleDouble** sidecars (`._*`) and `__MACOSX/` entries, instead of relying on govmomi's `"*.ovf"` glob. OVAs repackaged on macOS pack a binary `._foo.ovf` sidecar *before* the real descriptor; the glob matched it first and the import failed with `XML syntax error: illegal character code U+0000`. Found during live validation against a real macOS-packaged Ubuntu 24.04 OVA.
+- `internal/providers/vsphere/image_test.go`: host-independent unit tests (source-JSON parsing, checksum-hasher selection, file-checksum match/mismatch/unknown, nil-client guard, AppleDouble descriptor resolution + no-descriptor error) plus vcsim integration tests that import a trivial OVA and assert a template named `target_name` results, that a re-run is a no-op, and that the templateName verify-only branch returns success when present and `NotFound` when absent.
+
+### Changed
+- `internal/providers/vsphere/server.go`: removed the `ImagePrepare` `Unimplemented` stub (the method now lives in `image.go`); updated the `SupportsImageImport: true` comment to reference the now-real implementation (#154). The capability stays `true` — it is now honest.
+
+### Why
+PR-2 of the image-prepare vertical slice (#154). Makes vSphere's existing
+SupportsImageImport=true honest by importing OVA/OVF from a URL into vCenter
+as a template via govmomi, instead of returning Unimplemented.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (vSphere provider image; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- Synchronous import (empty TaskRef); very large OVAs may need async polling (future).
+- templateName/contentLibrary sources are verify-only; ovaURL does the real import.
+- **Deployment requirement:** the OVA disk upload uses an NFC lease that streams **directly from the provider to the ESXi host** (not via vCenter). The ESXi host(s) must therefore be DNS-resolvable and network-reachable from wherever the vSphere provider runs. This is inherent to vSphere NFC (the same applies to disk export/migration). Surfaced during live validation: vCenter returned a lease URL to `esxi.<domain>` which the provider pod could not resolve.
+- Live-validated against a real macOS-packaged Ubuntu 24.04 OVA on vCenter through descriptor parse → CreateImportSpec → ImportVApp → NFC lease; the byte upload requires ESXi reachability per the note above.
+
 ## [2026-06-08 11:08] - Implement libvirt ImagePrepare RPC: import image into storage pool (#154)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/vsphere/image.go
+++ b/internal/providers/vsphere/image.go
@@ -1,0 +1,723 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"archive/tar"
+	"context"
+	"crypto/md5"  // #nosec G501 -- md5 is an explicitly supported OVA checksum algorithm, not used for security
+	"crypto/sha1" // #nosec G505 -- sha1 is an explicitly supported OVA checksum algorithm, not used for security
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/ovf/importer"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25/progress"
+	"github.com/vmware/govmomi/vim25/types"
+
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+	"github.com/projectbeskar/virtrigaud/sdk/provider/errors"
+)
+
+const (
+	// vsphereDefaultChecksumType is the checksum algorithm assumed when an OVA
+	// source requests verification (non-empty checksum) but omits the algorithm.
+	// It matches the v1beta1 VSphereImageSource kubebuilder default.
+	vsphereDefaultChecksumType = "sha256"
+
+	// ovaDiskProvisioningThin requests thin-provisioned disks for the imported
+	// template, minimizing datastore consumption for a base image that is cloned
+	// (and grown) per VM at Create time.
+	ovaDiskProvisioningThin = string(types.OvfCreateImportSpecParamsDiskProvisioningTypeThin)
+)
+
+// vsphereImageSource is the normalized, provider-internal view of a VMImage's
+// vSphere source, decoupled from the on-the-wire JSON shape ImagePrepare
+// receives (see parseVSphereImageSource). Exactly one of TemplateName,
+// ContentLibrary, or OVAURL is expected to be set; the caller enforces that and
+// applies the documented precedence.
+type vsphereImageSource struct {
+	// TemplateName references a template expected to already exist in vCenter.
+	// When set, ImagePrepare verifies its existence and does NOT import.
+	TemplateName string
+	// ContentLibrary references a content-library item. When set, ImagePrepare
+	// verifies the item exists; deploying it to a template is out of scope here.
+	ContentLibrary *vsphereContentLibraryRef
+	// OVAURL is an HTTP(S) URL to an .ova or .ovf to import as a template. This
+	// is the only source that performs a real import.
+	OVAURL string
+	// Checksum is the expected checksum of the downloaded OVA; empty disables
+	// verification.
+	Checksum string
+	// ChecksumType is the checksum algorithm (md5/sha1/sha256/sha512); defaults
+	// to sha256 when a Checksum is set but the algorithm is omitted.
+	ChecksumType string
+}
+
+// vsphereContentLibraryRef mirrors v1beta1.ContentLibraryRef for the parsed
+// source.
+type vsphereContentLibraryRef struct {
+	// Library is the content-library name.
+	Library string
+	// Item is the library-item name within Library.
+	Item string
+	// Version is the optional item version.
+	Version string
+}
+
+// rawVSphereVMImageSpec mirrors the subset of v1beta1.VMImageSpec the vSphere
+// provider consumes for ImagePrepare. It is parsed directly from the rich
+// source.vsphere.* shape because that is the only serialized form able to carry
+// contentLibrary and ovaURL. Unmarshalling into the v1beta1 types directly is
+// avoided to keep the parser tolerant of partial/loosely-typed JSON.
+type rawVSphereVMImageSpec struct {
+	Source struct {
+		VSphere *struct {
+			TemplateName   string `json:"templateName"`
+			OVAURL         string `json:"ovaURL"`
+			Checksum       string `json:"checksum"`
+			ChecksumType   string `json:"checksumType"`
+			ContentLibrary *struct {
+				Library string `json:"library"`
+				Item    string `json:"item"`
+				Version string `json:"version"`
+			} `json:"contentLibrary"`
+		} `json:"vsphere"`
+	} `json:"source"`
+}
+
+// parseVSphereImageSource normalizes the JSON-encoded image spec carried by
+// ImagePrepareRequest.ImageJson into a vsphereImageSource.
+//
+// Two shapes are accepted, in priority order, mirroring the libvirt PR-1
+// approach (parseLibvirtImageSource):
+//
+//  1. The rich v1beta1.VMImageSpec shape with a nested
+//     source.vsphere.{templateName,ovaURL,contentLibrary,checksum,checksumType}.
+//     This is the ONLY shape that can express contentLibrary or ovaURL, so it is
+//     tried first.
+//  2. The flat, provider-agnostic contracts.VMImage shape that Create already
+//     round-trips (server.go Create unmarshals ImageJson into a struct with
+//     TemplateName/Path/Format). It can only express a TemplateName for vSphere
+//     (Path is a libvirt/imported-disk concern), so it is the fallback.
+//
+// Whichever shape yields a usable source (any of templateName/ovaURL/
+// contentLibrary) wins. An empty or unparseable ImageJson returns an empty
+// source — the caller turns that into an InvalidSpec error so a no-op is never
+// reported as success.
+func parseVSphereImageSource(imageJSON string) vsphereImageSource {
+	var src vsphereImageSource
+	if strings.TrimSpace(imageJSON) == "" {
+		return src
+	}
+
+	// Shape 1: rich v1beta1 spec with nested source.vsphere.
+	var spec rawVSphereVMImageSpec
+	if err := json.Unmarshal([]byte(imageJSON), &spec); err == nil && spec.Source.VSphere != nil {
+		vs := spec.Source.VSphere
+		if vs.TemplateName != "" || vs.OVAURL != "" || vs.ContentLibrary != nil {
+			src = vsphereImageSource{
+				TemplateName: vs.TemplateName,
+				OVAURL:       vs.OVAURL,
+				Checksum:     vs.Checksum,
+				ChecksumType: vs.ChecksumType,
+			}
+			if vs.ContentLibrary != nil {
+				src.ContentLibrary = &vsphereContentLibraryRef{
+					Library: vs.ContentLibrary.Library,
+					Item:    vs.ContentLibrary.Item,
+					Version: vs.ContentLibrary.Version,
+				}
+			}
+			return src
+		}
+	}
+
+	// Shape 2: flat contracts.VMImage (Go field names, no JSON tags). For vSphere
+	// only TemplateName is meaningful here.
+	var img struct {
+		TemplateName string
+	}
+	if err := json.Unmarshal([]byte(imageJSON), &img); err == nil && img.TemplateName != "" {
+		src.TemplateName = img.TemplateName
+	}
+
+	return src
+}
+
+// vsphereChecksumHasher returns a hash.Hash for the requested algorithm. An
+// empty or "sha256" type yields sha256 (the v1beta1 default). The boolean
+// reports whether the algorithm was recognized, so callers can reject an
+// explicitly-bad algorithm rather than silently hashing with the wrong one.
+func vsphereChecksumHasher(checksumType string) (h hash.Hash, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(checksumType)) {
+	case "", vsphereDefaultChecksumType:
+		return sha256.New(), true
+	case "md5":
+		return md5.New(), true // #nosec G401 -- supported OVA verification algorithm, not used for security
+	case "sha1":
+		return sha1.New(), true // #nosec G401 -- supported OVA verification algorithm, not used for security
+	case "sha512":
+		return sha512.New(), true
+	default:
+		return sha256.New(), false
+	}
+}
+
+// ImagePrepare implements the ProviderServer interface. It prepares a vSphere
+// template named req.TargetName from the image source encoded in req.ImageJson,
+// honoring three source kinds in precedence order:
+//
+//  1. Idempotency gate: if a template/VM named TargetName already exists, it
+//     returns success without importing — a re-run is a cheap no-op.
+//  2. source.vsphere.templateName: verify-only. The named template must already
+//     exist; if found, success; if missing, a NotFound error. No download.
+//  3. source.vsphere.contentLibrary: verify-only. The library item must exist;
+//     deploying it to a template is out of scope for this PR.
+//  4. source.vsphere.ovaURL: the real work. Download the OVA/OVF, optionally
+//     verify its checksum, import it into vCenter via an NFC lease, and mark the
+//     resulting VM as a template.
+//
+// The import is driven synchronously, so the returned TaskResponse carries an
+// empty (nil) Task — consistent with the libvirt provider — which the controller
+// treats as "completed synchronously". Very large OVAs may eventually warrant an
+// async TaskRef the controller polls (a future enhancement; the gRPC client
+// timeout is tracked separately in PR-4 of #154).
+func (p *Provider) ImagePrepare(ctx context.Context, req *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
+	if p.client == nil || p.finder == nil {
+		return nil, errors.NewUnavailable("vSphere", fmt.Errorf("provider client not initialized"))
+	}
+	targetName := strings.TrimSpace(req.GetTargetName())
+	if targetName == "" {
+		return nil, errors.NewInvalidSpec("ImagePrepare target name is required")
+	}
+
+	src := parseVSphereImageSource(req.GetImageJson())
+
+	p.logger.Info("ImagePrepare: starting",
+		"target_name", targetName,
+		"has_template_name", src.TemplateName != "",
+		"has_content_library", src.ContentLibrary != nil,
+		"has_ova_url", src.OVAURL != "",
+		"storage_hint", req.GetStorageHint(),
+	)
+
+	// Set datacenter context so finder lookups (VM, datastore, folder) resolve.
+	datacenter, err := p.finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ImagePrepare: find default datacenter: %w", err)
+	}
+	p.finder.SetDatacenter(datacenter)
+
+	// 1) Idempotency gate (load-bearing): a re-run must never re-import. If a
+	//    template/VM named targetName already exists, we are done.
+	if vm := p.findExistingByName(ctx, targetName); vm != nil {
+		p.logger.Info("ImagePrepare: target already exists; nothing to do",
+			"target_name", targetName, "vm", vm.Reference().Value)
+		return &providerv1.TaskResponse{}, nil
+	}
+
+	switch {
+	case src.TemplateName != "":
+		// 2) templateName: verify-only. Don't fabricate an import.
+		return p.imagePrepareVerifyTemplate(ctx, src.TemplateName)
+	case src.ContentLibrary != nil:
+		// 3) contentLibrary: verify-only.
+		return p.imagePrepareVerifyContentLibrary(ctx, src.ContentLibrary)
+	case src.OVAURL != "":
+		// 4) ovaURL: the real import.
+		return p.imagePrepareImportOVA(ctx, src, targetName, req.GetStorageHint())
+	default:
+		return nil, errors.NewInvalidSpec(
+			"ImagePrepare requires a vSphere image source with templateName, contentLibrary, or ovaURL " +
+				"(source.vsphere.*)")
+	}
+}
+
+// findExistingByName returns a VirtualMachine matching name (a plain name or an
+// inventory path), or nil if none is found. It first tries the configured
+// DefaultFolder, then falls back to a global search, so an existing template is
+// detected regardless of where it lives. Any lookup error is treated as "not
+// found" so preparation proceeds rather than skipping work on a false negative.
+//
+// Both powered-off VMs and templates are returned by the finder; the caller only
+// cares that the name is taken, so no template/VM distinction is made here.
+func (p *Provider) findExistingByName(ctx context.Context, name string) *object.VirtualMachine {
+	// Scoped search within the default folder first (cheaper, avoids unrelated
+	// same-named VMs in other folders shadowing a real template).
+	if folder := strings.TrimSpace(p.config.DefaultFolder); folder != "" {
+		if vms, err := p.finder.VirtualMachineList(ctx, path.Join(folder, name)); err == nil && len(vms) > 0 {
+			return vms[0]
+		}
+	}
+	// Global search by name.
+	if vm, err := p.finder.VirtualMachine(ctx, name); err == nil && vm != nil {
+		return vm
+	}
+	return nil
+}
+
+// imagePrepareVerifyTemplate implements the templateName source: the named
+// template must already exist in vCenter. On success the prepared image is the
+// template itself, so no import is performed. A missing template yields an
+// honest NotFound rather than a fabricated success.
+func (p *Provider) imagePrepareVerifyTemplate(ctx context.Context, templateName string) (*providerv1.TaskResponse, error) {
+	vm, err := p.finder.VirtualMachine(ctx, templateName)
+	if err != nil {
+		if _, ok := err.(*find.NotFoundError); ok {
+			return nil, errors.NewNotFound("vSphere template", templateName)
+		}
+		return nil, fmt.Errorf("ImagePrepare: look up template %q: %w", templateName, err)
+	}
+	p.logger.Info("ImagePrepare: template exists; nothing to import",
+		"template_name", templateName, "vm", vm.Reference().Value)
+	return &providerv1.TaskResponse{}, nil
+}
+
+// imagePrepareVerifyContentLibrary implements the contentLibrary source: verify
+// the referenced library and item exist via the vCenter REST (vAPI) endpoint.
+// Deploying a content-library item into a standalone template is intentionally
+// out of scope for this PR; an existing-but-unhandled item returns a clear
+// InvalidSpec pointing the user at templateName/ovaURL rather than a fake
+// success.
+func (p *Provider) imagePrepareVerifyContentLibrary(ctx context.Context, ref *vsphereContentLibraryRef) (*providerv1.TaskResponse, error) {
+	if ref.Library == "" || ref.Item == "" {
+		return nil, errors.NewInvalidSpec("ImagePrepare contentLibrary requires both library and item")
+	}
+
+	// The REST/vAPI client is a separate session from the vim25 SOAP client; log
+	// in with the same credentials and log out when done.
+	rc := rest.NewClient(p.client.Client)
+	userInfo := url.UserPassword(p.config.Username, p.config.Password)
+	if err := rc.Login(ctx, userInfo); err != nil {
+		return nil, errors.NewUnavailable("vSphere content library (vAPI)", err)
+	}
+	defer func() {
+		if err := rc.Logout(ctx); err != nil {
+			p.logger.Warn("ImagePrepare: content-library REST logout failed", "error", err)
+		}
+	}()
+
+	mgr := library.NewManager(rc)
+	libs, err := mgr.FindLibrary(ctx, library.Find{Name: ref.Library})
+	if err != nil {
+		return nil, fmt.Errorf("ImagePrepare: find content library %q: %w", ref.Library, err)
+	}
+	if len(libs) == 0 {
+		return nil, errors.NewNotFound("vSphere content library", ref.Library)
+	}
+
+	items, err := mgr.FindLibraryItems(ctx, library.FindItem{LibraryID: libs[0], Name: ref.Item})
+	if err != nil {
+		return nil, fmt.Errorf("ImagePrepare: find library item %q in %q: %w", ref.Item, ref.Library, err)
+	}
+	if len(items) == 0 {
+		return nil, errors.NewNotFound("vSphere content library item", fmt.Sprintf("%s/%s", ref.Library, ref.Item))
+	}
+
+	p.logger.Info("ImagePrepare: content-library item exists",
+		"library", ref.Library, "item", ref.Item, "library_id", libs[0], "item_id", items[0])
+
+	// Verified, but deploying CL item -> template is not implemented in this PR.
+	return nil, errors.NewInvalidSpec(
+		"ImagePrepare: content library item %q/%q exists but content-library prepare is not yet implemented; "+
+			"use source.vsphere.templateName or source.vsphere.ovaURL", ref.Library, ref.Item)
+}
+
+// imagePrepareImportOVA implements the ovaURL source: the real import. It
+// resolves placement (resource pool, datastore, folder), downloads the OVA/OVF
+// to a temp file (optionally verifying its checksum), imports it into vCenter via
+// an NFC lease using govmomi's ovf/importer, marks the resulting VM as a
+// template, and cleans up the partially-created VM on any mid-import failure so a
+// retry starts clean.
+func (p *Provider) imagePrepareImportOVA(ctx context.Context, src vsphereImageSource, targetName, storageHint string) (*providerv1.TaskResponse, error) {
+	placement, err := p.resolveImagePlacement(ctx, storageHint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Download the OVA/OVF to a temp file. The provider pod streams the bytes and
+	// then pushes the VMDKs to vCenter over the NFC lease; staging to disk first
+	// keeps the import path simple and lets a FileArchive/TapeArchive re-open the
+	// descriptor and each disk by name.
+	localPath, cleanupDownload, err := p.downloadOVA(ctx, src.OVAURL)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanupDownload()
+
+	if src.Checksum != "" {
+		if err := verifyFileChecksum(localPath, src.Checksum, src.ChecksumType); err != nil {
+			return nil, err
+		}
+	}
+
+	// Choose the archive based on the source kind: an .ova is a tar (TapeArchive);
+	// a bare .ovf is a plain file with sibling .vmdk(s) (FileArchive). For an OVA the
+	// descriptor's exact entry name is resolved up front (skipping macOS sidecars).
+	archive, descriptorPath, err := p.newOVAArchive(localPath, src.OVAURL)
+	if err != nil {
+		return nil, err
+	}
+
+	imp := &importer.Importer{
+		Log:          p.ovaImportLog,
+		Sinker:       progress.NewProgressLogger(p.ovaImportLog, "ImagePrepare upload"),
+		Client:       p.client.Client,
+		Finder:       p.finder,
+		Datacenter:   placement.datacenter,
+		Datastore:    placement.datastore,
+		ResourcePool: placement.resourcePool,
+		Folder:       placement.folder,
+		Archive:      archive,
+	}
+
+	opts := importer.Options{
+		// Accept-all EULA / no interactive properties: rely on OVF defaults.
+		DiskProvisioning: ovaDiskProvisioningThin,
+		// Name the resulting VM after the target so the idempotency gate and the
+		// downstream MarkAsTemplate operate on a deterministically-named object.
+		Name: &targetName,
+		// Do not power on or mark-as-template here; we mark-as-template explicitly
+		// after the import succeeds so a partial import never yields a template.
+	}
+
+	p.logger.Info("ImagePrepare: importing OVA into vCenter",
+		"target_name", targetName,
+		"ova_url", src.OVAURL,
+		"datastore", placement.datastore.Name(),
+		"resource_pool", placement.resourcePool.Reference().Value,
+		"folder", placement.folder.Reference().Value,
+	)
+
+	moref, err := imp.Import(ctx, descriptorPath, opts)
+	if err != nil {
+		return nil, errors.NewInternal(fmt.Sprintf("ImagePrepare: import OVA %q as %q", src.OVAURL, targetName), err)
+	}
+
+	vm := object.NewVirtualMachine(p.client.Client, *moref)
+
+	// Promote the imported VM to a template. On failure, clean up the VM so a
+	// retry starts clean (the idempotency gate would otherwise treat the
+	// powered-off VM as "already prepared").
+	if err := vm.MarkAsTemplate(ctx); err != nil {
+		p.cleanupPartialImport(ctx, vm, targetName)
+		return nil, errors.NewInternal(fmt.Sprintf("ImagePrepare: mark imported VM %q as template", targetName), err)
+	}
+
+	p.logger.Info("ImagePrepare: imported OVA and marked as template",
+		"target_name", targetName, "vm", vm.Reference().Value)
+	return &providerv1.TaskResponse{}, nil
+}
+
+// imagePlacement bundles the resolved vSphere placement objects for an OVA
+// import.
+type imagePlacement struct {
+	datacenter   *object.Datacenter
+	resourcePool *object.ResourcePool
+	datastore    *object.Datastore
+	folder       *object.Folder
+}
+
+// resolveImagePlacement resolves where an imported template lands, mirroring the
+// priority chain createVirtualMachine uses but driven solely by provider
+// defaults and the request's storage hint (ImagePrepare has no per-VM placement
+// overrides):
+//
+//   - ResourcePool: DefaultCluster's root resource pool (or the finder default
+//     pool when DefaultCluster is empty).
+//   - Datastore:    storageHint → DefaultDatastore → a datastore from
+//     DefaultStoragePod (datastore cluster).
+//   - Folder:       DefaultFolder → datacenter default VM folder.
+func (p *Provider) resolveImagePlacement(ctx context.Context, storageHint string) (*imagePlacement, error) {
+	datacenter, err := p.finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ImagePrepare: find default datacenter: %w", err)
+	}
+	p.finder.SetDatacenter(datacenter)
+
+	// Resource pool from the default cluster (or the finder default pool).
+	var resourcePool *object.ResourcePool
+	if cluster := strings.TrimSpace(p.config.DefaultCluster); cluster != "" {
+		cc, err := p.finder.ClusterComputeResource(ctx, cluster)
+		if err != nil {
+			return nil, fmt.Errorf("ImagePrepare: find cluster %q: %w", cluster, err)
+		}
+		resourcePool, err = cc.ResourcePool(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("ImagePrepare: resource pool of cluster %q: %w", cluster, err)
+		}
+	} else {
+		resourcePool, err = p.finder.ResourcePoolOrDefault(ctx, "")
+		if err != nil {
+			return nil, fmt.Errorf("ImagePrepare: resolve default resource pool: %w", err)
+		}
+	}
+
+	// Datastore: storageHint, then DefaultDatastore, then DefaultStoragePod.
+	datastore, err := p.resolveImageDatastore(ctx, storageHint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Folder: DefaultFolder, falling back to the datacenter VM folder.
+	folder, err := p.resolveImageFolder(ctx, datacenter)
+	if err != nil {
+		return nil, err
+	}
+
+	return &imagePlacement{
+		datacenter:   datacenter,
+		resourcePool: resourcePool,
+		datastore:    datastore,
+		folder:       folder,
+	}, nil
+}
+
+// resolveImageDatastore picks the datastore for an OVA import: the request's
+// storage hint wins, then the provider DefaultDatastore, then a datastore chosen
+// from the DefaultStoragePod (datastore cluster) by free space. An empty result
+// with no candidates is an InvalidSpec.
+func (p *Provider) resolveImageDatastore(ctx context.Context, storageHint string) (*object.Datastore, error) {
+	if hint := strings.TrimSpace(storageHint); hint != "" {
+		ds, err := p.finder.Datastore(ctx, hint)
+		if err != nil {
+			return nil, fmt.Errorf("ImagePrepare: find datastore from storage hint %q: %w", hint, err)
+		}
+		return ds, nil
+	}
+	if ds := strings.TrimSpace(p.config.DefaultDatastore); ds != "" {
+		found, err := p.finder.Datastore(ctx, ds)
+		if err != nil {
+			return nil, fmt.Errorf("ImagePrepare: find default datastore %q: %w", ds, err)
+		}
+		return found, nil
+	}
+	if pod := strings.TrimSpace(p.config.DefaultStoragePod); pod != "" {
+		ds, err := p.resolveDatastoreFromStoragePod(ctx, pod)
+		if err != nil {
+			return nil, fmt.Errorf("ImagePrepare: resolve datastore from StoragePod %q: %w", pod, err)
+		}
+		return ds, nil
+	}
+	return nil, errors.NewInvalidSpec(
+		"ImagePrepare: no datastore available (set storage_hint, or the provider's " +
+			"defaultDatastore / defaultStoragePod)")
+}
+
+// resolveImageFolder resolves the folder an imported template lands in:
+// DefaultFolder, falling back to the datacenter's default VM folder.
+func (p *Provider) resolveImageFolder(ctx context.Context, datacenter *object.Datacenter) (*object.Folder, error) {
+	folderName := strings.TrimSpace(p.config.DefaultFolder)
+	if folderName != "" {
+		if folder, err := p.finder.Folder(ctx, folderName); err == nil {
+			return folder, nil
+		}
+		p.logger.Warn("ImagePrepare: default folder not found; using datacenter VM folder",
+			"folder", folderName)
+	}
+	folder, err := p.finder.Folder(ctx, datacenter.Name()+"/vm")
+	if err != nil {
+		return nil, fmt.Errorf("ImagePrepare: find datacenter VM folder: %w", err)
+	}
+	return folder, nil
+}
+
+// downloadOVA streams the OVA/OVF at ovaURL to a temp file on the provider pod's
+// filesystem and returns the local path plus a cleanup func that removes it. The
+// cleanup is always safe to call (it tolerates an already-removed file). A
+// non-2xx response or transport error is reported as Unavailable (retryable).
+func (p *Provider) downloadOVA(ctx context.Context, ovaURL string) (localPath string, cleanup func(), err error) {
+	noop := func() {}
+
+	ext := strings.ToLower(filepath.Ext(ovaURL))
+	if ext != ".ova" && ext != ".ovf" {
+		// Default to .ova so the archive selection has a deterministic shape; the
+		// importer ultimately parses the descriptor regardless of extension.
+		ext = ".ova"
+	}
+
+	tmp, err := os.CreateTemp("", "virtrigaud-ova-*"+ext)
+	if err != nil {
+		return "", noop, fmt.Errorf("ImagePrepare: create temp file for OVA: %w", err)
+	}
+	localPath = tmp.Name()
+	cleanup = func() {
+		_ = tmp.Close()
+		if rmErr := os.Remove(localPath); rmErr != nil && !os.IsNotExist(rmErr) {
+			p.logger.Warn("ImagePrepare: failed to remove temp OVA", "path", localPath, "error", rmErr)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ovaURL, nil)
+	if err != nil {
+		cleanup()
+		return "", noop, errors.NewInvalidSpec("ImagePrepare: invalid OVA URL %q: %v", ovaURL, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		cleanup()
+		return "", noop, errors.NewUnavailable("OVA download", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		cleanup()
+		return "", noop, errors.NewUnavailable("OVA download",
+			fmt.Errorf("unexpected HTTP status %d downloading %q", resp.StatusCode, ovaURL))
+	}
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("ImagePrepare: write OVA to temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("ImagePrepare: flush OVA temp file: %w", err)
+	}
+
+	p.logger.Info("ImagePrepare: downloaded OVA", "url", ovaURL, "path", localPath)
+	return localPath, cleanup, nil
+}
+
+// newOVAArchive returns the importer.Archive and the descriptor path to pass to
+// importer.Import for the staged file. A bare .ovf is a plain file with sibling
+// disks (FileArchive, descriptor is the file itself). An .ova is a tar of the
+// descriptor + disks (TapeArchive); the descriptor's EXACT entry name is resolved
+// up front (skipping macOS AppleDouble sidecars) rather than relying on a "*.ovf"
+// glob, which would otherwise match a "._foo.ovf" metadata file packed before the
+// real descriptor by macOS tar.
+func (p *Provider) newOVAArchive(localPath, ovaURL string) (importer.Archive, string, error) {
+	opener := importer.Opener{Client: p.client.Client}
+	if strings.EqualFold(filepath.Ext(ovaURL), ".ovf") {
+		return &importer.FileArchive{Path: localPath, Opener: opener}, localPath, nil
+	}
+	descriptor, err := findOVADescriptorName(localPath)
+	if err != nil {
+		return nil, "", err
+	}
+	return &importer.TapeArchive{Path: localPath, Opener: opener}, descriptor, nil
+}
+
+// findOVADescriptorName returns the exact base name of the OVF descriptor inside
+// an OVA tar. It skips macOS AppleDouble sidecar files (a leading "._" on the base
+// name) and __MACOSX/ directory entries, which OVAs repackaged on macOS include
+// and which precede the real descriptor in tar order. govmomi's TapeArchive
+// matches the descriptor by glob, so without this filter a "._foo.ovf" sidecar (a
+// small binary AppleDouble blob) is parsed as the descriptor and fails with an
+// XML null-byte error. Returning the exact name also makes the subsequent disk
+// uploads resolve their hrefs exactly, never matching a "._disk.vmdk" sidecar.
+func findOVADescriptorName(ovaPath string) (string, error) {
+	f, err := os.Open(filepath.Clean(ovaPath))
+	if err != nil {
+		return "", fmt.Errorf("open OVA to locate descriptor: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	tr := tar.NewReader(f)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("read OVA tar to locate descriptor: %w", err)
+		}
+		if strings.Contains(h.Name, "__MACOSX/") {
+			continue
+		}
+		base := path.Base(h.Name)
+		if strings.HasPrefix(base, "._") {
+			continue // macOS AppleDouble sidecar
+		}
+		if strings.EqualFold(filepath.Ext(base), ".ovf") {
+			return base, nil
+		}
+	}
+	return "", errors.NewInvalidSpec("OVA contains no .ovf descriptor (after skipping macOS sidecar files)")
+}
+
+// ovaImportLog adapts govmomi's progress.LogFunc to the provider's structured
+// logger, surfacing importer warnings/upload progress lines at debug level.
+func (p *Provider) ovaImportLog(msg string) (int, error) {
+	p.logger.Debug("ImagePrepare: ova import", "msg", strings.TrimRight(msg, "\n"))
+	return len(msg), nil
+}
+
+// cleanupPartialImport best-effort destroys a VM left behind by a failed import
+// (e.g. MarkAsTemplate failed after ImportVApp succeeded) so a retry starts
+// clean and the idempotency gate does not mistake the orphan for a prepared
+// template. Failures are logged, not returned.
+func (p *Provider) cleanupPartialImport(ctx context.Context, vm *object.VirtualMachine, targetName string) {
+	task, err := vm.Destroy(ctx)
+	if err != nil {
+		p.logger.Warn("ImagePrepare: failed to start cleanup of partial import",
+			"target_name", targetName, "vm", vm.Reference().Value, "error", err)
+		return
+	}
+	if err := task.Wait(ctx); err != nil {
+		p.logger.Warn("ImagePrepare: cleanup of partial import did not complete",
+			"target_name", targetName, "vm", vm.Reference().Value, "error", err)
+		return
+	}
+	p.logger.Info("ImagePrepare: cleaned up partial import",
+		"target_name", targetName, "vm", vm.Reference().Value)
+}
+
+// verifyFileChecksum verifies that the file at path hashes to expected using the
+// requested algorithm. An empty expected disables verification (no-op). An
+// unknown algorithm or a mismatch returns an InvalidSpec error so the caller
+// rejects the OVA before importing it.
+func verifyFileChecksum(path, expected, checksumType string) error {
+	if strings.TrimSpace(expected) == "" {
+		return nil
+	}
+	h, known := vsphereChecksumHasher(checksumType)
+	if !known {
+		return errors.NewInvalidSpec(
+			"ImagePrepare: unsupported checksum type %q (want md5/sha1/sha256/sha512)", checksumType)
+	}
+
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("ImagePrepare: open OVA for checksum: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("ImagePrepare: hash OVA: %w", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, strings.TrimSpace(expected)) {
+		return errors.NewInvalidSpec(
+			"ImagePrepare: checksum mismatch for OVA: expected %s, got %s", expected, got)
+	}
+	return nil
+}

--- a/internal/providers/vsphere/image_test.go
+++ b/internal/providers/vsphere/image_test.go
@@ -1,0 +1,470 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// ---- parseVSphereImageSource ------------------------------------------------
+
+// TestParseVSphereImageSource_RichOVAURL verifies the rich source.vsphere shape
+// is parsed, including ovaURL and checksum fields (only this shape can express
+// them).
+func TestParseVSphereImageSource_RichOVAURL(t *testing.T) {
+	imageJSON := `{
+		"source": {
+			"vsphere": {
+				"ovaURL": "https://images.example.com/photon.ova",
+				"checksum": "abc123",
+				"checksumType": "sha512"
+			}
+		}
+	}`
+
+	src := parseVSphereImageSource(imageJSON)
+
+	assert.Equal(t, "https://images.example.com/photon.ova", src.OVAURL)
+	assert.Equal(t, "abc123", src.Checksum)
+	assert.Equal(t, "sha512", src.ChecksumType)
+	assert.Empty(t, src.TemplateName)
+	assert.Nil(t, src.ContentLibrary)
+}
+
+// TestParseVSphereImageSource_RichTemplateName verifies the templateName branch
+// of the rich shape (verify-only, no import).
+func TestParseVSphereImageSource_RichTemplateName(t *testing.T) {
+	src := parseVSphereImageSource(`{"source":{"vsphere":{"templateName":"ubuntu-2404-tmpl"}}}`)
+
+	assert.Equal(t, "ubuntu-2404-tmpl", src.TemplateName)
+	assert.Empty(t, src.OVAURL)
+	assert.Nil(t, src.ContentLibrary)
+}
+
+// TestParseVSphereImageSource_RichContentLibrary verifies the contentLibrary
+// branch parses library/item/version.
+func TestParseVSphereImageSource_RichContentLibrary(t *testing.T) {
+	imageJSON := `{
+		"source":{"vsphere":{"contentLibrary":{"library":"prod-cl","item":"jammy","version":"3"}}}
+	}`
+
+	src := parseVSphereImageSource(imageJSON)
+
+	require.NotNil(t, src.ContentLibrary)
+	assert.Equal(t, "prod-cl", src.ContentLibrary.Library)
+	assert.Equal(t, "jammy", src.ContentLibrary.Item)
+	assert.Equal(t, "3", src.ContentLibrary.Version)
+	assert.Empty(t, src.OVAURL)
+	assert.Empty(t, src.TemplateName)
+}
+
+// TestParseVSphereImageSource_FlatTemplateName verifies the fallback flat
+// contracts.VMImage shape (Go field name TemplateName) is parsed when no nested
+// source.vsphere is present. This is the shape Create already round-trips.
+func TestParseVSphereImageSource_FlatTemplateName(t *testing.T) {
+	src := parseVSphereImageSource(`{"TemplateName":"legacy-template"}`)
+
+	assert.Equal(t, "legacy-template", src.TemplateName)
+	assert.Empty(t, src.OVAURL)
+	assert.Nil(t, src.ContentLibrary)
+}
+
+// TestParseVSphereImageSource_RichWins verifies the rich source.vsphere shape
+// wins over flat fields when both are present.
+func TestParseVSphereImageSource_RichWins(t *testing.T) {
+	imageJSON := `{
+		"source":{"vsphere":{"ovaURL":"https://rich/x.ova"}},
+		"TemplateName":"flat-template"
+	}`
+
+	src := parseVSphereImageSource(imageJSON)
+
+	assert.Equal(t, "https://rich/x.ova", src.OVAURL)
+	assert.Empty(t, src.TemplateName, "rich source.vsphere should win over the flat TemplateName field")
+}
+
+// TestParseVSphereImageSource_Empty verifies empty / source-less / unparseable
+// inputs yield an empty source (the caller turns this into an InvalidSpec error).
+func TestParseVSphereImageSource_Empty(t *testing.T) {
+	for _, in := range []string{
+		"", "   ", "{}", `{"source":{}}`, `{"source":{"vsphere":{}}}`, `{not json`,
+	} {
+		src := parseVSphereImageSource(in)
+		assert.Empty(t, src.OVAURL, "input %q", in)
+		assert.Empty(t, src.TemplateName, "input %q", in)
+		assert.Nil(t, src.ContentLibrary, "input %q", in)
+	}
+}
+
+// ---- vsphereChecksumHasher --------------------------------------------------
+
+// TestVSphereChecksumHasher verifies algorithm selection, the sha256 default,
+// and rejection of an unknown algorithm.
+func TestVSphereChecksumHasher(t *testing.T) {
+	tests := []struct {
+		in     string
+		wantOK bool
+	}{
+		{"", true},
+		{"sha256", true},
+		{"SHA256", true},
+		{"md5", true},
+		{"sha1", true},
+		{"sha512", true},
+		{"  sha512  ", true},
+		{"crc32", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			h, ok := vsphereChecksumHasher(tt.in)
+			assert.NotNil(t, h)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+// ---- verifyFileChecksum -----------------------------------------------------
+
+// TestVerifyFileChecksum covers the no-op (empty checksum), match, mismatch, and
+// unknown-algorithm cases against a real temp file.
+func TestVerifyFileChecksum(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "checksum-*.bin")
+	require.NoError(t, err)
+	content := []byte("virtrigaud-ova-bytes")
+	_, err = f.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	sum := sha256.Sum256(content)
+	hexSum := hex.EncodeToString(sum[:])
+
+	// Empty checksum disables verification.
+	assert.NoError(t, verifyFileChecksum(f.Name(), "", ""))
+
+	// Correct checksum (default sha256, and explicit, and uppercase tolerant).
+	assert.NoError(t, verifyFileChecksum(f.Name(), hexSum, ""))
+	assert.NoError(t, verifyFileChecksum(f.Name(), hexSum, "sha256"))
+	assert.NoError(t, verifyFileChecksum(f.Name(), hexSum, "SHA256"))
+
+	// Mismatch is an InvalidSpec error.
+	err = verifyFileChecksum(f.Name(), "deadbeef", "sha256")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum mismatch")
+
+	// Unknown algorithm is rejected before hashing.
+	err = verifyFileChecksum(f.Name(), hexSum, "crc32")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported checksum type")
+}
+
+// ---- ImagePrepare request validation (host-independent) ---------------------
+
+// TestImagePrepare_NilClient verifies the guard fires before any vCenter
+// interaction when the govmomi client is not initialized.
+func TestImagePrepare_NilClient(t *testing.T) {
+	p := &Provider{logger: slog.Default()}
+	resp, err := p.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"vsphere":{"ovaURL":"https://x/y.ova"}}}`,
+		TargetName: "tmpl",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "not initialized")
+}
+
+// ---- vcsim integration: OVA import + idempotency ----------------------------
+
+// minimalDisklessOVF is a self-contained OVF descriptor with a VirtualSystem but
+// no disk references. CreateImportSpec therefore returns no FileItem, so the
+// import completes the NFC lease without a disk upload — exercising the full
+// import + MarkAsTemplate path against vcsim without needing a real VMDK.
+const minimalDisklessOVF = `<?xml version="1.0" encoding="UTF-8"?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1"
+          xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1"
+          xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
+          xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
+  <References/>
+  <VirtualSystem ovf:id="vm">
+    <Info>A minimal virtual machine</Info>
+    <Name>minimal-vm</Name>
+    <OperatingSystemSection ovf:id="36">
+      <Info>The kind of installed guest operating system</Info>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemIdentifier>minimal-vm</vssd:VirtualSystemIdentifier>
+        <vssd:VirtualSystemType>vmx-09</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>32MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>32</rasd:VirtualQuantity>
+      </Item>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>`
+
+// newOVATarServer serves a single-entry OVA tar (the descriptor only) over HTTP
+// and returns its URL plus its sha256. The path ends in .ova so ImagePrepare
+// uses a TapeArchive.
+func newOVATarServer(t *testing.T) (ovaURL, sha256hex string, close func()) {
+	t.Helper()
+
+	// Build the OVA tar in memory: a single descriptor.ovf member.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	hdr := &tar.Header{
+		Name: "descriptor.ovf",
+		Mode: 0o644,
+		Size: int64(len(minimalDisklessOVF)),
+	}
+	require.NoError(t, tw.WriteHeader(hdr))
+	_, err := tw.Write([]byte(minimalDisklessOVF))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	ova := buf.Bytes()
+	sum := sha256.Sum256(ova)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(ova)
+	}))
+
+	return srv.URL + "/image.ova", hex.EncodeToString(sum[:]), srv.Close
+}
+
+// newImageTestProvider builds a Provider backed by the in-memory vCenter
+// simulator with the placement defaults vcsim's VPX model provides.
+func newImageTestProvider(t *testing.T) (*Provider, func()) {
+	t.Helper()
+	cfg, cleanupSim := newSimConfig(t)
+	// VPX model default inventory names.
+	cfg.DefaultCluster = "DC0_C0"
+	cfg.DefaultDatastore = "LocalDS_0"
+	cfg.DefaultFolder = ""
+
+	client, finder, err := createVSphereClient(cfg)
+	require.NoError(t, err)
+
+	// Pin the finder to the default datacenter so direct finder calls in tests (and
+	// the idempotency gate) resolve; ImagePrepare also does this internally.
+	dc, err := finder.DefaultDatacenter(context.Background())
+	require.NoError(t, err)
+	finder.SetDatacenter(dc)
+
+	p := &Provider{
+		client: client,
+		finder: finder,
+		config: cfg,
+		logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+	cleanup := func() {
+		_ = client.Logout(context.Background())
+		cleanupSim()
+	}
+	return p, cleanup
+}
+
+// TestImagePrepare_OVAImport_AndIdempotency imports a trivial OVA into vcsim,
+// asserts a template named target_name results, and that a re-run is a no-op
+// (does not re-import).
+func TestImagePrepare_OVAImport_AndIdempotency(t *testing.T) {
+	p, cleanup := newImageTestProvider(t)
+	defer cleanup()
+
+	ovaURL, ovaSum, closeSrv := newOVATarServer(t)
+	defer closeSrv()
+
+	const targetName = "virtrigaud-it-template"
+
+	imageJSON := `{"source":{"vsphere":{"ovaURL":"` + ovaURL + `","checksum":"` + ovaSum + `","checksumType":"sha256"}}}`
+
+	// First run: imports and marks as template.
+	resp, err := p.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
+		ImageJson:  imageJSON,
+		TargetName: targetName,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.GetTask(), "synchronous import returns an empty task")
+
+	// The imported object exists and is a template.
+	vm, err := p.finder.VirtualMachine(context.Background(), targetName)
+	require.NoError(t, err, "expected a VM/template named %q after import", targetName)
+	require.NotNil(t, vm)
+	isTemplate, err := vm.IsTemplate(context.Background())
+	require.NoError(t, err)
+	assert.True(t, isTemplate, "imported VM should be marked as a template")
+
+	// Second run: idempotent no-op. Point at a URL that would fail if downloaded,
+	// to prove the idempotency gate short-circuits BEFORE any import work.
+	resp2, err := p.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"vsphere":{"ovaURL":"http://127.0.0.1:1/never.ova"}}}`,
+		TargetName: targetName,
+	})
+	require.NoError(t, err, "re-run must be a no-op, not re-import")
+	require.NotNil(t, resp2)
+}
+
+// TestImagePrepare_TemplateName_VerifyOnly_NotFound verifies the templateName
+// branch returns NotFound when the named template does not exist (honest, no
+// fabricated success).
+func TestImagePrepare_TemplateName_VerifyOnly_NotFound(t *testing.T) {
+	p, cleanup := newImageTestProvider(t)
+	defer cleanup()
+
+	resp, err := p.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"vsphere":{"templateName":"does-not-exist-tmpl"}}}`,
+		TargetName: "prepared-name",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestImagePrepare_TemplateName_VerifyOnly_Exists verifies the templateName
+// branch succeeds without importing when the named template already exists. It
+// uses an existing vcsim VM (DC0_H0_VM0) as the "template".
+func TestImagePrepare_TemplateName_VerifyOnly_Exists(t *testing.T) {
+	p, cleanup := newImageTestProvider(t)
+	defer cleanup()
+
+	// Confirm the simulator VM exists, then ask ImagePrepare to verify it.
+	const existing = "DC0_H0_VM0"
+	_, err := p.finder.VirtualMachine(context.Background(), existing)
+	require.NoError(t, err)
+
+	resp, err := p.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"vsphere":{"templateName":"` + existing + `"}}}`,
+		TargetName: "prepared-from-existing",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+// TestImagePrepare_NoSource verifies an image spec with no usable vSphere source
+// is rejected as InvalidSpec (no fabricated success).
+func TestImagePrepare_NoSource(t *testing.T) {
+	p, cleanup := newImageTestProvider(t)
+	defer cleanup()
+
+	resp, err := p.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"vsphere":{}}}`,
+		TargetName: "tmpl",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "templateName, contentLibrary, or ovaURL")
+}
+
+// TestImagePrepare_MissingTargetName verifies the target-name guard fires before
+// any vCenter interaction.
+func TestImagePrepare_MissingTargetName(t *testing.T) {
+	p, cleanup := newImageTestProvider(t)
+	defer cleanup()
+
+	resp, err := p.ImagePrepare(context.Background(), &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"vsphere":{"ovaURL":"https://x/y.ova"}}}`,
+		TargetName: "  ",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "target name is required")
+}
+
+// TestFindOVADescriptorName_SkipsAppleDouble verifies the OVA descriptor resolver
+// skips macOS AppleDouble sidecars (._*) and __MACOSX entries that precede the
+// real descriptor — the failure mode hit by a macOS-packaged OVA during live
+// validation (govmomi's "*.ovf" glob matched the binary "._foo.ovf" first).
+func TestFindOVADescriptorName_SkipsAppleDouble(t *testing.T) {
+	dir := t.TempDir()
+	ovaPath := filepath.Join(dir, "test.ova")
+	f, err := os.Create(ovaPath)
+	require.NoError(t, err)
+	tw := tar.NewWriter(f)
+	// Order mirrors a real macOS-packaged OVA: AppleDouble sidecars first.
+	entries := []struct {
+		name string
+		data string
+	}{
+		{"._ubuntu-24-04-ovf.ovf", "\x00\x05\x16\x07binary applesingle blob"},
+		{"__MACOSX/._x.ovf", "\x00\x00binary"},
+		{"ubuntu-24-04-ovf.ovf", "<?xml version='1.0'?><Envelope/>"},
+		{"._ubuntu-24-04-ovf-1.vmdk", "\x00binary"},
+		{"ubuntu-24-04-ovf-1.vmdk", "diskbytes"},
+	}
+	for _, e := range entries {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: e.name, Mode: 0o644, Size: int64(len(e.data))}))
+		_, err := tw.Write([]byte(e.data))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, f.Close())
+
+	name, err := findOVADescriptorName(ovaPath)
+	require.NoError(t, err)
+	assert.Equal(t, "ubuntu-24-04-ovf.ovf", name,
+		"must skip ._*.ovf AppleDouble sidecars and pick the real descriptor")
+}
+
+// TestFindOVADescriptorName_NoDescriptor verifies an OVA with no real .ovf (only
+// sidecars) is a clear error rather than a binary-parse failure downstream.
+func TestFindOVADescriptorName_NoDescriptor(t *testing.T) {
+	dir := t.TempDir()
+	ovaPath := filepath.Join(dir, "nodesc.ova")
+	f, err := os.Create(ovaPath)
+	require.NoError(t, err)
+	tw := tar.NewWriter(f)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "._only.ovf", Mode: 0o644, Size: 3}))
+	_, _ = tw.Write([]byte("\x00ab"))
+	require.NoError(t, tw.Close())
+	require.NoError(t, f.Close())
+
+	_, err = findOVADescriptorName(ovaPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no .ovf descriptor")
+}

--- a/internal/providers/vsphere/server.go
+++ b/internal/providers/vsphere/server.go
@@ -411,7 +411,7 @@ func (p *Provider) GetCapabilities(ctx context.Context, req *providerv1.GetCapab
 		SupportsSnapshots:           true,
 		SupportsMemorySnapshots:     true, // vSphere captures RAM-inclusive snapshots via CreateSnapshot(memory=true); requires the VM to be powered on
 		SupportsLinkedClones:        true,
-		SupportsImageImport:         true,
+		SupportsImageImport:         true, // ImagePrepare imports an OVA/OVF URL into vCenter as a template (#154)
 		SupportedDiskTypes:          []string{"thin", "thick", "eager-zeroed"},
 		SupportedNetworkTypes:       []string{"standard", "distributed"},
 		// Disk migration: ExportDisk and ImportDisk are implemented (issue #178).
@@ -1946,12 +1946,9 @@ func (p *Provider) Clone(ctx context.Context, req *providerv1.CloneRequest) (*pr
 	}, nil
 }
 
-// ImagePrepare implements the ProviderServer interface. Image preparation (converting
-// an external image into a vSphere template) is not yet implemented for this provider;
-// the method always returns an Unimplemented error.
-func (p *Provider) ImagePrepare(ctx context.Context, req *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
-	return nil, errors.NewUnimplemented("ImagePrepare operation not yet implemented for vSphere")
-}
+// ImagePrepare is implemented in image.go: it imports an OVA/OVF from a URL into
+// vCenter as a template (or verifies an existing template / content-library item),
+// backing the SupportsImageImport capability (#154).
 
 // VMSpec represents the parsed virtual machine specification
 type VMSpec struct {


### PR DESCRIPTION
## What

**PR-2 of the image-prepare vertical slice (#154).** Replaces vSphere's `ImagePrepare` `Unimplemented` stub with a **real OVA/OVF URL import** — making the existing `SupportsImageImport=true` capability *honest by implementation* rather than by flipping the flag off (per maintainer direction).

Three source kinds, idempotency-first:
- **`source.vsphere.ovaURL`** (the real work): download the OVA/OVF, optionally verify checksum (md5/sha1/sha256/sha512), import into vCenter via an NFC lease using govmomi's `ovf/importer` (`TapeArchive` for `.ova`, `FileArchive` for `.ovf`), then `MarkAsTemplate`. Result: a thin-provisioned template named `target_name`.
- **`source.vsphere.templateName`**: verify-only — the named template must already exist (missing → `NotFound`); no import.
- **`source.vsphere.contentLibrary`**: verify-only via vAPI — the item must exist; deploying a CL item to a template is out of scope here and returns a clear `InvalidSpec` (never a fake success).
- **Idempotency gate first**: an existing template/VM named `target_name` → no-op (a re-run never re-imports).
- **Placement**: resource pool from `DefaultCluster`, datastore from `StorageHint` → `DefaultDatastore` → `DefaultStoragePod`, folder from `DefaultFolder`.
- **Partial-import cleanup**: a VM left by a failed `MarkAsTemplate` is destroyed so a retry starts clean and the idempotency gate isn't fooled.

`SupportsImageImport` stays **`true`** (now backed by a real implementation). Synchronous (empty `TaskRef`); large-OVA async polling is a documented future enhancement.

## Scope boundary

vSphere-provider-only. No proto/CRD/controller/transport changes. Not yet controller-reachable (PR-4/PR-5).

## Verification

- `make fmt` clean · `make lint` / `golangci-lint ./internal/providers/vsphere/...` **0 issues** · `make test` / `go test ./internal/providers/vsphere/...` pass · `make build` OK · no manifest drift · only 4 files changed.
- **vcsim integration tests** (the suite already wires the simulator): import a trivial OVA into vcsim → assert a template named `target_name` is created → re-run no-ops; templateName verify (found/not-found); parse/checksum/placement/guard unit tests.
- **Live vCenter validation**: see PR thread — needs a small real OVA + a one-time prod-vCenter window (vcsim does not exercise real NFC disk transfer).

## Risk

- vSphere-provider-only; the path was previously `Unimplemented` (unused) → no regression surface to existing template-clone VM creation.
- Large OVAs stage to the provider pod's `/tmp` (ephemeral); fine for small base images, but very large OVAs + the synchronous model may hit the gRPC client deadline — async `TaskRef` is the documented follow-up. Use a small OVA for first live validation.
- vCenter service account needs `Datastore.AllocateSpace`, VApp import, `VirtualMachine.Inventory.Create`, and mark-as-template rights.

Part of #154.
