### PR TITLE
feat(transport): contracts.ImagePreparer + gRPC client PrepareImage (#154, PR-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-08 11:25] - Manager transport: contracts.ImagePreparer + gRPC client PrepareImage (#154)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/contracts/image.go` (new): optional `ImagePreparer` capability mirroring `Cloner` — `ImagePrepareRequest{ImageJSON, TargetName, StorageHint}` → `ImagePrepareResponse{TaskRef}`, with a `PrepareImage` method. Callers type-assert a `Provider` to `ImagePreparer` to invoke a prepare without widening the core `Provider` interface, so in-process providers and fakes that don't support it are unaffected.
+- `internal/transport/grpc/client.go`: `*Client.PrepareImage` implements `ImagePreparer` — calls the provider `ImagePrepare` RPC (5-minute timeout like Create/Clone, `mapGRPCError`, `trackTaskStart` on a returned TaskRef) — plus a compile-time `_ contracts.ImagePreparer = (*Client)(nil)` assertion.
+- `internal/transport/grpc/client_imageprepare_test.go` (new): bufconn tests for request-field forwarding + async TaskRef surfacing, synchronous empty-task, and error mapping.
+
+### Why
+PR-4 of the image-prepare vertical slice (#154). Pure manager-side plumbing so the manager can *call* `ImagePrepare`; no reconcile behavior change yet. The VM/VMImage controller wiring that drives it (the CR-driven E2E) lands in PR-5.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager image; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-08 11:18] - Audit + tighten Proxmox ImagePrepare to honor the contract (#154)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/contracts/image.go
+++ b/internal/providers/contracts/image.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contracts
+
+import "context"
+
+// ImagePrepareRequest contains the information needed to prepare/import a VM
+// image into a provider so it can back subsequent VM creation. It is the
+// manager-side, transport-agnostic mirror of the provider.v1 ImagePrepareRequest
+// message (issue #154).
+type ImagePrepareRequest struct {
+	// ImageJSON is the JSON-encoded VMImage spec describing the image source
+	// (e.g. source.vsphere.ovaURL, source.libvirt.path/url, source.proxmox.*).
+	ImageJSON string
+	// TargetName is the desired name of the prepared template/image on the
+	// provider.
+	TargetName string
+	// StorageHint names the target storage location (vSphere datastore, libvirt
+	// pool, Proxmox storage), or empty to let the provider choose.
+	StorageHint string
+}
+
+// ImagePrepareResponse contains the result of an image-prepare operation.
+type ImagePrepareResponse struct {
+	// TaskRef references an async operation when the prepare is not synchronous;
+	// an empty TaskRef means the operation completed synchronously.
+	TaskRef string
+}
+
+// ImagePreparer is an optional capability of a Provider: it prepares/imports a
+// VM image into the provider (download and/or convert into a template or storage
+// pool) so it can back subsequent VM creation. The manager gRPC client implements
+// it; callers type-assert a Provider to ImagePreparer to invoke a prepare without
+// widening the core Provider interface, so in-process provider implementations and
+// test fakes that do not support it are unaffected (issue #154). This mirrors the
+// Cloner pattern.
+type ImagePreparer interface {
+	// PrepareImage prepares the image described by req into a template/image named
+	// req.TargetName. Returns a TaskRef the caller can poll via IsTaskComplete when
+	// the operation is asynchronous; an empty TaskRef means it completed
+	// synchronously. The operation is idempotent: preparing an image that already
+	// exists is a no-op success.
+	PrepareImage(ctx context.Context, req ImagePrepareRequest) (ImagePrepareResponse, error)
+}

--- a/internal/transport/grpc/client.go
+++ b/internal/transport/grpc/client.go
@@ -41,11 +41,12 @@ import (
 
 // Compile-time assertions that the gRPC Client satisfies the core Provider
 // interface plus the optional capability interfaces it advertises via
-// type-assertion (issues #176, #179).
+// type-assertion (issues #176, #179, #154).
 var (
 	_ contracts.Provider           = (*Client)(nil)
 	_ contracts.CapabilityReporter = (*Client)(nil)
 	_ contracts.Cloner             = (*Client)(nil)
+	_ contracts.ImagePreparer      = (*Client)(nil)
 )
 
 // Client wraps a gRPC provider client and implements the contracts.Provider interface
@@ -485,6 +486,35 @@ func (c *Client) Clone(ctx context.Context, req contracts.CloneRequest) (contrac
 		TargetVmID: resp.TargetVmId,
 	}
 
+	if resp.Task != nil {
+		result.TaskRef = resp.Task.Id
+		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)
+	}
+
+	return result, nil
+}
+
+// PrepareImage implements contracts.ImagePreparer (#154): it prepares/imports a
+// VM image into the provider as a template/image named req.TargetName.
+//
+// Image preparation can be a long-running provider operation (download + convert
+// + register), so it uses the same generous timeout as Create/Clone. When the
+// provider reports a TaskRef the caller polls it via IsTaskComplete; an empty
+// TaskRef means the operation completed synchronously.
+func (c *Client) PrepareImage(ctx context.Context, req contracts.ImagePrepareRequest) (contracts.ImagePrepareResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	resp, err := c.client.ImagePrepare(ctx, &providerv1.ImagePrepareRequest{
+		ImageJson:   req.ImageJSON,
+		TargetName:  req.TargetName,
+		StorageHint: req.StorageHint,
+	})
+	if err != nil {
+		return contracts.ImagePrepareResponse{}, c.mapGRPCError("image prepare", err)
+	}
+
+	result := contracts.ImagePrepareResponse{}
 	if resp.Task != nil {
 		result.TaskRef = resp.Task.Id
 		c.trackTaskStart(resp.Task.Id) // G7.3 (#129)

--- a/internal/transport/grpc/client_imageprepare_test.go
+++ b/internal/transport/grpc/client_imageprepare_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// imagePrepareFakeServer is a minimal ProviderServer whose ImagePrepare is
+// configurable, used to exercise the manager-side Client.PrepareImage transport
+// (#154). It embeds the Unimplemented server so only ImagePrepare needs a body.
+type imagePrepareFakeServer struct {
+	providerv1.UnimplementedProviderServer
+	fn func(ctx context.Context, req *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error)
+}
+
+func (s *imagePrepareFakeServer) ImagePrepare(ctx context.Context, req *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
+	return s.fn(ctx, req)
+}
+
+// TestClient_PrepareImage_AsyncTaskRef verifies the request fields are forwarded
+// and an async TaskRef is surfaced on the contract response.
+func TestClient_PrepareImage_AsyncTaskRef(t *testing.T) {
+	var got *providerv1.ImagePrepareRequest
+	dialer, cleanup := startBufconnServer(t, &imagePrepareFakeServer{
+		fn: func(_ context.Context, req *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
+			got = req
+			return &providerv1.TaskResponse{Task: &providerv1.TaskRef{Id: "task-42"}}, nil
+		},
+	})
+	defer cleanup()
+	cli := newTestClient(t, dialer, "test-imgprep")
+
+	resp, err := cli.PrepareImage(context.Background(), contracts.ImagePrepareRequest{
+		ImageJSON:   `{"source":{"vsphere":{"ovaURL":"http://x/y.ova"}}}`,
+		TargetName:  "ubuntu-tmpl",
+		StorageHint: "datastore1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "task-42", resp.TaskRef)
+
+	// Request fields forwarded verbatim (JSON / Json field-name mapping).
+	require.NotNil(t, got)
+	assert.Equal(t, `{"source":{"vsphere":{"ovaURL":"http://x/y.ova"}}}`, got.GetImageJson())
+	assert.Equal(t, "ubuntu-tmpl", got.GetTargetName())
+	assert.Equal(t, "datastore1", got.GetStorageHint())
+}
+
+// TestClient_PrepareImage_SyncEmptyTask verifies a synchronous provider (nil
+// Task) yields an empty TaskRef, which the controller treats as "completed".
+func TestClient_PrepareImage_SyncEmptyTask(t *testing.T) {
+	dialer, cleanup := startBufconnServer(t, &imagePrepareFakeServer{
+		fn: func(_ context.Context, _ *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
+			return &providerv1.TaskResponse{}, nil
+		},
+	})
+	defer cleanup()
+	cli := newTestClient(t, dialer, "test-imgprep")
+
+	resp, err := cli.PrepareImage(context.Background(), contracts.ImagePrepareRequest{TargetName: "t"})
+	require.NoError(t, err)
+	assert.Empty(t, resp.TaskRef)
+}
+
+// TestClient_PrepareImage_ErrorMapped verifies a provider error is mapped through
+// mapGRPCError rather than leaking the raw gRPC status.
+func TestClient_PrepareImage_ErrorMapped(t *testing.T) {
+	dialer, cleanup := startBufconnServer(t, &imagePrepareFakeServer{
+		fn: func(_ context.Context, _ *providerv1.ImagePrepareRequest) (*providerv1.TaskResponse, error) {
+			return nil, status.Error(codes.InvalidArgument, "bad image spec")
+		},
+	})
+	defer cleanup()
+	cli := newTestClient(t, dialer, "test-imgprep")
+
+	_, err := cli.PrepareImage(context.Background(), contracts.ImagePrepareRequest{TargetName: "t"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad image spec")
+}


### PR DESCRIPTION
## What

**PR-4 of the image-prepare vertical slice (#154).** Pure manager-side plumbing so the manager can finally *call* the provider `ImagePrepare` RPC — the prerequisite for PR-5's controller wiring.

- **`contracts.ImagePreparer`** (new optional capability, mirrors `Cloner`): `ImagePrepareRequest{ImageJSON, TargetName, StorageHint}` → `ImagePrepareResponse{TaskRef}`, with a `PrepareImage` method. Callers type-assert a `Provider` to `ImagePreparer`, so the **core `Provider` interface is not widened** and in-process providers/fakes that don't support it are unaffected.
- **`*grpc.Client.PrepareImage`** implements it — calls the `ImagePrepare` RPC with a 5-minute timeout (like Create/Clone), `mapGRPCError`, and `trackTaskStart` on a returned TaskRef; plus a compile-time `_ contracts.ImagePreparer = (*Client)(nil)` assertion.

No reconcile behavior change yet; no CRD/proto change.

## Verification

- `make fmt` clean · `make lint` 0 issues · `make test` pass · `make build` OK · no generated drift.
- New bufconn tests: request-field forwarding + async TaskRef surfacing, synchronous empty-task → empty TaskRef, and provider error → `mapGRPCError`.

## Scope

Manager transport only. The VM controller `EnsureImageOnProvider` + VMImage status owner (the CR-driven E2E + ADR) land in **PR-5**.

Part of #154.
