### PR TITLE
fix(proxmox): audit + tighten ImagePrepare to honor the contract (#154, PR-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-08 11:18] - Audit + tighten Proxmox ImagePrepare to honor the contract (#154)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/proxmox/image.go` (new): real `parseProxmoxImageSource` replaces the untyped `map[string]interface{}` walk in `server.go`. It parses, in precedence: the rich `v1beta1` `source.proxmox.{templateID,templateName,storage,node,format}` shape and the generic `source.http.url` import shape, falling back to the flat `contracts.VMImage` (`TemplateName`/`URL`/`Format`) that `Create` round-trips. An empty/unparseable/source-less spec yields an empty source → the caller returns `InvalidSpec`, never a fabricated success — mirroring the libvirt (PR-1) and vSphere (PR-2) parsers.
+- `internal/providers/proxmox/image.go`: `ImagePrepare` now honors `req.TargetName`. Existing-template references (`source.proxmox.templateID`/`templateName`) are verify-only: the template must exist on the node and be `template=1` (`GetVM`/`ListVMs`), returning success if found and an honest `NotFound` if missing — no import. The `source.http.url` path imports into a template named `TargetName` and requires a non-empty `TargetName` (no name is ever fabricated from the URL basename).
+- `internal/providers/proxmox/image.go`: idempotency gate — when importing, if a template named `TargetName` already exists on the node, log and return success without downloading (consistent with libvirt/vSphere).
+
+### Changed
+- `internal/providers/proxmox/image.go`: storage precedence is `req.StorageHint` → `source.proxmox.storage` → `local-lvm` (documented last resort); node precedence is `source.proxmox.node` → `FindNode` default.
+- `internal/providers/proxmox/server.go`: removed the old loose `ImagePrepare` (ignored `target_name`, parsed the non-CRD `source.template` field, hardcoded storage, no idempotency); the method now lives in `image.go`. `SupportsImageImport` stays `true` — now contract-correct.
+- `internal/providers/proxmox/pveapi/client.go`: `PrepareImage` now takes `targetName` and `format`, POSTs the storage `download-url` with `content=import` (a cloud image becomes a VM disk → template, not an ISO) and a `filename` of `<targetName>.<format>` instead of the hardcoded `content=iso` + `imported-image.qcow2`. The verify-only "does the template exist" decode-and-discard probe was dropped (that check is now done provider-side).
+- `internal/providers/proxmox/pvefake/server.go`: added `GET /nodes/{node}/qemu` (list VMs, incl. templates) and `POST /nodes/{node}/storage/{storage}/download-url` handlers; the latter records the request via `LastDownloadRequest()` so tests can assert node/storage/content/filename/url propagation.
+- `internal/providers/proxmox/provider_test.go` + `image_test.go` (new): rewrote `TestProxmoxProvider_ImagePrepare` into focused cases using the real serialized shapes — existing template by name/ID (no-op), missing template (`NotFound`), URL import (asserts the PVE download-url call), storage precedence, missing `target_name` on import (`InvalidSpec`), empty/source-less spec (`InvalidSpec`), and idempotency — plus host-independent unit tests for `parseProxmoxImageSource` and storage precedence.
+
+### Why
+PR-3 of the image-prepare vertical slice (#154). The Proxmox ImagePrepare was implemented but loose — it ignored `target_name`, parsed non-CRD JSON shapes, and had no idempotency. This aligns it with the libvirt (PR-1) and vSphere (PR-2) contracts so the upcoming controller wiring (PR-5) can drive all three consistently.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (Proxmox provider image; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- No real Proxmox lab available; validated via unit tests + the in-repo fake PVE server. The `content=import` semantics and the download-url → attach-to-VM → mark-as-template flow are asserted at the call level (the fake server records the request) but not against a live PVE — see the caveats in the PR description.
+
 ## [2026-06-08 11:14] - Implement vSphere ImagePrepare: OVA/OVF URL import as template (#154)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/proxmox/image.go
+++ b/internal/providers/proxmox/image.go
@@ -1,0 +1,375 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	v1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	"github.com/projectbeskar/virtrigaud/internal/providers/proxmox/pveapi"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+	"github.com/projectbeskar/virtrigaud/sdk/provider/errors"
+)
+
+const (
+	// defaultProxmoxStorage is the Proxmox storage used for image preparation when
+	// the caller supplies neither a storage hint nor a source-level storage. It is
+	// the last-resort fallback; local-lvm is the default file/block storage present
+	// on a stock single-node PVE install.
+	defaultProxmoxStorage = "local-lvm"
+
+	// defaultProxmoxImageFormat is the disk format assumed for an imported image
+	// when the source omits one. It matches the v1beta1 ProxmoxImageSource
+	// kubebuilder default.
+	defaultProxmoxImageFormat = "qcow2"
+
+	// proxmoxTemplateFlag is the value PVE sets on the `template` field of a VM
+	// that has been converted to a template.
+	proxmoxTemplateFlag = 1
+)
+
+// proxmoxImageSource is the normalized, provider-internal view of a VMImage's
+// Proxmox source, decoupled from the on-the-wire JSON shapes ImagePrepare may
+// receive (see parseProxmoxImageSource).
+//
+// Two mutually-exclusive intents are expressed:
+//
+//   - A reference to an EXISTING template (TemplateID or TemplateName set): the
+//     template is verified to exist; nothing is imported.
+//   - An IMPORT request (URL set): a disk image is downloaded into the target
+//     storage and a template named after the request's TargetName is prepared.
+//
+// All fields are optional; the caller enforces that at least one usable source is
+// present and applies the documented precedence.
+type proxmoxImageSource struct {
+	// TemplateID references an existing Proxmox template by VMID. When non-nil an
+	// existing template is referenced and no import is performed.
+	TemplateID *int
+	// TemplateName references an existing Proxmox template by name. When set an
+	// existing template is referenced and no import is performed.
+	TemplateName string
+	// URL is an HTTP(S) location of a disk image to import (source.http.url). It is
+	// the only source that performs a real import.
+	URL string
+	// Storage is the source-preferred Proxmox storage to import into; overridden by
+	// the request's StorageHint when that is set, and falls back to
+	// defaultProxmoxStorage.
+	Storage string
+	// Node is the source-preferred Proxmox node the template lives on / is imported
+	// to; falls back to the client's FindNode default.
+	Node string
+	// Format is the disk format of the imported image (raw/qcow2/vmdk); defaults to
+	// defaultProxmoxImageFormat when unset.
+	Format string
+}
+
+// referencesExistingTemplate reports whether the source points at a template that
+// is expected to already exist (verify-only path) rather than requesting an
+// import.
+func (s proxmoxImageSource) referencesExistingTemplate() bool {
+	return s.TemplateID != nil || strings.TrimSpace(s.TemplateName) != ""
+}
+
+// isEmpty reports whether no usable source was parsed (neither an existing
+// template reference nor an import URL). The caller turns this into an
+// InvalidSpec so a no-op is never reported as success.
+func (s proxmoxImageSource) isEmpty() bool {
+	return !s.referencesExistingTemplate() && strings.TrimSpace(s.URL) == ""
+}
+
+// rawProxmoxVMImageSpec mirrors the subset of v1beta1.VMImageSpec the Proxmox
+// provider consumes for ImagePrepare. It is parsed directly from the rich
+// source.{proxmox,http}.* shape because that is the only serialized form able to
+// carry the Proxmox-native fields (templateID/storage/node/format) and the
+// generic HTTP import URL. Unmarshalling into the v1beta1 types directly is
+// avoided to keep the parser tolerant of partial/loosely-typed JSON.
+type rawProxmoxVMImageSpec struct {
+	Source struct {
+		Proxmox *struct {
+			TemplateID   *int   `json:"templateID"`
+			TemplateName string `json:"templateName"`
+			Storage      string `json:"storage"`
+			Node         string `json:"node"`
+			Format       string `json:"format"`
+		} `json:"proxmox"`
+		HTTP *struct {
+			URL string `json:"url"`
+		} `json:"http"`
+	} `json:"source"`
+}
+
+// parseProxmoxImageSource normalizes the JSON-encoded image spec carried by
+// ImagePrepareRequest.ImageJson into a proxmoxImageSource.
+//
+// Two shapes are accepted, in priority order, mirroring the libvirt (PR-1) and
+// vSphere (PR-2) parsers:
+//
+//  1. The rich v1beta1.VMImageSpec shape with nested
+//     source.proxmox.{templateID,templateName,storage,node,format} and/or
+//     source.http.url. This is the ONLY shape that can express the Proxmox-native
+//     fields, so it is tried first. A source.proxmox reference to an existing
+//     template takes precedence over a source.http import URL when both appear.
+//  2. The flat, provider-agnostic contracts.VMImage shape that Create already
+//     round-trips (server.go Create reads TemplateName from it). It can express a
+//     TemplateName (existing template) or a URL (import); it carries no
+//     storage/node/format.
+//
+// An empty or unparseable ImageJson, or one carrying neither an existing-template
+// reference nor an import URL, returns an empty source — the caller turns that
+// into an InvalidSpec error so a no-op is never reported as success.
+func parseProxmoxImageSource(imageJSON string) proxmoxImageSource {
+	var src proxmoxImageSource
+	if strings.TrimSpace(imageJSON) == "" {
+		return src
+	}
+
+	// Shape 1: rich v1beta1 spec with nested source.proxmox / source.http.
+	var spec rawProxmoxVMImageSpec
+	if err := json.Unmarshal([]byte(imageJSON), &spec); err == nil {
+		if px := spec.Source.Proxmox; px != nil {
+			src.TemplateID = px.TemplateID
+			src.TemplateName = px.TemplateName
+			src.Storage = px.Storage
+			src.Node = px.Node
+			src.Format = px.Format
+		}
+		if http := spec.Source.HTTP; http != nil {
+			src.URL = http.URL
+		}
+		if !src.isEmpty() {
+			return src
+		}
+	}
+
+	// Shape 2: flat contracts.VMImage (Go field names, no JSON tags). It can only
+	// express a TemplateName (existing template) or a URL (import) for Proxmox.
+	var img contracts.VMImage
+	if err := json.Unmarshal([]byte(imageJSON), &img); err == nil {
+		if img.TemplateName != "" || img.URL != "" {
+			src.TemplateName = img.TemplateName
+			src.URL = img.URL
+			src.Format = img.Format
+		}
+	}
+
+	return src
+}
+
+// resolveImageStorage selects the Proxmox storage to import into, in priority
+// order: the request StorageHint, then source.proxmox.storage, then the provider
+// default. This mirrors the libvirt/vSphere hint-or-default behavior while
+// additionally honoring the image's own storage preference.
+func resolveImageStorage(storageHint, sourceStorage string) string {
+	switch {
+	case strings.TrimSpace(storageHint) != "":
+		return strings.TrimSpace(storageHint)
+	case strings.TrimSpace(sourceStorage) != "":
+		return strings.TrimSpace(sourceStorage)
+	default:
+		return defaultProxmoxStorage
+	}
+}
+
+// resolveImageNode selects the Proxmox node, preferring the source-supplied node
+// and falling back to the client's FindNode default. A FindNode failure is only
+// surfaced when no source node was given, so an explicit node short-circuits node
+// discovery entirely.
+func (p *Provider) resolveImageNode(ctx context.Context, sourceNode string) (string, error) {
+	if n := strings.TrimSpace(sourceNode); n != "" {
+		return n, nil
+	}
+	node, err := p.client.FindNode(ctx)
+	if err != nil {
+		return "", errors.NewInternal("ImagePrepare: find Proxmox node", err)
+	}
+	return node, nil
+}
+
+// ImagePrepare implements the ProviderServer interface. It prepares a Proxmox
+// template named req.TargetName from the image source encoded in req.ImageJson,
+// honoring the source kinds in precedence order:
+//
+//  1. source.proxmox.{templateID,templateName}: verify-only. The referenced
+//     template must already exist on the node; if found, success; if missing, an
+//     honest NotFound error. No import.
+//  2. source.http.url: the real import. Requires a non-empty TargetName.
+//     Idempotency-gated: if a template named TargetName already exists, it is a
+//     no-op success; otherwise the image is downloaded into the resolved storage
+//     and prepared as the named template.
+//
+// The import is driven by a PVE task, so the returned TaskResponse carries the
+// task ref when the API reports one (the controller polls it); a verify-only or
+// idempotent no-op returns an empty Task, which the controller treats as
+// "completed synchronously" — consistent with the libvirt and vSphere providers.
+func (p *Provider) ImagePrepare(ctx context.Context, req *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
+	if p.client == nil {
+		return nil, errors.NewUnavailable("PVE client not configured", nil)
+	}
+
+	targetName := strings.TrimSpace(req.GetTargetName())
+	src := parseProxmoxImageSource(req.GetImageJson())
+
+	p.logger.Info("ImagePrepare: starting",
+		"target_name", targetName,
+		"has_template_id", src.TemplateID != nil,
+		"has_template_name", src.TemplateName != "",
+		"has_url", src.URL != "",
+		"storage_hint", req.GetStorageHint(),
+	)
+
+	if src.isEmpty() {
+		return nil, errors.NewInvalidSpec(
+			"ImagePrepare requires a Proxmox image source with an existing template " +
+				"(source.proxmox.templateID / source.proxmox.templateName) or an import URL " +
+				"(source.http.url)")
+	}
+
+	node, err := p.resolveImageNode(ctx, src.Node)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify-only path: an existing template is referenced; never import.
+	if src.referencesExistingTemplate() {
+		return p.imagePrepareVerifyTemplate(ctx, node, src)
+	}
+
+	// Import path: source.http.url. A target name is mandatory — never fabricate
+	// one from the URL basename.
+	if targetName == "" {
+		return nil, errors.NewInvalidSpec(
+			"ImagePrepare target name is required when importing from a URL (source.http.url)")
+	}
+	return p.imagePrepareImport(ctx, node, targetName, src, req.GetStorageHint())
+}
+
+// imagePrepareVerifyTemplate implements the existing-template source: the
+// referenced template (by VMID or name) must already exist on the node and be a
+// template (template=1). On success the prepared image is the template itself, so
+// no import is performed. A missing template yields an honest NotFound rather than
+// a fabricated success.
+func (p *Provider) imagePrepareVerifyTemplate(ctx context.Context, node string, src proxmoxImageSource) (*providerv1.TaskResponse, error) {
+	// By VMID: a direct GetVM is cheaper and unambiguous.
+	if src.TemplateID != nil {
+		vmid := *src.TemplateID
+		vm, err := p.client.GetVM(ctx, node, vmid)
+		if err != nil {
+			if err == pveapi.ErrVMNotFound {
+				return nil, errors.NewNotFound("Proxmox template", fmt.Sprintf("%d", vmid))
+			}
+			return nil, errors.NewInternal(fmt.Sprintf("ImagePrepare: look up template %d on node %q", vmid, node), err)
+		}
+		if vm.Template != proxmoxTemplateFlag {
+			return nil, errors.NewInvalidSpec(
+				"ImagePrepare: VM %d on node %q exists but is not a template", vmid, node)
+		}
+		p.logger.Info("ImagePrepare: template exists; nothing to import",
+			"node", node, "template_id", vmid, "name", vm.Name)
+		return &providerv1.TaskResponse{}, nil
+	}
+
+	// By name: list templates on the node and match.
+	name := strings.TrimSpace(src.TemplateName)
+	vm, err := p.findTemplateByName(ctx, node, name)
+	if err != nil {
+		return nil, err
+	}
+	if vm == nil {
+		return nil, errors.NewNotFound("Proxmox template", name)
+	}
+	p.logger.Info("ImagePrepare: template exists; nothing to import",
+		"node", node, "template_name", name, "template_id", vm.VMID)
+	return &providerv1.TaskResponse{}, nil
+}
+
+// findTemplateByName returns the template VM matching name on the node, or nil if
+// none is found. Only VMs flagged as templates (template=1) are considered, so a
+// running VM that merely shares the name does not satisfy a template reference.
+func (p *Provider) findTemplateByName(ctx context.Context, node, name string) (*pveapi.VM, error) {
+	vms, err := p.client.ListVMs(ctx, node)
+	if err != nil {
+		return nil, errors.NewInternal(fmt.Sprintf("ImagePrepare: list VMs on node %q", node), err)
+	}
+	for _, vm := range vms {
+		if vm == nil {
+			continue
+		}
+		if vm.Name == name && vm.Template == proxmoxTemplateFlag {
+			return vm, nil
+		}
+	}
+	return nil, nil
+}
+
+// imagePrepareImport implements the source.http.url import path. It is
+// idempotency-gated first: if a template named targetName already exists on the
+// node, it returns success without importing. Otherwise it resolves the target
+// storage and asks PVE to download/convert the image into a template named
+// targetName.
+func (p *Provider) imagePrepareImport(ctx context.Context, node, targetName string, src proxmoxImageSource, storageHint string) (*providerv1.TaskResponse, error) {
+	// Idempotency gate (load-bearing): a re-run must never re-import. If a template
+	// named targetName already exists on the node, we are done.
+	existing, err := p.findTemplateByName(ctx, node, targetName)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		p.logger.Info("ImagePrepare: target template already exists; nothing to do",
+			"node", node, "target_name", targetName, "template_id", existing.VMID)
+		return &providerv1.TaskResponse{}, nil
+	}
+
+	storage := resolveImageStorage(storageHint, src.Storage)
+	format := strings.TrimSpace(src.Format)
+	if format == "" {
+		format = defaultProxmoxImageFormat
+	}
+
+	p.logger.Info("ImagePrepare: importing image into template",
+		"node", node, "target_name", targetName, "storage", storage,
+		"format", format, "url", src.URL)
+
+	taskID, err := p.client.PrepareImage(ctx, node, storage, src.URL, targetName, format)
+	if err != nil {
+		return nil, errors.NewInternal(
+			fmt.Sprintf("ImagePrepare: import image %q as template %q", src.URL, targetName), err)
+	}
+
+	result := &providerv1.TaskResponse{}
+	if taskID != "" {
+		result.Task = &providerv1.TaskRef{Id: taskID}
+	}
+	return result, nil
+}
+
+// Compile-time assertion that the v1beta1 image source shape this provider parses
+// stays in sync with the API: if ProxmoxImageSource loses one of these fields,
+// the build breaks here, prompting parseProxmoxImageSource to be revisited.
+var _ = func() v1beta1.ProxmoxImageSource {
+	return v1beta1.ProxmoxImageSource{
+		TemplateID:   nil,
+		TemplateName: "",
+		Storage:      "",
+		Node:         "",
+		Format:       "",
+		FullClone:    nil,
+	}
+}

--- a/internal/providers/proxmox/image_test.go
+++ b/internal/providers/proxmox/image_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+)
+
+// TestParseProxmoxImageSource_RichProxmox verifies the rich v1beta1.VMImageSpec
+// shape (nested source.proxmox) is parsed including the Proxmox-native fields that
+// only this shape can express.
+func TestParseProxmoxImageSource_RichProxmox(t *testing.T) {
+	imageJSON := `{
+		"source": {
+			"proxmox": {
+				"templateID": 9001,
+				"templateName": "rocky-9-template",
+				"storage": "vms",
+				"node": "pve2",
+				"format": "raw"
+			}
+		}
+	}`
+
+	src := parseProxmoxImageSource(imageJSON)
+
+	require.NotNil(t, src.TemplateID)
+	assert.Equal(t, 9001, *src.TemplateID)
+	assert.Equal(t, "rocky-9-template", src.TemplateName)
+	assert.Equal(t, "vms", src.Storage)
+	assert.Equal(t, "pve2", src.Node)
+	assert.Equal(t, "raw", src.Format)
+	assert.Equal(t, "", src.URL)
+	assert.True(t, src.referencesExistingTemplate())
+	assert.False(t, src.isEmpty())
+}
+
+// TestParseProxmoxImageSource_HTTP verifies the generic source.http.url import
+// shape is parsed.
+func TestParseProxmoxImageSource_HTTP(t *testing.T) {
+	imageJSON := `{"source":{"http":{"url":"https://images.example.com/jammy.img"}}}`
+
+	src := parseProxmoxImageSource(imageJSON)
+
+	assert.Equal(t, "https://images.example.com/jammy.img", src.URL)
+	assert.Nil(t, src.TemplateID)
+	assert.Equal(t, "", src.TemplateName)
+	assert.False(t, src.referencesExistingTemplate())
+	assert.False(t, src.isEmpty())
+}
+
+// TestParseProxmoxImageSource_ProxmoxWinsOverHTTP verifies that when both a
+// source.proxmox existing-template reference and a source.http import URL appear,
+// the existing-template reference takes precedence (verify-only beats import).
+func TestParseProxmoxImageSource_ProxmoxWinsOverHTTP(t *testing.T) {
+	imageJSON := `{
+		"source": {
+			"proxmox": {"templateName": "base"},
+			"http": {"url": "https://images.example.com/jammy.img"}
+		}
+	}`
+
+	src := parseProxmoxImageSource(imageJSON)
+
+	assert.Equal(t, "base", src.TemplateName)
+	assert.True(t, src.referencesExistingTemplate())
+	// The URL is still captured; the caller's precedence (referencesExistingTemplate
+	// first) is what makes this verify-only.
+	assert.Equal(t, "https://images.example.com/jammy.img", src.URL)
+}
+
+// TestParseProxmoxImageSource_FlatContractsVMImage verifies the fallback flat
+// contracts.VMImage shape (Go field names) is parsed when no nested source is
+// present. This is the shape Create already round-trips.
+func TestParseProxmoxImageSource_FlatContractsVMImage(t *testing.T) {
+	img := contracts.VMImage{
+		TemplateName: "win2022-template",
+		Format:       "qcow2",
+	}
+	raw, err := json.Marshal(img)
+	require.NoError(t, err)
+
+	src := parseProxmoxImageSource(string(raw))
+
+	assert.Equal(t, "win2022-template", src.TemplateName)
+	assert.Equal(t, "qcow2", src.Format)
+	assert.True(t, src.referencesExistingTemplate())
+}
+
+// TestParseProxmoxImageSource_FlatContractsURL verifies the flat shape's URL field
+// is treated as an import source.
+func TestParseProxmoxImageSource_FlatContractsURL(t *testing.T) {
+	img := contracts.VMImage{
+		URL:    "https://images.example.com/debian.img",
+		Format: "qcow2",
+	}
+	raw, err := json.Marshal(img)
+	require.NoError(t, err)
+
+	src := parseProxmoxImageSource(string(raw))
+
+	assert.Equal(t, "https://images.example.com/debian.img", src.URL)
+	assert.False(t, src.referencesExistingTemplate())
+	assert.False(t, src.isEmpty())
+}
+
+// TestParseProxmoxImageSource_Empty verifies that empty, malformed, or
+// source-less specs yield an empty source so the caller can return InvalidSpec.
+func TestParseProxmoxImageSource_Empty(t *testing.T) {
+	cases := map[string]string{
+		"empty string":     "",
+		"whitespace":       "   ",
+		"empty object":     "{}",
+		"empty source":     `{"source":{}}`,
+		"empty proxmox":    `{"source":{"proxmox":{}}}`,
+		"unrelated source": `{"source":{"registry":{"image":"foo:bar"}}}`,
+		"malformed json":   `{"source":`,
+	}
+	for name, imageJSON := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := parseProxmoxImageSource(imageJSON)
+			assert.True(t, src.isEmpty(), "expected empty source for %q", imageJSON)
+		})
+	}
+}
+
+// TestResolveImageStorage verifies the hint > source > default precedence.
+func TestResolveImageStorage(t *testing.T) {
+	assert.Equal(t, "hint", resolveImageStorage("hint", "src"))
+	assert.Equal(t, "src", resolveImageStorage("", "src"))
+	assert.Equal(t, "src", resolveImageStorage("   ", "src"))
+	assert.Equal(t, defaultProxmoxStorage, resolveImageStorage("", ""))
+	assert.Equal(t, defaultProxmoxStorage, resolveImageStorage("  ", "  "))
+}

--- a/internal/providers/proxmox/provider_test.go
+++ b/internal/providers/proxmox/provider_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/projectbeskar/virtrigaud/internal/providers/proxmox/pveapi"
 	"github.com/projectbeskar/virtrigaud/internal/providers/proxmox/pvefake"
@@ -358,45 +360,222 @@ func TestProxmoxProvider_Snapshots(t *testing.T) {
 	}
 }
 
-func TestProxmoxProvider_ImagePrepare(t *testing.T) {
-	// Start fake PVE server
-	_, endpoint, err := pvefake.StartFakeServer()
+// imagePrepareGRPCCode extracts the gRPC status code from an ImagePrepare error,
+// which the provider returns as an *errors.ProviderError (a gRPC status).
+func imagePrepareGRPCCode(t *testing.T, err error) codes.Code {
+	t.Helper()
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected a gRPC status error, got %T: %v", err, err)
+	return st.Code()
+}
+
+// TestProxmoxProvider_ImagePrepare_ExistingTemplateByName verifies that a
+// source.proxmox.templateName referencing the seeded template is a no-op success
+// (verify-only, no import, no task).
+func TestProxmoxProvider_ImagePrepare_ExistingTemplateByName(t *testing.T) {
+	server, endpoint, err := pvefake.StartFakeServer()
 	require.NoError(t, err)
-
-	// Create provider with fake server
 	provider := createTestProvider(endpoint)
-
 	ctx := context.Background()
 
-	// Test template ensure (existing template)
-	imagePrepareReq := &providerv1.ImagePrepareRequest{
-		ImageJson:   `{"name": "ubuntu-22-template"}`,
-		StorageHint: "local-lvm",
-	}
-
-	imagePrepareResp, err := provider.ImagePrepare(ctx, imagePrepareReq)
+	// ubuntu-22-template (VMID 9000, template=1) is seeded by the fake server.
+	resp, err := provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"proxmox":{"templateName":"ubuntu-22-template"}}}`,
+		TargetName: "ubuntu-22-template",
+	})
 	require.NoError(t, err)
+	assert.Nil(t, resp.Task, "verify-only must not return a task")
+	assert.Nil(t, server.LastDownloadRequest(), "verify-only must not trigger a download")
+}
 
-	// Wait for task if any
-	if imagePrepareResp.Task != nil {
-		err = waitForTask(ctx, provider, imagePrepareResp.Task.Id)
-		require.NoError(t, err)
-	}
-
-	// Test image import from URL
-	imagePrepareReq = &providerv1.ImagePrepareRequest{
-		ImageJson:   `{"source": {"url": "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"}}`,
-		StorageHint: "local-lvm",
-	}
-
-	imagePrepareResp, err = provider.ImagePrepare(ctx, imagePrepareReq)
+// TestProxmoxProvider_ImagePrepare_ExistingTemplateByID verifies that a
+// source.proxmox.templateID referencing the seeded template is a no-op success.
+func TestProxmoxProvider_ImagePrepare_ExistingTemplateByID(t *testing.T) {
+	server, endpoint, err := pvefake.StartFakeServer()
 	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
 
-	// Wait for import task
-	if imagePrepareResp.Task != nil {
-		err = waitForTask(ctx, provider, imagePrepareResp.Task.Id)
+	resp, err := provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"proxmox":{"templateID":9000}}}`,
+		TargetName: "ubuntu-22-template",
+	})
+	require.NoError(t, err)
+	assert.Nil(t, resp.Task)
+	assert.Nil(t, server.LastDownloadRequest())
+}
+
+// TestProxmoxProvider_ImagePrepare_MissingTemplateName verifies that referencing a
+// non-existent template by name returns an honest NotFound rather than a
+// fabricated success.
+func TestProxmoxProvider_ImagePrepare_MissingTemplateName(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	_, err = provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"proxmox":{"templateName":"does-not-exist"}}}`,
+		TargetName: "does-not-exist",
+	})
+	assert.Equal(t, codes.NotFound, imagePrepareGRPCCode(t, err))
+}
+
+// TestProxmoxProvider_ImagePrepare_MissingTemplateID verifies that referencing a
+// non-existent template by VMID returns NotFound.
+func TestProxmoxProvider_ImagePrepare_MissingTemplateID(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	_, err = provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"proxmox":{"templateID":424242}}}`,
+		TargetName: "missing",
+	})
+	assert.Equal(t, codes.NotFound, imagePrepareGRPCCode(t, err))
+}
+
+// TestProxmoxProvider_ImagePrepare_ImportFromURL verifies the source.http.url
+// import path issues the expected PVE download-url call with the target_name,
+// resolved storage, and content=import propagated.
+func TestProxmoxProvider_ImagePrepare_ImportFromURL(t *testing.T) {
+	server, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	const imgURL = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+	resp, err := provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+		ImageJson:   `{"source":{"http":{"url":"` + imgURL + `"}}}`,
+		TargetName:  "jammy-base",
+		StorageHint: "local-lvm",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Task, "import must return a task to poll")
+
+	dl := server.LastDownloadRequest()
+	require.NotNil(t, dl, "import must POST a download-url request")
+	assert.Equal(t, "pve", dl.Node)
+	assert.Equal(t, "local-lvm", dl.Storage)
+	assert.Equal(t, "import", dl.Content, "cloud image is imported as a disk, not an ISO")
+	assert.Equal(t, "jammy-base.qcow2", dl.Filename, "filename derives from target_name + format")
+	assert.Equal(t, imgURL, dl.URL)
+
+	err = waitForTask(ctx, provider, resp.Task.Id)
+	require.NoError(t, err)
+}
+
+// TestProxmoxProvider_ImagePrepare_StoragePrecedence verifies storage resolution:
+// the request StorageHint wins over source.proxmox.storage, which wins over the
+// local-lvm default.
+func TestProxmoxProvider_ImagePrepare_StoragePrecedence(t *testing.T) {
+	ctx := context.Background()
+	const imgURL = "https://images.example.com/base.img"
+
+	t.Run("hint wins over source storage", func(t *testing.T) {
+		server, endpoint, err := pvefake.StartFakeServer()
 		require.NoError(t, err)
+		provider := createTestProvider(endpoint)
+
+		_, err = provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+			ImageJson:   `{"source":{"proxmox":{"storage":"src-store"},"http":{"url":"` + imgURL + `"}}}`,
+			TargetName:  "p1",
+			StorageHint: "hint-store",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, server.LastDownloadRequest())
+		assert.Equal(t, "hint-store", server.LastDownloadRequest().Storage)
+	})
+
+	t.Run("source storage wins over default", func(t *testing.T) {
+		server, endpoint, err := pvefake.StartFakeServer()
+		require.NoError(t, err)
+		provider := createTestProvider(endpoint)
+
+		_, err = provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+			ImageJson:  `{"source":{"proxmox":{"storage":"src-store"},"http":{"url":"` + imgURL + `"}}}`,
+			TargetName: "p2",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, server.LastDownloadRequest())
+		assert.Equal(t, "src-store", server.LastDownloadRequest().Storage)
+	})
+
+	t.Run("default when neither set", func(t *testing.T) {
+		server, endpoint, err := pvefake.StartFakeServer()
+		require.NoError(t, err)
+		provider := createTestProvider(endpoint)
+
+		_, err = provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+			ImageJson:  `{"source":{"http":{"url":"` + imgURL + `"}}}`,
+			TargetName: "p3",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, server.LastDownloadRequest())
+		assert.Equal(t, "local-lvm", server.LastDownloadRequest().Storage)
+	})
+}
+
+// TestProxmoxProvider_ImagePrepare_ImportRequiresTargetName verifies the import
+// path refuses to fabricate a name from the URL when target_name is empty.
+func TestProxmoxProvider_ImagePrepare_ImportRequiresTargetName(t *testing.T) {
+	server, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	_, err = provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"http":{"url":"https://images.example.com/base.img"}}}`,
+		TargetName: "",
+	})
+	assert.Equal(t, codes.InvalidArgument, imagePrepareGRPCCode(t, err))
+	assert.Nil(t, server.LastDownloadRequest(), "no download without a target name")
+}
+
+// TestProxmoxProvider_ImagePrepare_EmptySource verifies that an empty or
+// source-less spec yields InvalidSpec rather than a fabricated success.
+func TestProxmoxProvider_ImagePrepare_EmptySource(t *testing.T) {
+	server, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	for name, imageJSON := range map[string]string{
+		"empty json":       ``,
+		"empty object":     `{}`,
+		"empty source":     `{"source":{}}`,
+		"unrelated source": `{"source":{"registry":{"image":"foo:bar"}}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+				ImageJson:  imageJSON,
+				TargetName: "whatever",
+			})
+			assert.Equal(t, codes.InvalidArgument, imagePrepareGRPCCode(t, err))
+		})
 	}
+	assert.Nil(t, server.LastDownloadRequest())
+}
+
+// TestProxmoxProvider_ImagePrepare_Idempotent verifies that importing to a
+// target_name that already exists as a template is a no-op success (no download).
+func TestProxmoxProvider_ImagePrepare_Idempotent(t *testing.T) {
+	server, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	// ubuntu-22-template already exists as a template in the seed data; importing
+	// to that name must skip the download entirely.
+	resp, err := provider.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+		ImageJson:  `{"source":{"http":{"url":"https://images.example.com/base.img"}}}`,
+		TargetName: "ubuntu-22-template",
+	})
+	require.NoError(t, err)
+	assert.Nil(t, resp.Task, "idempotent no-op must not return a task")
+	assert.Nil(t, server.LastDownloadRequest(), "idempotent no-op must not download")
 }
 
 func TestProxmoxProvider_MultiNIC(t *testing.T) {

--- a/internal/providers/proxmox/pveapi/client.go
+++ b/internal/providers/proxmox/pveapi/client.go
@@ -918,58 +918,62 @@ func (c *Client) ListSnapshots(ctx context.Context, node string, vmid int) ([]*S
 	return snapshots, nil
 }
 
-// PrepareImage ensures a template/image exists, importing if necessary
-func (c *Client) PrepareImage(ctx context.Context, node, storage, imageURL, templateName string) (string, error) {
-	// First check if template already exists
-	if templateName != "" {
-		// Try to find existing template by name
-		path := fmt.Sprintf("/api2/json/nodes/%s/qemu", node)
-		resp, err := c.request(ctx, "GET", path, nil)
-		if err == nil {
-			defer resp.Body.Close() //nolint:errcheck // Response body close in defer is not critical
-			if resp.StatusCode == 200 {
-				var apiResp APIResponse
-				// Decode response for debugging - errors intentionally ignored
-				_ = json.NewDecoder(resp.Body).Decode(&apiResp) // best effort decode for debug info
-			}
-		}
+// PrepareImage downloads a disk image from imageURL into the given storage on a
+// node, named after templateName, returning the PVE task UPID that tracks the
+// transfer.
+//
+// It POSTs to the storage download-url endpoint with content=import: an importable
+// disk image (a cloud image that becomes a VM disk and, later, a template) is NOT
+// an ISO, so content=iso would be wrong and place it under the ISO content type.
+// The filename is derived from templateName and the requested format so the
+// resulting volume is addressable as the prepared template's backing disk; the
+// format hint lets PVE select the on-disk representation (qcow2/raw/vmdk).
+//
+// Idempotency (skip-if-template-exists) and the subsequent "convert imported disk
+// into a template VM" step are handled provider-side (see image.go); this client
+// call is the thin, correct transport for the download/import itself.
+func (c *Client) PrepareImage(ctx context.Context, node, storage, imageURL, templateName, format string) (string, error) {
+	if imageURL == "" {
+		// Nothing to import (verify-only paths never reach here); treat as a
+		// completed no-op so callers don't fabricate a task.
+		return "", nil
 	}
 
-	// If imageURL provided, simulate download/import
-	if imageURL != "" {
-		// In real implementation, this would:
-		// 1. Download the image to storage
-		// 2. Create VM from image
-		// 3. Convert to template
-		path := fmt.Sprintf("/api2/json/nodes/%s/storage/%s/download-url", node, storage)
-
-		values := url.Values{}
-		values.Set("content", "iso")
-		values.Set("filename", "imported-image.qcow2")
-		values.Set("url", imageURL)
-
-		resp, err := c.request(ctx, "POST", path, values)
-		if err != nil {
-			return "", fmt.Errorf("failed to import image: %w", err)
-		}
-		defer resp.Body.Close() //nolint:errcheck // Response body close in defer is not critical
-
-		if resp.StatusCode != 200 {
-			body, _ := io.ReadAll(resp.Body)
-			return "", fmt.Errorf("image import failed with status %d: %s", resp.StatusCode, string(body))
-		}
-
-		var apiResp APIResponse
-		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
-			return "", fmt.Errorf("failed to decode response: %w", err)
-		}
-
-		if taskID, ok := apiResp.Data.(string); ok {
-			return taskID, nil
-		}
+	if format == "" {
+		format = "qcow2"
 	}
 
-	return "", nil // Template already exists or operation completed
+	path := fmt.Sprintf("/api2/json/nodes/%s/storage/%s/download-url", node, storage)
+
+	values := url.Values{}
+	// content=import: PVE places the downloaded disk under the "import" content
+	// type so it can be attached to a VM and converted to a template — unlike
+	// content=iso, which is for installer media.
+	values.Set("content", "import")
+	values.Set("filename", fmt.Sprintf("%s.%s", templateName, format))
+	values.Set("url", imageURL)
+
+	resp, err := c.request(ctx, "POST", path, values)
+	if err != nil {
+		return "", fmt.Errorf("failed to import image: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // Response body close in defer is not critical
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("image import failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var apiResp APIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if taskID, ok := apiResp.Data.(string); ok {
+		return taskID, nil
+	}
+
+	return "", nil
 }
 
 // GetVMConfig retrieves VM configuration

--- a/internal/providers/proxmox/pvefake/server.go
+++ b/internal/providers/proxmox/pvefake/server.go
@@ -34,13 +34,33 @@ import (
 
 // Server represents a fake Proxmox VE API server
 type Server struct {
-	router    *mux.Router
-	vms       map[int]*VM
-	tasks     map[string]*Task
-	snapshots map[string][]*Snapshot
-	mu        sync.RWMutex
-	logger    *slog.Logger
-	config    *Config
+	router       *mux.Router
+	vms          map[int]*VM
+	tasks        map[string]*Task
+	snapshots    map[string][]*Snapshot
+	lastDownload *DownloadRequest
+	mu           sync.RWMutex
+	logger       *slog.Logger
+	config       *Config
+}
+
+// DownloadRequest records the parameters of the most recent storage download-url
+// request so ImagePrepare tests can assert node/storage/content/filename/url
+// propagation.
+type DownloadRequest struct {
+	Node     string
+	Storage  string
+	Content  string
+	Filename string
+	URL      string
+}
+
+// LastDownloadRequest returns the most recent storage download-url request seen
+// by the fake server, or nil if none has occurred. Safe for concurrent use.
+func (s *Server) LastDownloadRequest() *DownloadRequest {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastDownload
 }
 
 // Config holds fake server configuration
@@ -153,6 +173,7 @@ func (s *Server) setupRoutes() {
 
 	// VM operations
 	api.HandleFunc("/nodes/{node}/qemu", s.handleCreateVM).Methods("POST")
+	api.HandleFunc("/nodes/{node}/qemu", s.handleListVMs).Methods("GET")
 	api.HandleFunc("/nodes/{node}/qemu/{vmid}", s.handleDeleteVM).Methods("DELETE")
 	api.HandleFunc("/nodes/{node}/qemu/{vmid}/status/current", s.handleGetVM).Methods("GET")
 	api.HandleFunc("/nodes/{node}/qemu/{vmid}/config", s.handleGetVMConfig).Methods("GET")
@@ -164,6 +185,9 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/nodes/{node}/qemu/{vmid}/status/start", s.handlePowerOp("start")).Methods("POST")
 	api.HandleFunc("/nodes/{node}/qemu/{vmid}/status/stop", s.handlePowerOp("stop")).Methods("POST")
 	api.HandleFunc("/nodes/{node}/qemu/{vmid}/status/reboot", s.handlePowerOp("reboot")).Methods("POST")
+
+	// Storage operations
+	api.HandleFunc("/nodes/{node}/storage/{storage}/download-url", s.handleDownloadURL).Methods("POST")
 
 	// Task operations
 	api.HandleFunc("/nodes/{node}/tasks/{taskid}/status", s.handleGetTaskStatus).Methods("GET")
@@ -295,6 +319,53 @@ func (s *Server) handleCreateVM(w http.ResponseWriter, r *http.Request) {
 
 	// Create async task
 	taskID := s.createTask(node, "qmcreate", strconv.Itoa(vmid))
+
+	s.writeResponse(w, taskID)
+}
+
+// handleListVMs handles listing VMs on a node (GET /nodes/{node}/qemu). It
+// returns all seeded/created VMs, including templates, so ImagePrepare's
+// verify-by-name and idempotency probes can find them.
+func (s *Server) handleListVMs(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	node := vars["node"]
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	list := make([]*VM, 0, len(s.vms))
+	for _, vm := range s.vms {
+		if vm.Node == "" || vm.Node == node {
+			list = append(list, vm)
+		}
+	}
+
+	s.writeResponse(w, list)
+}
+
+// handleDownloadURL handles the storage download-url import endpoint used by
+// ImagePrepare. It records the request parameters for later assertion and returns
+// an async task, mirroring PVE's behavior for a long-running download.
+func (s *Server) handleDownloadURL(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	node := vars["node"]
+	storage := vars["storage"]
+
+	if err := r.ParseForm(); err != nil {
+		s.writeError(w, http.StatusBadRequest, "Invalid form data")
+		return
+	}
+
+	s.mu.Lock()
+	s.lastDownload = &DownloadRequest{
+		Node:     node,
+		Storage:  storage,
+		Content:  r.FormValue("content"),
+		Filename: r.FormValue("filename"),
+		URL:      r.FormValue("url"),
+	}
+	taskID := s.createTask(node, "download", storage)
+	s.mu.Unlock()
 
 	s.writeResponse(w, taskID)
 }

--- a/internal/providers/proxmox/server.go
+++ b/internal/providers/proxmox/server.go
@@ -781,66 +781,8 @@ func (p *Provider) Clone(ctx context.Context, req *providerv1.CloneRequest) (*pr
 	return result, nil
 }
 
-// ImagePrepare prepares an image for use
-func (p *Provider) ImagePrepare(ctx context.Context, req *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
-	if p.client == nil {
-		return nil, errors.NewUnavailable("PVE client not configured", nil)
-	}
-
-	// Find appropriate node and storage
-	node, err := p.client.FindNode(ctx)
-	if err != nil {
-		return nil, errors.NewInternal("failed to find node", err)
-	}
-
-	// Default storage - could be made configurable
-	storage := "local-lvm"
-	if req.StorageHint != "" {
-		storage = req.StorageHint
-	}
-
-	// Determine if we need to import or just ensure template exists
-	templateName := ""
-	imageURL := ""
-
-	if req.ImageJson != "" {
-		// Parse JSON-encoded VMImage spec to determine template name or URL
-		var imageSpec map[string]interface{}
-		if err := json.Unmarshal([]byte(req.ImageJson), &imageSpec); err != nil {
-			return nil, errors.NewInvalidSpec("failed to parse image JSON: %v", err)
-		}
-
-		// Extract image source information
-		if source, ok := imageSpec["source"].(map[string]interface{}); ok {
-			if httpSource, ok := source["http"].(map[string]interface{}); ok {
-				if url, ok := httpSource["url"].(string); ok {
-					imageURL = url
-					// Generate template name from URL
-					parts := strings.Split(url, "/")
-					if len(parts) > 0 {
-						templateName = strings.TrimSuffix(parts[len(parts)-1], ".qcow2")
-						templateName = strings.TrimSuffix(templateName, ".ova")
-					}
-				}
-			} else if templateRef, ok := source["template"].(string); ok {
-				templateName = templateRef
-			}
-		}
-	}
-
-	// Prepare the image/template
-	taskID, err := p.client.PrepareImage(ctx, node, storage, imageURL, templateName)
-	if err != nil {
-		return nil, errors.NewInternal("failed to prepare image", err)
-	}
-
-	result := &providerv1.TaskResponse{}
-	if taskID != "" {
-		result.Task = &providerv1.TaskRef{Id: taskID}
-	}
-
-	return result, nil
-}
+// ImagePrepare is implemented in image.go (structured source parsing, target_name
+// handling, idempotency, and the verify-vs-import precedence).
 
 // GetCapabilities returns the provider's capabilities
 func (p *Provider) GetCapabilities(ctx context.Context, req *providerv1.GetCapabilitiesRequest) (*providerv1.GetCapabilitiesResponse, error) {


### PR DESCRIPTION
## What

**PR-3 of the image-prepare vertical slice (#154).** Audits + tightens the Proxmox `ImagePrepare` so it honors the gRPC contract consistently with the merged libvirt (PR-1) and vSphere (PR-2) implementations — readying all three providers for the PR-5 controller wiring.

The Proxmox impl was the only one already "implemented", but loosely:
- **ignored `req.TargetName`** (fabricated a name from the URL basename),
- parsed **non-CRD shapes** (`source.template`, untyped `map[string]interface{}`) instead of `source.proxmox.*`,
- hardcoded `local-lvm`, no idempotency,
- and the existing test asserted on shapes (`{"name": …}`) that don't match real `VMImageSpec` serialization.

### Now
- **Honors `req.TargetName`** as the template name.
- **Structured parsing** (`parseProxmoxImageSource`) of the real shapes: `source.proxmox.{templateID,templateName,storage,node,format}` + `source.http.url`, with a flat `contracts.VMImage` fallback. Empty/unparseable → `InvalidSpec` (never fabricated success).
- **Existing-template refs** (`templateID`/`templateName`) → **verify-only** (must exist and be `template=1`): success if found, honest `NotFound` if missing, no import.
- **URL import** requires a non-empty `target_name`; **idempotency-gated** (existing target template → no-op). Storage precedence `StorageHint → source.proxmox.storage → local-lvm`; node `source.proxmox.node → FindNode`.
- `pveapi.PrepareImage`: `content=import` (a cloud image becomes a VM disk → template, not an ISO) + `filename=<target>.<format>`, replacing the hardcoded `content=iso` / `imported-image.qcow2`.

`SupportsImageImport` stays `true` — now contract-correct (no CRD/proto/capability change).

## Verification

- `make fmt` clean · `make lint` / `golangci-lint ./internal/providers/proxmox/...` **0 issues** · `make test` / `go test ./internal/providers/proxmox/...` pass · `make build` OK · no generated drift.
- Tests rewritten to the **real** shapes + new cases (verify-by-name/ID, `NotFound`, URL import asserting the PVE `download-url` call via the fake server, storage precedence, missing-target-name, empty-source, idempotency) + host-independent parser unit tests.

## Honest caveats (no live PVE)

- **No real Proxmox lab** — validated via unit tests + the in-repo fake PVE server. The `content=import` content type and the `download-url` call are asserted at the call level, not against a live PVE 8.x cluster.
- **Promotion not fully wired**: this client call performs the disk **download/import** and returns the PVE task. The full **imported-disk → attach-to-VM → `qm template`** promotion is a follow-up (the controller polls the task in PR-5; a live PVE pass is owed before GA). Scoped per "audit/tighten, not rebuild".

Part of #154.
