### PR TITLE
feat(libvirt): advertise memory-inclusive snapshots (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-09 07:48] - libvirt memory-inclusive snapshots: advertise SupportsMemorySnapshots (#202)
+**Author:** @wrkode (William Rizzo)
+
+### Changed
+- `internal/providers/libvirt/server.go`: advertise `SupportsMemorySnapshots=true`. `SnapshotCreate` already captures RAM for a running VM (full system checkpoint via `virsh snapshot-create-as` *without* `--disk-only`); the flag was understated. Extracted a testable `buildSnapshotCreateArgs` helper, and when a memory snapshot is requested for a **non-running** VM it now logs a clear WARN and creates a disk-only snapshot (honest downgrade — a stopped VM has no RAM state to capture) instead of silently behaving as if memory were captured.
+
+### Added
+- `internal/providers/libvirt/snapshot_test.go`: unit tests for the args helper (memory vs disk-only across running/stopped) + the `SupportsMemorySnapshots=true` capability.
+
+### Why
+KVM supports full-system checkpoints; the libvirt provider already created them when `IncludeMemory` was set on a running VM, but advertised the capability as `false`. This makes the flag honest (mirrors the vSphere memory-snapshot honesty fix #200).
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (libvirt provider image; no CRD/proto change)
+- [ ] Config change only
+- [ ] Documentation only
+
+### Notes
+- Memory snapshots require the VM running; the captured RAM state lives inside the qcow2 (≈ RAM size, so larger/slower than a disk-only snapshot). A memory snapshot requested for a stopped VM is downgraded to disk-only with a WARN.
+
 ## [2026-06-09 07:41] - libvirt online disk expansion: live blockresize + best-effort guest FS grow (#201)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -293,25 +293,22 @@ func (s *Server) SnapshotCreate(ctx context.Context, req *providerv1.SnapshotCre
 
 	log.Printf("INFO Domain %s is in state: %s", req.VmId, domainState)
 
-	// Build virsh snapshot-create-as command
-	// Format: virsh snapshot-create-as DOMAIN NAME --description "DESC" [--disk-only] [--atomic]
-	args := []string{
-		"snapshot-create-as",
-		req.VmId,
-		snapshotName,
-		"--description", description,
-		"--atomic", // Ensure atomic operation
-	}
-
-	// Determine snapshot type based on domain state and request
-	if req.IncludeMemory && domainState == "running" {
-		// Memory snapshot (full system checkpoint including RAM)
-		log.Printf("INFO Creating memory snapshot (includes RAM state)")
-		// No --disk-only flag = full snapshot with memory
-	} else {
-		// Disk-only snapshot (faster, no memory state)
-		log.Printf("INFO Creating disk-only snapshot")
-		args = append(args, "--disk-only")
+	// Build the virsh snapshot-create-as arguments. A memory-inclusive (full
+	// system) snapshot omits --disk-only and is only possible for a RUNNING
+	// domain (there is no RAM state to capture otherwise); any other case is a
+	// disk-only snapshot.
+	args, memorySnapshot := buildSnapshotCreateArgs(req.VmId, snapshotName, description, req.IncludeMemory, domainState == "running")
+	switch {
+	case memorySnapshot:
+		log.Printf("INFO Creating memory snapshot (full system checkpoint including RAM) for domain %s", req.VmId)
+	case req.IncludeMemory:
+		// Honest downgrade: a stopped VM has no RAM state to capture. The
+		// snapshot still succeeds as disk-only; the caller is told why rather
+		// than silently advertising a memory snapshot that did not happen.
+		log.Printf("WARN Memory snapshot requested for domain %s but it is not running (state=%s); "+
+			"creating a disk-only snapshot — memory state cannot be captured for a stopped VM", req.VmId, domainState)
+	default:
+		log.Printf("INFO Creating disk-only snapshot for domain %s", req.VmId)
 	}
 
 	// Execute snapshot creation
@@ -327,6 +324,29 @@ func (s *Server) SnapshotCreate(ctx context.Context, req *providerv1.SnapshotCre
 		SnapshotId: snapshotName,
 		// No task reference - libvirt snapshots are synchronous
 	}, nil
+}
+
+// buildSnapshotCreateArgs builds the `virsh snapshot-create-as` arguments and
+// reports whether the result is a memory-inclusive (full system) snapshot.
+//
+// A memory snapshot — a full system checkpoint that captures RAM together with
+// the disk state — is created by OMITTING --disk-only, and is only meaningful
+// for a RUNNING domain (a stopped domain has no RAM state). In every other case
+// (includeMemory false, or the domain not running) a --disk-only snapshot is
+// taken. The boolean lets the caller log/report honestly which kind was made.
+func buildSnapshotCreateArgs(vmID, name, description string, includeMemory, running bool) (args []string, memorySnapshot bool) {
+	args = []string{
+		"snapshot-create-as",
+		vmID,
+		name,
+		"--description", description,
+		"--atomic", // fail cleanly rather than leaving a half-created snapshot
+	}
+	if includeMemory && running {
+		// No --disk-only flag → full snapshot including memory.
+		return args, true
+	}
+	return append(args, "--disk-only"), false
 }
 
 // SnapshotDelete deletes a VM snapshot
@@ -501,7 +521,7 @@ func (s *Server) GetCapabilities(ctx context.Context, req *providerv1.GetCapabil
 		SupportsReconfigureOnline:   false, // Libvirt typically requires power cycle for CPU/memory changes
 		SupportsDiskExpansionOnline: true,  // Online grow via `virsh blockresize` + best-effort in-guest FS grow (resize2fs/xfs_growfs) when the guest agent is present; grow-only (#201)
 		SupportsSnapshots:           true,  // Libvirt supports snapshots (storage-dependent)
-		SupportsMemorySnapshots:     false, // Memory snapshots not always supported
+		SupportsMemorySnapshots:     true,  // Full system checkpoints incl. RAM via `snapshot-create-as` without --disk-only; requires the VM running (#202)
 		SupportsLinkedClones:        true,  // Clone RPC implemented: qcow2 overlay (linked) + vol-clone (full) (issue #153)
 		SupportsImageImport:         true,  // ImagePrepare RPC implemented: import/convert image into a storage pool (issue #154)
 		SupportedDiskTypes:          []string{"qcow2", "raw", "vmdk"},

--- a/internal/providers/libvirt/snapshot_test.go
+++ b/internal/providers/libvirt/snapshot_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestBuildSnapshotCreateArgs verifies that a memory-inclusive (full system)
+// snapshot omits --disk-only and is only chosen when the domain is running,
+// while every other combination yields a --disk-only snapshot (#202).
+func TestBuildSnapshotCreateArgs(t *testing.T) {
+	const vm, name, desc = "vm-1", "snap-1", "a snapshot"
+	base := []string{"snapshot-create-as", vm, name, "--description", desc, "--atomic"}
+
+	tests := []struct {
+		name          string
+		includeMemory bool
+		running       bool
+		wantMemory    bool
+		wantDiskOnly  bool
+	}{
+		{"memory + running -> full system snapshot", true, true, true, false},
+		{"memory + stopped -> disk-only (no RAM to capture)", true, false, false, true},
+		{"no-memory + running -> disk-only", false, true, false, true},
+		{"no-memory + stopped -> disk-only", false, false, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, mem := buildSnapshotCreateArgs(vm, name, desc, tt.includeMemory, tt.running)
+			assert.Equal(t, tt.wantMemory, mem)
+			// Base args always present, in order.
+			require.GreaterOrEqual(t, len(args), len(base))
+			assert.Equal(t, base, args[:len(base)])
+			hasDiskOnly := false
+			for _, a := range args {
+				if a == "--disk-only" {
+					hasDiskOnly = true
+				}
+			}
+			assert.Equal(t, tt.wantDiskOnly, hasDiskOnly,
+				"--disk-only must be present iff this is not a memory snapshot")
+		})
+	}
+}
+
+// TestServer_GetCapabilities_MemorySnapshots verifies the libvirt provider now
+// advertises memory snapshots honestly (the SnapshotCreate path captures RAM via
+// snapshot-create-as without --disk-only for a running VM — issue #202).
+func TestServer_GetCapabilities_MemorySnapshots(t *testing.T) {
+	s := &Server{}
+	caps, err := s.GetCapabilities(context.Background(), &providerv1.GetCapabilitiesRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, caps)
+	assert.True(t, caps.SupportsMemorySnapshots,
+		"libvirt advertises memory snapshots now that SnapshotCreate honors IncludeMemory for running VMs (#202)")
+}


### PR DESCRIPTION
## What

**Closes #202 — libvirt memory-inclusive snapshots.** The libvirt `SnapshotCreate` **already** captures RAM for a running VM (a full system checkpoint via `virsh snapshot-create-as` *without* `--disk-only`), but the provider advertised `SupportsMemorySnapshots=false`. This makes the flag honest — the same understatement fixed for vSphere in #200.

- Flip `SupportsMemorySnapshots=true`.
- Extract a testable `buildSnapshotCreateArgs` helper (memory ⇒ no `--disk-only`, only for a running domain; otherwise `--disk-only`).
- **Honest downgrade:** a memory snapshot requested for a **non-running** VM now logs a clear WARN and creates a disk-only snapshot (a stopped VM has no RAM state to capture) instead of silently behaving as if memory were captured.

## Verification
- libvirt excluded from `make`, run directly: `go build ./...` OK · `golangci-lint ./internal/providers/libvirt/...` **0 issues** · `go test ./internal/providers/libvirt/...` pass · `make build` OK.
- Unit tests: `buildSnapshotCreateArgs` across memory/disk-only × running/stopped (incl. base-arg order) + the `SupportsMemorySnapshots=true` capability assertion.
- **Lab E2E** (to run): take a memory snapshot of a running VM, confirm the full-system checkpoint captures RAM (resume restores running state); verify the stopped-VM request downgrades to disk-only with the WARN.

## Risk
libvirt-provider-only; no CRD/proto change. Memory snapshots require the VM running; the RAM state is internal to the qcow2 (≈ RAM size — larger/slower than disk-only). Watch SELinux/AppArmor only applies to the external `--memspec` form, which this internal-snapshot path does not use.

Closes #202.
