### PR TITLE
feat(libvirt): online disk expansion — live blockresize + best-effort guest FS grow (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-09 07:41] - libvirt online disk expansion: live blockresize + best-effort guest FS grow (#201)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/libvirt/disk_expand.go`: online disk-grow path for the libvirt provider. Resolves the primary disk target and current capacity from the live domain (`domblklist` + `domblkinfo`, NOT the `<vmid>-disk` volume-name guess), applies a grow-only/idempotency guard, persists the larger size to the backing volume, runs `virsh blockresize <dom> <target> <n>G` so live QEMU exposes the new size immediately, then best-effort extends the in-guest partition/filesystem via the guest agent (`growpart` → `resize2fs`/`xfs_growfs`).
+- `internal/providers/libvirt/disk_expand_test.go`: host-independent unit tests for target-device parsing, capacity parsing, the grow-only guard, the blockresize size-arg, and the FS-grow command sequence.
+
+### Changed
+- `internal/providers/libvirt/provider_virsh.go`: `Reconfigure` disk block now branches on domain state — running → `growDiskOnline` (live block-device resize is fatal on failure; in-guest FS grow is non-fatal); stopped → existing offline volume resize for next boot. CPU/memory paths unchanged.
+- `internal/providers/libvirt/server.go`: `GetCapabilities` now advertises `SupportsDiskExpansionOnline: true`.
+- `internal/providers/libvirt/server_test.go`: assert the online-disk-expansion capability is advertised.
+
+### Why
+KVM/QEMU supports growing a running VM's block device live via `blockresize`; the provider already resized the qcow2 volume but never told live QEMU or the guest, so the capability flag was honestly understated as `false`.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (libvirt provider image)
+- [ ] Config change only
+- [ ] Documentation only
+
+No CRD or proto change.
+
+### Notes
+Grow-only: shrinks are rejected and resizing to the current size is a no-op (libvirt/qcow2 cannot shrink a live device). The in-guest filesystem grow is best-effort and gated on the QEMU guest agent — without it (or for non-standard partition layouts) the block device is still grown but the operator must finish the FS grow via cloud-init or manually.
+
 ## [2026-06-09 07:35] - ImagePrepare returns the prepared location; Create consumes it (#154, PR-6 / #214)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/disk_expand.go
+++ b/internal/providers/libvirt/disk_expand.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+)
+
+// bytesPerGiB is the number of bytes in one GiB, used to convert the
+// provider-agnostic GiB disk-size contract into byte-accurate comparisons
+// against virsh's domblkinfo Capacity (reported in bytes).
+const bytesPerGiB = int64(1024) * 1024 * 1024
+
+// growThresholdBytes is the minimum delta (in bytes) between the desired and
+// current block-device capacity that justifies a live blockresize. virsh and
+// qcow2 round capacities to alignment boundaries, so a sub-threshold positive
+// delta is treated as "already at target" to keep the operation idempotent and
+// avoid no-op blockresize churn on every reconcile.
+const growThresholdBytes = int64(1024) * 1024 // 1 MiB
+
+// parseDomblklistPrimaryTarget extracts the primary (boot) disk's target device
+// name (e.g. "vda") from `virsh domblklist <dom>` output. It skips the header,
+// separator, and any non-primary devices (cloud-init ISOs, CD-ROMs) using the
+// same heuristics as getDomainDiskPaths so the result is naming-convention
+// agnostic — it relies on the live domain's real block topology, NOT on the
+// fragile "<vmid>-disk" volume-name guess that bit the clone full-path bug
+// (#207).
+//
+// domblklist output looks like:
+//
+//	Target   Source
+//	---------------------------------------------
+//	vda      /var/lib/libvirt/images/vm-foo.qcow2
+//	hda      /var/lib/libvirt/images/vm-foo-cidata.iso
+//
+// The first row whose source is a real disk (not a cloud-init/cdrom ISO) wins.
+func parseDomblklistPrimaryTarget(domblklistStdout string) (string, error) {
+	lines := strings.Split(strings.TrimSpace(domblklistStdout), "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// Skip the header row and the dashed separator.
+		if i == 0 || strings.HasPrefix(trimmed, "-") {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) < 1 {
+			continue
+		}
+		target := fields[0]
+		source := ""
+		if len(fields) >= 2 {
+			source = fields[1]
+		}
+		// Skip devices with no backing source (e.g. an empty CD-ROM shows "-").
+		if source == "" || source == "-" {
+			continue
+		}
+		// Skip cloud-init ISOs / CD-ROMs; mirror getDomainDiskPaths.
+		if strings.HasSuffix(source, "-cidata.iso") || strings.HasSuffix(source, "cloud-init.iso") {
+			continue
+		}
+		return target, nil
+	}
+	return "", fmt.Errorf("no primary disk target found in domblklist output")
+}
+
+// parseDomblkinfoCapacity extracts the "Capacity:" value (in bytes) from
+// `virsh domblkinfo <dom> <target>` output. domblkinfo reports:
+//
+//	Capacity:       10737418240
+//	Allocation:     2147483648
+//	Physical:       2147483648
+//
+// Capacity is the virtual (guest-visible) block size, which is exactly what a
+// grow-only guard must compare against.
+func parseDomblkinfoCapacity(domblkinfoStdout string) (int64, error) {
+	lines := strings.Split(domblkinfoStdout, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "Capacity:") {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) < 2 {
+			return 0, fmt.Errorf("malformed Capacity line in domblkinfo: %q", trimmed)
+		}
+		capBytes, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse domblkinfo Capacity %q: %w", fields[1], err)
+		}
+		return capBytes, nil
+	}
+	return 0, fmt.Errorf("no Capacity line found in domblkinfo output")
+}
+
+// blockresizeSizeArg formats a desired GiB size into the size argument virsh
+// `blockresize` expects. The file's existing convention (ResizeVolume's
+// vol-resize) passes a scaled "<n>G" value, and blockresize accepts the same
+// scaled-suffix form, so we mirror it for consistency. The unsuffixed default
+// for blockresize would be KiB, which is why an explicit "G" suffix is
+// mandatory here.
+func blockresizeSizeArg(desiredGiB int) string {
+	return fmt.Sprintf("%dG", desiredGiB)
+}
+
+// shouldGrowDisk implements the grow-only + idempotency guard. It returns true
+// only when the desired capacity exceeds the current capacity by more than the
+// rounding threshold. libvirt/qcow2 cannot shrink a live block device, so any
+// desired ≤ current request is reported as a no-op (false) and must be skipped
+// by the caller — never attempted as a shrink.
+func shouldGrowDisk(currentBytes, desiredBytes int64) bool {
+	return desiredBytes-currentBytes > growThresholdBytes
+}
+
+// fsGrowCommands returns the best-effort, in-guest filesystem-grow shell
+// commands to run via the guest agent after a live blockresize, given the
+// guest's primary block target (e.g. "vda"). The block device is already
+// larger at the QEMU level; these commands extend the partition table and then
+// the filesystem so the guest actually sees the new space without a reboot.
+//
+// Sequence:
+//  1. growpart /dev/<target> 1 — grow partition 1 to fill the enlarged device
+//     (from cloud-guest-utils; the canonical online partition-grow tool).
+//  2. resize2fs /dev/<target>1 — grow an ext2/3/4 filesystem online.
+//  3. xfs_growfs / — grow an XFS filesystem (XFS grows by mountpoint, not
+//     device); "/" is the overwhelmingly common root mountpoint for the boot
+//     disk this provider manages.
+//
+// We return all three because cheaply detecting the FS type inside the guest is
+// not always reliable; each command is harmless on a mismatched FS (resize2fs
+// refuses a non-ext volume, xfs_growfs refuses a non-XFS mount) and the whole
+// sequence is best-effort: any failure is logged WARN and does NOT fail the
+// reconfigure. The "1" partition assumption matches standard cloud images
+// (single root partition); exotic layouts simply fall back to user/cloud-init
+// completion, which is the documented #201 caveat.
+func fsGrowCommands(target string) []string {
+	dev := "/dev/" + target
+	return []string{
+		fmt.Sprintf("growpart %s 1", dev),
+		fmt.Sprintf("resize2fs %s1", dev),
+		"xfs_growfs /",
+	}
+}
+
+// growDiskOnline grows a running domain's primary disk live. It is the online
+// branch of Reconfigure's disk handling (#201):
+//
+//  1. Resolve the primary disk's target device and current capacity from the
+//     live domain (domblklist + domblkinfo) — NOT from the volume-name guess.
+//  2. Apply the grow-only / idempotency guard.
+//  3. Resize the backing qcow2 volume so the larger size persists across reboot.
+//  4. `virsh blockresize` so live QEMU sees the new block size immediately.
+//  5. Best-effort in-guest filesystem grow via the guest agent (non-fatal).
+//
+// A failure in steps 1–4 is fatal to the disk step and returned to the caller.
+// Step 5 never fails the operation. It returns true when the live block device
+// was actually grown (so the caller can record a change), false when the
+// request was a no-op.
+func (p *Provider) growDiskOnline(ctx context.Context, id string, desiredDiskGB int, sp *StorageProvider) (grew bool, err error) {
+	// Resolve the primary disk target from the live domain topology.
+	blkResult, err := p.virshProvider.runVirshCommand(ctx, "domblklist", id)
+	if err != nil {
+		return false, fmt.Errorf("list block devices for domain %s: %w", id, err)
+	}
+	target, err := parseDomblklistPrimaryTarget(blkResult.Stdout)
+	if err != nil {
+		return false, fmt.Errorf("resolve primary disk target for domain %s: %w", id, err)
+	}
+
+	// Read the current virtual capacity (bytes) for the grow-only guard.
+	infoResult, err := p.virshProvider.runVirshCommand(ctx, "domblkinfo", id, target)
+	if err != nil {
+		return false, fmt.Errorf("read block info for domain %s target %s: %w", id, target, err)
+	}
+	currentBytes, err := parseDomblkinfoCapacity(infoResult.Stdout)
+	if err != nil {
+		return false, fmt.Errorf("parse current capacity for domain %s target %s: %w", id, target, err)
+	}
+
+	desiredBytes := int64(desiredDiskGB) * bytesPerGiB
+	if !shouldGrowDisk(currentBytes, desiredBytes) {
+		// desired ≤ current (or within rounding): no-op. Never shrink live.
+		log.Printf("INFO Disk grow skipped for domain %s target %s: desired %d bytes ≤ current %d bytes (grow-only)",
+			id, target, desiredBytes, currentBytes)
+		return false, nil
+	}
+
+	log.Printf("INFO Growing disk for running domain %s target %s: %d bytes -> %d bytes (%dGB)",
+		id, target, currentBytes, desiredBytes, desiredDiskGB)
+
+	// Persist the larger size to the backing volume first so the size survives a
+	// reboot and the qcow2 file is large enough for blockresize to expose. This
+	// uses the existing best-effort volume convention; if it fails we still try
+	// blockresize, but log the volume failure. ResizeVolume is grow-only-safe
+	// for files (qemu-img/vol-resize grows the file).
+	if verr := sp.ResizeVolume(ctx, clonePoolName, fmt.Sprintf("%s-disk", id), desiredDiskGB); verr != nil {
+		log.Printf("WARN Backing volume resize for domain %s did not apply (continuing to blockresize): %v", id, verr)
+	}
+
+	// Grow the live block device so QEMU exposes the new size to the guest.
+	if _, rerr := p.virshProvider.runVirshCommand(ctx, "blockresize", id, target, blockresizeSizeArg(desiredDiskGB)); rerr != nil {
+		return false, fmt.Errorf("blockresize domain %s target %s to %dGB: %w", id, target, desiredDiskGB, rerr)
+	}
+	log.Printf("INFO Successfully grew live block device for domain %s target %s to %dGB", id, target, desiredDiskGB)
+
+	// Best-effort in-guest filesystem grow. Non-fatal: the block device is
+	// already larger, and cloud-init / a user can finish the FS grow. Gated on
+	// guest-agent availability (#201).
+	p.growGuestFilesystemBestEffort(ctx, id, target)
+
+	return true, nil
+}
+
+// growGuestFilesystemBestEffort attempts to extend the in-guest partition and
+// filesystem after a live blockresize. It is entirely best-effort: it requires
+// the QEMU guest agent, and every command failure is logged WARN and swallowed
+// so it never fails the surrounding Reconfigure. This is the documented #201
+// caveat — without the guest agent (or for exotic partition layouts) the
+// operator must finish the FS grow via cloud-init or manually.
+func (p *Provider) growGuestFilesystemBestEffort(ctx context.Context, id, target string) {
+	ga := NewGuestAgentProvider(p.virshProvider)
+	if !ga.isGuestAgentAvailable(ctx, id) {
+		log.Printf("WARN In-guest filesystem grow skipped for domain %s: guest agent unavailable; "+
+			"block device is grown but the guest filesystem must be extended via cloud-init or manually (#201)", id)
+		return
+	}
+
+	for _, cmd := range fsGrowCommands(target) {
+		out, err := ga.ExecuteGuestCommand(ctx, id, cmd)
+		if err != nil {
+			log.Printf("WARN In-guest filesystem grow step %q failed for domain %s (non-fatal): %v", cmd, id, err)
+			continue
+		}
+		log.Printf("INFO In-guest filesystem grow step %q succeeded for domain %s: %s", cmd, id, strings.TrimSpace(out))
+	}
+	log.Printf("INFO In-guest filesystem grow (best-effort) completed for domain %s", id)
+}

--- a/internal/providers/libvirt/disk_expand_test.go
+++ b/internal/providers/libvirt/disk_expand_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// domblklistStdout is a representative `virsh domblklist <dom>` output: a
+// primary virtio disk plus a cloud-init CD-ROM that must be skipped.
+const domblklistStdout = ` Target   Source
+---------------------------------------------------
+ vda      /var/lib/libvirt/images/vm-foo.qcow2
+ hda      /var/lib/libvirt/images/vm-foo-cidata.iso
+`
+
+// TestParseDomblklistPrimaryTarget_SkipsCloudInit verifies the primary disk
+// target is resolved from the live domain topology and the cloud-init ISO row
+// is skipped — naming-convention agnostic, not the "<vmid>-disk" guess (#201,
+// #207).
+func TestParseDomblklistPrimaryTarget_SkipsCloudInit(t *testing.T) {
+	target, err := parseDomblklistPrimaryTarget(domblklistStdout)
+	require.NoError(t, err)
+	assert.Equal(t, "vda", target)
+}
+
+// TestParseDomblklistPrimaryTarget_SkipsEmptyCdrom verifies an empty CD-ROM row
+// (source "-") is skipped and the first real disk wins.
+func TestParseDomblklistPrimaryTarget_SkipsEmptyCdrom(t *testing.T) {
+	out := ` Target   Source
+------------------------------------------------
+ sda      -
+ vdb      /var/lib/libvirt/images/vm-bar.qcow2
+`
+	target, err := parseDomblklistPrimaryTarget(out)
+	require.NoError(t, err)
+	assert.Equal(t, "vdb", target)
+}
+
+// TestParseDomblklistPrimaryTarget_NoDisk verifies an error when no usable disk
+// row exists (only a cloud-init ISO).
+func TestParseDomblklistPrimaryTarget_NoDisk(t *testing.T) {
+	out := ` Target   Source
+------------------------------------------------
+ hda      /var/lib/libvirt/images/vm-foo-cidata.iso
+`
+	_, err := parseDomblklistPrimaryTarget(out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no primary disk target")
+}
+
+// TestParseDomblkinfoCapacity_Bytes verifies the virtual Capacity (bytes) is
+// parsed for the grow-only guard, ignoring Allocation/Physical.
+func TestParseDomblkinfoCapacity_Bytes(t *testing.T) {
+	out := `Capacity:       10737418240
+Allocation:     2147483648
+Physical:       2147483648
+`
+	capBytes, err := parseDomblkinfoCapacity(out)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10737418240), capBytes) // 10 GiB
+}
+
+// TestParseDomblkinfoCapacity_Missing verifies an error when no Capacity line
+// is present.
+func TestParseDomblkinfoCapacity_Missing(t *testing.T) {
+	_, err := parseDomblkinfoCapacity("Allocation: 0\nPhysical: 0\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Capacity line")
+}
+
+// TestBlockresizeSizeArg verifies the size argument uses the explicit "G"
+// suffix virsh blockresize requires (unsuffixed would be interpreted as KiB).
+func TestBlockresizeSizeArg(t *testing.T) {
+	assert.Equal(t, "20G", blockresizeSizeArg(20))
+	assert.Equal(t, "1G", blockresizeSizeArg(1))
+}
+
+// TestShouldGrowDisk_GrowOnlyGuard verifies the grow-only + idempotency guard:
+// grow when strictly larger past the rounding threshold; skip when equal,
+// smaller (would-be shrink), or within rounding.
+func TestShouldGrowDisk_GrowOnlyGuard(t *testing.T) {
+	tenGiB := int64(10) * bytesPerGiB
+	twentyGiB := int64(20) * bytesPerGiB
+
+	tests := []struct {
+		name    string
+		current int64
+		desired int64
+		want    bool
+	}{
+		{"grow 10->20 GiB", tenGiB, twentyGiB, true},
+		{"equal is no-op (idempotent)", tenGiB, tenGiB, false},
+		{"shrink 20->10 GiB is rejected", twentyGiB, tenGiB, false},
+		{"sub-threshold delta is no-op", tenGiB, tenGiB + (512 * 1024), false},
+		{"just past threshold grows", tenGiB, tenGiB + bytesPerGiB, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, shouldGrowDisk(tc.current, tc.desired))
+		})
+	}
+}
+
+// TestFsGrowCommands verifies the best-effort in-guest FS-grow sequence:
+// growpart on the partition, then resize2fs (ext) and xfs_growfs (xfs), built
+// from the resolved target device.
+func TestFsGrowCommands(t *testing.T) {
+	cmds := fsGrowCommands("vda")
+	require.Len(t, cmds, 3)
+	assert.Equal(t, "growpart /dev/vda 1", cmds[0])
+	assert.Equal(t, "resize2fs /dev/vda1", cmds[1])
+	assert.Equal(t, "xfs_growfs /", cmds[2])
+}
+
+// TestBytesPerGiB sanity-checks the GiB constant used for byte-accurate
+// comparisons against domblkinfo Capacity.
+func TestBytesPerGiB(t *testing.T) {
+	assert.Equal(t, int64(1073741824), bytesPerGiB)
+}

--- a/internal/providers/libvirt/provider_virsh.go
+++ b/internal/providers/libvirt/provider_virsh.go
@@ -608,7 +608,19 @@ func (p *Provider) Reconfigure(ctx context.Context, id string, desired contracts
 		}
 	}
 
-	// Handle Disk changes
+	// Handle Disk changes.
+	//
+	// Online (domain running): grow the live block device via `virsh
+	// blockresize` so QEMU exposes the new size immediately, then best-effort
+	// extend the in-guest filesystem via the guest agent. The target device and
+	// current size are resolved from the live domain (domblklist/domblkinfo),
+	// not the "<vmid>-disk" volume-name guess. Grow-only: shrinks are rejected
+	// (libvirt/qcow2 cannot shrink live) and resizing to the current size is a
+	// no-op. A blockresize failure is fatal to the disk step; the in-guest FS
+	// grow is non-fatal (#201).
+	//
+	// Offline (domain stopped): resize the backing volume so the larger size
+	// applies on next boot.
 	if len(desired.Disks) > 0 || (desired.Class.DiskDefaults != nil && desired.Class.DiskDefaults.SizeGiB > 0) {
 		storageProvider := NewStorageProvider(p.virshProvider)
 
@@ -619,18 +631,32 @@ func (p *Provider) Reconfigure(ctx context.Context, id string, desired contracts
 		}
 
 		if desiredDiskGB > 0 {
-			// Find the VM's disk volume
-			volumeName := fmt.Sprintf("%s-disk", id)
-
-			// Try to resize the volume
-			log.Printf("INFO Attempting to resize disk for VM %s to %dGB", id, desiredDiskGB)
-			err = storageProvider.ResizeVolume(ctx, "default", volumeName, desiredDiskGB)
-			if err != nil {
-				log.Printf("WARN Disk resize failed: %v", err)
-				// Disk resize failure is not fatal, just log it
+			if isRunning {
+				// Online live grow (grow-only + idempotent guards inside).
+				log.Printf("INFO Attempting online disk grow for running VM %s to %dGB", id, desiredDiskGB)
+				grew, gerr := p.growDiskOnline(ctx, id, desiredDiskGB, storageProvider)
+				if gerr != nil {
+					// The live block-device resize failing IS fatal to the disk
+					// step: the guest would not see the requested capacity.
+					log.Printf("WARN Online disk grow failed for VM %s: %v", id, gerr)
+					return "", contracts.NewRetryableError("online disk grow failed", gerr)
+				}
+				if grew {
+					hasChanges = true
+				}
 			} else {
-				log.Printf("INFO Successfully resized disk for VM: %s", id)
-				hasChanges = true
+				// Offline: resize the backing volume so the larger size applies
+				// on next boot. Find the VM's disk volume by the pool convention.
+				volumeName := fmt.Sprintf("%s-disk", id)
+				log.Printf("INFO Attempting offline disk resize for VM %s to %dGB", id, desiredDiskGB)
+				err = storageProvider.ResizeVolume(ctx, "default", volumeName, desiredDiskGB)
+				if err != nil {
+					log.Printf("WARN Offline disk resize failed: %v", err)
+					// Offline resize failure is not fatal, just log it.
+				} else {
+					log.Printf("INFO Successfully resized disk for VM: %s", id)
+					hasChanges = true
+				}
 			}
 		}
 	}

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -499,7 +499,7 @@ func (s *Server) ImagePrepare(ctx context.Context, req *providerv1.ImagePrepareR
 func (s *Server) GetCapabilities(ctx context.Context, req *providerv1.GetCapabilitiesRequest) (*providerv1.GetCapabilitiesResponse, error) {
 	return &providerv1.GetCapabilitiesResponse{
 		SupportsReconfigureOnline:   false, // Libvirt typically requires power cycle for CPU/memory changes
-		SupportsDiskExpansionOnline: false, // Disk expansion usually requires power cycle
+		SupportsDiskExpansionOnline: true,  // Online grow via `virsh blockresize` + best-effort in-guest FS grow (resize2fs/xfs_growfs) when the guest agent is present; grow-only (#201)
 		SupportsSnapshots:           true,  // Libvirt supports snapshots (storage-dependent)
 		SupportsMemorySnapshots:     false, // Memory snapshots not always supported
 		SupportsLinkedClones:        true,  // Clone RPC implemented: qcow2 overlay (linked) + vol-clone (full) (issue #153)

--- a/internal/providers/libvirt/server_test.go
+++ b/internal/providers/libvirt/server_test.go
@@ -80,6 +80,8 @@ func TestServer_GetCapabilities_HonestFlags(t *testing.T) {
 		"libvirt advertises image import now that ImagePrepare is implemented (issue #154)")
 	assert.True(t, caps.SupportsSnapshots,
 		"libvirt snapshots are implemented and must remain advertised")
+	assert.True(t, caps.SupportsDiskExpansionOnline,
+		"libvirt advertises online disk expansion now that Reconfigure grows the live block device via blockresize (issue #201)")
 }
 
 // TestServer_GetCapabilities_DiskMigration verifies the disk-migration


### PR DESCRIPTION
## What

**Closes #201 — libvirt online disk expansion.** The libvirt provider can now grow a *running* VM's disk live and honestly advertises `SupportsDiskExpansionOnline=true`.

Previously `Reconfigure` only resized the backing qcow2 volume — for a running VM, live QEMU never learned the disk grew (no `blockresize`) and the in-guest filesystem was never extended, so the flag was honestly `false`.

### Now (running domain)
- Resolve the primary disk's **target device + current capacity from the live domain** (`domblklist`/`domblkinfo`) — not the fragile `<vmid>-disk` volume-name guess (the bug behind #207).
- **Grow-only + idempotent** guard (1 MiB rounding threshold): shrink is rejected (libvirt/qcow2 can't shrink live), resizing to current size is a no-op.
- `virsh blockresize <dom> <target> <n>G` so QEMU exposes the new block size immediately. **A `blockresize` failure is fatal to the disk step.**
- **Best-effort in-guest FS grow** via the guest agent (`growpart` → `resize2fs`/`xfs_growfs`), gated on guest-agent availability and **fully non-fatal** — without it the block device is grown but the guest FS must be finished via cloud-init or manually (documented caveat).

Offline path unchanged (resize backing volume → applies next boot). CPU/memory reconfigure paths untouched.

## Verification

- libvirt is excluded from `make`, run directly: `gofmt` clean · `go build ./...` OK · `golangci-lint ./internal/providers/libvirt/...` **0 issues** · `go test ./internal/providers/libvirt/...` pass · `make build` (whole repo) OK.
- Host-independent unit tests: `domblklist` target parsing (skips cloud-init ISO / empty CD-ROM / header; errors on no disk), `domblkinfo` capacity parsing, `blockresize` size-arg (the mandatory `G` suffix), grow-only guard table (grow/equal/shrink/sub-threshold), FS-grow command construction, and the capability flag now true.
- **Lab E2E** (to run): grow a running VM's disk, confirm the guest sees the larger block device; verify the grow-only no-op on re-reconcile; note guest-agent-absent + SELinux/AppArmor cases.

## Risk

libvirt-provider-only; no CRD/proto change. Grow-only (never shrinks). The block-device grow is the load-bearing step (fatal on failure); the in-guest FS grow is best-effort. Exotic partition layouts (LVM/multi-partition) fall back to user/cloud-init completion.

Closes #201.
