### PR TITLE
feat(libvirt): online CPU/memory reconfigure via hotplug headroom (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-09 07:52] - libvirt online CPU/memory reconfigure: hotplug headroom + live setvcpus/setmem (#203)
+**Author:** @wrkode (William Rizzo)
+
+### Changed
+- `internal/providers/libvirt/provider_virsh.go`: the create-path now provisions hotplug headroom in the domain XML when the VMClass opts into `CPUHotAddEnabled`/`MemoryHotAddEnabled`. CPU becomes `<vcpu placement='static' current='<initial>'>=ceiling</vcpu>` (extra vCPUs start offline, brought online by `setvcpus --live`); memory becomes `<memory>=ceiling` (balloon maximum) with `<currentMemory>=initial` (so `setmem --live` can inflate up to the ceiling). When hot-add is disabled the emitted XML is byte-identical to before (`<vcpu placement='static'>N</vcpu>`, `<memory>==<currentMemory>==initial`) — no regression for existing/most VMs.
+- `internal/providers/libvirt/provider_virsh.go`: the `Reconfigure` online CPU/memory `--live` failure logs are now honest — they state the desired increase exceeds the provisioned hotplug headroom (the `<vcpu>` max / `<memory>` balloon maximum) or the VM was created without the hot-add flag, and that a power cycle is required. The CPU/memory comparison and `requiresRestart` fallback logic are unchanged.
+- `internal/providers/libvirt/server.go`: `GetCapabilities` now advertises `SupportsReconfigureOnline: true` — online CPU/mem reconfigure via `setvcpus/setmem --live` for VMs created with the hot-add flags (headroom provisioned at create), up to the ~4× ceiling, beyond which a power cycle is required.
+
+### Added
+- `internal/providers/libvirt/reconfigure_online.go`: `buildCPUMemoryXML` helper plus `computeHotplugCeilingVCPUs`/`computeHotplugCeilingMemoryMiB` with named, tunable constants — `hotplugResourceMultiplier` (4×) and `maxHotplugVCPUs` (64). The ceiling is floored to be strictly greater than the initial (so headroom always exists) and the vCPU ceiling is hard-capped; memory has no hard cap (the guest only allocates `currentMemory`).
+- `internal/providers/libvirt/reconfigure_online_test.go`: host-independent table tests for the CPU/memory XML helper (hot-add off = unchanged layout/no `current=`; hot-add on = `<vcpu current='<initial>'>` with ceiling max and memory ceiling > currentMemory) and the ceiling computation (4× multiplier, floor, CPU cap, no-headroom-at-cap).
+- `internal/providers/libvirt/server_test.go`: assert `SupportsReconfigureOnline` is now advertised.
+
+### Why
+KVM/QEMU supports live CPU and memory hotplug, but the prior libvirt create-path provisioned zero headroom (`<memory>==<currentMemory>`, `<vcpu>` with no `current<max`), so the existing `setvcpus/setmem --live` path could never grow a running VM past its boot size and the capability flag was understated as `false`. Provisioning the headroom at create (opt-in via the existing hot-add flags, no CRD/proto change) lets the live path actually grow the VM and lets the provider honestly advertise online reconfigure.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
+Rebuild/redeploy the libvirt provider image. This **changes the domain XML for VMs created with `CPUHotAddEnabled`/`MemoryHotAddEnabled`** (headroom is provisioned at create time); VMs created without those flags are unaffected (byte-identical XML). No CRD or proto change.
+
+### Notes
+- Online grow is bounded by the ~4× ceiling provisioned at create; growing beyond the ceiling still requires a power cycle, and the `--live` failure log says so.
+- Headroom only exists for VMs created with the hot-add flags **after** this change — existing VMs (and VMs created without the flags) have no headroom and still need a power-cycle to grow CPU/memory.
+- Memory live grow inflates the balloon up to `<memory>`; it is balloon-based (`currentMemory`), not DIMM hotplug. The guest sees the new memory as the balloon deflates.
+- Follow-up: the clone path (`clone.go` `applyClassOverrides`) rewrites `<vcpu>`/`<memory>`/`<currentMemory>` and would drop the `current<max` headroom on a clone; preserving headroom across clone is a separate change and out of scope here.
 ## [2026-06-09 07:48] - libvirt memory-inclusive snapshots: advertise SupportsMemorySnapshots (#202)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/provider_virsh.go
+++ b/internal/providers/libvirt/provider_virsh.go
@@ -552,7 +552,13 @@ func (p *Provider) Reconfigure(ctx context.Context, id string, desired contracts
 				_, err = p.virshProvider.runVirshCommand(ctx, "setvcpus", id,
 					fmt.Sprintf("%d", desired.Class.CPU), "--live")
 				if err != nil {
-					log.Printf("WARN Online CPU change failed, will require restart: %v", err)
+					// A `setvcpus --live` failure here means the desired vCPU
+					// count exceeds the hotplug headroom provisioned at create
+					// (the <vcpu> max), or the VM was created without
+					// CPUHotAddEnabled (no headroom at all). Either way the
+					// increase requires a power cycle to take effect (#203).
+					log.Printf("WARN Online CPU change to %d failed for %s: exceeds provisioned hotplug headroom (the <vcpu> max) or the VM was created without CPUHotAddEnabled; a power cycle is required to apply this increase: %v",
+						desired.Class.CPU, id, err)
 					requiresRestart = true
 				} else {
 					log.Printf("INFO Successfully changed CPUs online for domain: %s", id)
@@ -585,7 +591,14 @@ func (p *Provider) Reconfigure(ctx context.Context, id string, desired contracts
 				_, err = p.virshProvider.runVirshCommand(ctx, "setmem", id,
 					fmt.Sprintf("%dK", desiredMemoryKB), "--live")
 				if err != nil {
-					log.Printf("WARN Online memory change failed, will require restart: %v", err)
+					// `setmem --live` inflates the balloon up to the <memory>
+					// ceiling. A failure here means the desired memory exceeds
+					// the hotplug headroom provisioned at create (the <memory>
+					// balloon maximum), or the VM was created without
+					// MemoryHotAddEnabled (no headroom at all). Either way the
+					// increase requires a power cycle to take effect (#203).
+					log.Printf("WARN Online memory change to %d KiB failed for %s: exceeds provisioned hotplug headroom (the <memory> balloon maximum) or the VM was created without MemoryHotAddEnabled; a power cycle is required to apply this increase: %v",
+						desiredMemoryKB, id, err)
 					requiresRestart = true
 				} else {
 					log.Printf("INFO Successfully changed memory online for domain: %s", id)
@@ -1178,12 +1191,21 @@ func (p *Provider) generateDomainXMLWithStorage(req contracts.CreateRequest, dis
 
 	// Extract performance and security features
 	var nestedVirtualization bool
+	var cpuHotAddEnabled bool
+	var memoryHotAddEnabled bool
 	var vtdEnabled bool
 	var secureBoot bool
 	var tpmEnabled bool
 
 	if req.Class.PerformanceProfile != nil {
 		nestedVirtualization = req.Class.PerformanceProfile.NestedVirtualization
+		// CPU/MemoryHotAddEnabled provision hotplug headroom at create time so
+		// the live Reconfigure path (`setvcpus/setmem --live`) can grow a
+		// running VM up to the ~4× ceiling without a power cycle (#203). When
+		// these are false the emitted XML is byte-identical to the historical
+		// layout (no <vcpu current=...>, <memory>==<currentMemory>).
+		cpuHotAddEnabled = req.Class.PerformanceProfile.CPUHotAddEnabled
+		memoryHotAddEnabled = req.Class.PerformanceProfile.MemoryHotAddEnabled
 	}
 
 	if req.Class.SecurityProfile != nil {
@@ -1267,12 +1289,18 @@ func (p *Provider) generateDomainXMLWithStorage(req contracts.CreateRequest, dis
 	// Generate network interfaces based on request
 	networkInterfacesXML := p.generateNetworkInterfacesXML(req.Networks)
 
+	// Build the CPU/memory elements, provisioning hotplug headroom when the
+	// VMClass opts into CPU/MemoryHotAddEnabled (#203). When hot-add is off the
+	// rendered elements are byte-identical to the historical
+	// <memory>==<currentMemory>, <vcpu placement='static'>N</vcpu> layout.
+	cpuMem := buildCPUMemoryXML(cpuCount, memoryMB, cpuHotAddEnabled, memoryHotAddEnabled)
+
 	domainXML := fmt.Sprintf(`<domain type='qemu'>
   <name>%s</name>
   <uuid>%s</uuid>
-  <memory unit='MiB'>%d</memory>
-  <currentMemory unit='MiB'>%d</currentMemory>
-  <vcpu placement='static'>%d</vcpu>
+  %s
+  %s
+  %s
   <os>
 %s
   </os>
@@ -1347,9 +1375,9 @@ func (p *Provider) generateDomainXMLWithStorage(req contracts.CreateRequest, dis
 </domain>`,
 		req.Name,
 		uuid,
-		memoryMB,
-		memoryMB,
-		cpuCount,
+		cpuMem.Memory,
+		cpuMem.CurrentMemory,
+		cpuMem.VCPU,
 		osXML,
 		featuresXML,
 		cpuXML,

--- a/internal/providers/libvirt/reconfigure_online.go
+++ b/internal/providers/libvirt/reconfigure_online.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import "fmt"
+
+// Hotplug headroom policy for online CPU/memory reconfigure (#203).
+//
+// When a VMClass opts into CPU/MemoryHotAddEnabled, the create-path provisions
+// a *ceiling* above the boot/initial allocation so that the live grow path
+// (`virsh setvcpus --live` / `virsh setmem --live`) can raise the running
+// allocation up to that ceiling without a power cycle. The guest boots with the
+// initial allocation online; the headroom is the difference between the ceiling
+// and the initial.
+//
+// These constants are deliberately conservative and tunable:
+//   - hotplugResourceMultiplier: the ceiling is this multiple of the initial
+//     allocation (e.g. 4× initial CPUs / 4× initial memory).
+//   - maxHotplugVCPUs: a hard cap on the provisioned vCPU ceiling so an
+//     unusually large initial CPU count cannot provision an unbootable or
+//     host-hostile maximum. Memory has no hard cap because the guest only
+//     allocates currentMemory; the <memory> ceiling is merely the balloon
+//     maximum.
+const (
+	// hotplugResourceMultiplier is the multiple of the initial allocation used
+	// as the hotplug ceiling when CPU/memory hot-add is enabled.
+	hotplugResourceMultiplier = 4
+
+	// maxHotplugVCPUs caps the provisioned vCPU ceiling. The ceiling is never
+	// allowed to exceed this value, regardless of the multiplier.
+	maxHotplugVCPUs = 64
+)
+
+// CPUMemoryXML holds the three domain-XML lines that govern CPU and memory
+// allocation, already rendered. The create-path substitutes these directly into
+// the domain template so the headroom decision lives in one testable place.
+type CPUMemoryXML struct {
+	// VCPU is the full `<vcpu .../>` element.
+	VCPU string
+	// Memory is the full `<memory .../>` element (the balloon maximum).
+	Memory string
+	// CurrentMemory is the full `<currentMemory .../>` element (the initial,
+	// guest-visible allocation).
+	CurrentMemory string
+}
+
+// computeHotplugCeilingVCPUs returns the vCPU ceiling for a VM created with CPU
+// hot-add enabled. The ceiling is hotplugResourceMultiplier × initial, floored
+// so that it is strictly greater than the initial (so headroom always exists
+// even for a 1-vCPU VM where the multiplier would otherwise be exact), and
+// capped at maxHotplugVCPUs. If the initial already meets or exceeds the cap,
+// the ceiling equals the initial (no headroom is possible).
+func computeHotplugCeilingVCPUs(initial int32) int32 {
+	if initial < 1 {
+		initial = 1
+	}
+	ceiling := initial * hotplugResourceMultiplier
+	// Floor: ensure the ceiling is strictly greater than the initial so that
+	// live grow has somewhere to go.
+	if ceiling <= initial {
+		ceiling = initial + 1
+	}
+	// Hard cap.
+	if ceiling > maxHotplugVCPUs {
+		ceiling = maxHotplugVCPUs
+	}
+	// If the initial is already at/over the cap, no headroom is possible.
+	if ceiling < initial {
+		ceiling = initial
+	}
+	return ceiling
+}
+
+// computeHotplugCeilingMemoryMiB returns the memory balloon-maximum ceiling for
+// a VM created with memory hot-add enabled. The ceiling is
+// hotplugResourceMultiplier × initial, floored so that it is strictly greater
+// than the initial. There is no hard cap: the guest only allocates
+// currentMemory (the initial); <memory> is just the balloon maximum that
+// `setmem --live` can inflate up to.
+func computeHotplugCeilingMemoryMiB(initial int64) int64 {
+	if initial < 1 {
+		initial = 1
+	}
+	ceiling := initial * hotplugResourceMultiplier
+	if ceiling <= initial {
+		ceiling = initial + 1
+	}
+	return ceiling
+}
+
+// buildCPUMemoryXML renders the `<vcpu>`, `<memory>`, and `<currentMemory>`
+// domain-XML elements for the create-path, provisioning hotplug headroom when
+// the corresponding hot-add flag is set (#203).
+//
+// Behavior:
+//
+//   - CPU hot-add OFF (default): `<vcpu placement='static'>N</vcpu>` — byte
+//     identical to the historical layout, no `current=` attribute.
+//
+//   - CPU hot-add ON: `<vcpu placement='static' current='I'>C</vcpu>` where I is
+//     the initial (boots online) and C is the ceiling (the extra vCPUs start
+//     offline and are brought online by `setvcpus --live`).
+//
+//   - Memory hot-add OFF (default): `<memory>` == `<currentMemory>` == initial —
+//     byte identical to the historical layout.
+//
+//   - Memory hot-add ON: `<memory>` = ceiling (the balloon maximum) and
+//     `<currentMemory>` = initial, so `setmem --live` can inflate the balloon
+//     from initial up to the ceiling.
+//
+// The cpuCount and memMiB arguments are the initial (boot) allocations.
+func buildCPUMemoryXML(cpuCount int32, memMiB int64, cpuHotAdd, memHotAdd bool) CPUMemoryXML {
+	var out CPUMemoryXML
+
+	// --- CPU ---
+	if cpuHotAdd {
+		ceiling := computeHotplugCeilingVCPUs(cpuCount)
+		out.VCPU = fmt.Sprintf("<vcpu placement='static' current='%d'>%d</vcpu>", cpuCount, ceiling)
+	} else {
+		out.VCPU = fmt.Sprintf("<vcpu placement='static'>%d</vcpu>", cpuCount)
+	}
+
+	// --- Memory ---
+	if memHotAdd {
+		ceiling := computeHotplugCeilingMemoryMiB(memMiB)
+		out.Memory = fmt.Sprintf("<memory unit='MiB'>%d</memory>", ceiling)
+		out.CurrentMemory = fmt.Sprintf("<currentMemory unit='MiB'>%d</currentMemory>", memMiB)
+	} else {
+		out.Memory = fmt.Sprintf("<memory unit='MiB'>%d</memory>", memMiB)
+		out.CurrentMemory = fmt.Sprintf("<currentMemory unit='MiB'>%d</currentMemory>", memMiB)
+	}
+
+	return out
+}

--- a/internal/providers/libvirt/reconfigure_online_test.go
+++ b/internal/providers/libvirt/reconfigure_online_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBuildCPUMemoryXML_HotAddOff verifies that with both hot-add flags off the
+// rendered CPU/memory elements are byte-identical to the historical layout:
+// no `current=` attribute on <vcpu>, and <memory>==<currentMemory>==initial. No
+// regression for existing/most VMs (#203).
+func TestBuildCPUMemoryXML_HotAddOff(t *testing.T) {
+	out := buildCPUMemoryXML(2, 2048, false, false)
+
+	assert.Equal(t, "<vcpu placement='static'>2</vcpu>", out.VCPU)
+	assert.Equal(t, "<memory unit='MiB'>2048</memory>", out.Memory)
+	assert.Equal(t, "<currentMemory unit='MiB'>2048</currentMemory>", out.CurrentMemory)
+
+	// Explicitly assert no headroom leaked in.
+	assert.NotContains(t, out.VCPU, "current=", "hot-add off must not emit a vcpu current= attribute")
+	// <memory> and <currentMemory> must carry the same numeric value: stripping
+	// the differing element names yields identical strings.
+	memValue := strings.ReplaceAll(out.Memory, "memory", "")
+	curValue := strings.ReplaceAll(out.CurrentMemory, "currentMemory", "")
+	assert.Equal(t, memValue, curValue,
+		"hot-add off must keep <memory> and <currentMemory> at the same value")
+}
+
+// TestBuildCPUMemoryXML_CPUHotAddOnly verifies CPU headroom is provisioned
+// (vcpu carries current='<initial>' and a max of the ceiling) while memory is
+// left at the historical equal-value layout when only CPU hot-add is enabled.
+func TestBuildCPUMemoryXML_CPUHotAddOnly(t *testing.T) {
+	out := buildCPUMemoryXML(2, 2048, true, false)
+
+	// 2 vCPUs initial, 4× ceiling = 8 max, boots 2 online.
+	assert.Equal(t, "<vcpu placement='static' current='2'>8</vcpu>", out.VCPU)
+
+	// Memory untouched.
+	assert.Equal(t, "<memory unit='MiB'>2048</memory>", out.Memory)
+	assert.Equal(t, "<currentMemory unit='MiB'>2048</currentMemory>", out.CurrentMemory)
+}
+
+// TestBuildCPUMemoryXML_MemoryHotAddOnly verifies the memory balloon ceiling is
+// the 4× headroom and currentMemory stays at the initial, while CPU is left at
+// the historical no-current layout when only memory hot-add is enabled.
+func TestBuildCPUMemoryXML_MemoryHotAddOnly(t *testing.T) {
+	out := buildCPUMemoryXML(2, 2048, false, true)
+
+	// CPU untouched.
+	assert.Equal(t, "<vcpu placement='static'>2</vcpu>", out.VCPU)
+
+	// 2048 MiB initial, 4× ceiling = 8192 max (balloon maximum), guest sees 2048.
+	assert.Equal(t, "<memory unit='MiB'>8192</memory>", out.Memory)
+	assert.Equal(t, "<currentMemory unit='MiB'>2048</currentMemory>", out.CurrentMemory)
+}
+
+// TestBuildCPUMemoryXML_BothHotAdd verifies that with both flags on, CPU carries
+// current=<initial> with the ceiling max, and memory's <memory> ceiling is
+// strictly greater than <currentMemory> (the initial), so live grow has
+// headroom on both axes (#203).
+func TestBuildCPUMemoryXML_BothHotAdd(t *testing.T) {
+	out := buildCPUMemoryXML(4, 4096, true, true)
+
+	assert.Equal(t, "<vcpu placement='static' current='4'>16</vcpu>", out.VCPU)
+	assert.Equal(t, "<memory unit='MiB'>16384</memory>", out.Memory)
+	assert.Equal(t, "<currentMemory unit='MiB'>4096</currentMemory>", out.CurrentMemory)
+}
+
+// TestComputeHotplugCeilingVCPUs covers the multiplier, the floor (ceiling must
+// be strictly > initial even for a 1-vCPU VM), the hard cap at maxHotplugVCPUs,
+// and the at/over-cap case where no headroom is possible.
+func TestComputeHotplugCeilingVCPUs(t *testing.T) {
+	cases := []struct {
+		name    string
+		initial int32
+		want    int32
+	}{
+		{"single vcpu floored to >initial", 1, 4},     // 1*4 = 4, already > 1
+		{"two vcpus", 2, 8},                           // 2*4 = 8
+		{"four vcpus", 4, 16},                         // 4*4 = 16
+		{"multiplier exceeds cap is clamped", 32, 64}, // 32*4 = 128 -> cap 64
+		{"initial at cap yields no headroom", 64, 64}, // 64*4 = 256 -> cap 64 == initial
+		{"initial over cap yields initial", 100, 100}, // ceiling clamps back to initial
+		{"zero treated as one", 0, 4},                 // normalized to 1, then 1*4
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeHotplugCeilingVCPUs(tc.initial)
+			assert.Equal(t, tc.want, got)
+			// Invariant: a ceiling can never be below the initial.
+			if tc.initial >= 1 {
+				assert.GreaterOrEqual(t, got, tc.initial)
+			}
+		})
+	}
+}
+
+// TestComputeHotplugCeilingVCPUs_AlwaysHasHeadroomBelowCap asserts that for any
+// initial strictly below the cap, the ceiling is strictly greater than the
+// initial (headroom actually exists).
+func TestComputeHotplugCeilingVCPUs_AlwaysHasHeadroomBelowCap(t *testing.T) {
+	for initial := int32(1); initial < maxHotplugVCPUs; initial++ {
+		got := computeHotplugCeilingVCPUs(initial)
+		assert.Greater(t, got, initial,
+			"initial=%d below cap must provision headroom", initial)
+		assert.LessOrEqual(t, got, int32(maxHotplugVCPUs),
+			"initial=%d ceiling must never exceed the cap", initial)
+	}
+}
+
+// TestComputeHotplugCeilingMemoryMiB covers the multiplier and the floor; memory
+// has no hard cap because the guest only allocates currentMemory.
+func TestComputeHotplugCeilingMemoryMiB(t *testing.T) {
+	cases := []struct {
+		name    string
+		initial int64
+		want    int64
+	}{
+		{"1 GiB", 1024, 4096},
+		{"2 GiB", 2048, 8192},
+		{"tiny floored to >initial", 1, 4},
+		{"zero treated as one", 0, 4},
+		{"large no cap", 65536, 262144}, // 64 GiB * 4 = 256 GiB, uncapped
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeHotplugCeilingMemoryMiB(tc.initial)
+			assert.Equal(t, tc.want, got)
+			if tc.initial >= 1 {
+				assert.Greater(t, got, tc.initial, "memory ceiling must exceed the initial")
+			}
+		})
+	}
+}

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -518,12 +518,12 @@ func (s *Server) ImagePrepare(ctx context.Context, req *providerv1.ImagePrepareR
 // GetCapabilities returns the capabilities of the Libvirt provider
 func (s *Server) GetCapabilities(ctx context.Context, req *providerv1.GetCapabilitiesRequest) (*providerv1.GetCapabilitiesResponse, error) {
 	return &providerv1.GetCapabilitiesResponse{
-		SupportsReconfigureOnline:   false, // Libvirt typically requires power cycle for CPU/memory changes
-		SupportsDiskExpansionOnline: true,  // Online grow via `virsh blockresize` + best-effort in-guest FS grow (resize2fs/xfs_growfs) when the guest agent is present; grow-only (#201)
-		SupportsSnapshots:           true,  // Libvirt supports snapshots (storage-dependent)
-		SupportsMemorySnapshots:     true,  // Full system checkpoints incl. RAM via `snapshot-create-as` without --disk-only; requires the VM running (#202)
-		SupportsLinkedClones:        true,  // Clone RPC implemented: qcow2 overlay (linked) + vol-clone (full) (issue #153)
-		SupportsImageImport:         true,  // ImagePrepare RPC implemented: import/convert image into a storage pool (issue #154)
+		SupportsReconfigureOnline:   true, // Online CPU/mem reconfigure via `setvcpus/setmem --live` for VMs created with CPU/MemoryHotAddEnabled (headroom provisioned at create); grows up to the ~4× ceiling, beyond which a power-cycle is required (#203)
+		SupportsDiskExpansionOnline: true, // Online grow via `virsh blockresize` + best-effort in-guest FS grow (resize2fs/xfs_growfs) when the guest agent is present; grow-only (#201)
+		SupportsSnapshots:           true, // Libvirt supports snapshots (storage-dependent)
+		SupportsMemorySnapshots:     true, // Full system checkpoints incl. RAM via `snapshot-create-as` without --disk-only; requires the VM running (#202)
+		SupportsLinkedClones:        true, // Clone RPC implemented: qcow2 overlay (linked) + vol-clone (full) (issue #153)
+		SupportsImageImport:         true, // ImagePrepare RPC implemented: import/convert image into a storage pool (issue #154)
 		SupportedDiskTypes:          []string{"qcow2", "raw", "vmdk"},
 		SupportedNetworkTypes:       []string{"virtio", "e1000", "rtl8139"},
 		SupportsDiskExport:          true, // ExportDisk wired to virsh impl (issue #177)

--- a/internal/providers/libvirt/server_test.go
+++ b/internal/providers/libvirt/server_test.go
@@ -82,6 +82,8 @@ func TestServer_GetCapabilities_HonestFlags(t *testing.T) {
 		"libvirt snapshots are implemented and must remain advertised")
 	assert.True(t, caps.SupportsDiskExpansionOnline,
 		"libvirt advertises online disk expansion now that Reconfigure grows the live block device via blockresize (issue #201)")
+	assert.True(t, caps.SupportsReconfigureOnline,
+		"libvirt advertises online CPU/memory reconfigure now that the create-path provisions hotplug headroom for VMs with CPU/MemoryHotAddEnabled and Reconfigure grows them live via setvcpus/setmem --live (issue #203)")
 }
 
 // TestServer_GetCapabilities_DiskMigration verifies the disk-migration


### PR DESCRIPTION
## Summary

Closes #203. Makes libvirt **online CPU/memory reconfigure** real by provisioning hotplug *headroom* in the create-path domain XML when a VMClass opts into `CPUHotAddEnabled`/`MemoryHotAddEnabled`. The existing `Reconfigure` path already calls `virsh setvcpus/setmem --live` for running domains — but the old create-path emitted zero headroom (`<memory>==<currentMemory>`, `<vcpu>` with no `current<max`), so `--live` could never grow a running VM past its boot size, and the capability flag was understated as `false`.

**Design: Option A** (chosen) — reuse the existing hot-add flags + a default ceiling. **No CRD or proto change.**

## What changed

- **`reconfigure_online.go`** (new): `buildCPUMemoryXML` + `computeHotplugCeiling{VCPUs,MemoryMiB}` with tunable named constants — `hotplugResourceMultiplier` (4×) and `maxHotplugVCPUs` (64). The ceiling is floored strictly above the initial (headroom always exists), the vCPU ceiling is hard-capped, and memory is uncapped (the guest only allocates `currentMemory`; `<memory>` is just the balloon maximum).
- **`provider_virsh.go`**: the create-path renders the `<vcpu>`/`<memory>`/`<currentMemory>` elements via the helper. **Hot-add OFF ⇒ byte-identical XML to before** (`<vcpu placement='static'>N</vcpu>`, `<memory>==<currentMemory>==initial`) — no regression. The `Reconfigure` `--live` failure logs are now honest about exceeding the provisioned headroom / a missing hot-add flag and the need for a power cycle.
- **`server.go`**: `GetCapabilities` advertises `SupportsReconfigureOnline: true`.
- **tests**: host-independent table tests for the XML helper (off = unchanged layout; on = `current=<initial>` with ceiling max, memory ceiling > currentMemory) and the ceiling math (multiplier, floor, CPU cap, no-headroom-at-cap, property test), plus the capability assertion.

## Behaviour (hot-add ON example, 2 vCPU / 2048 MiB)
```
<vcpu placement='static' current='2'>8</vcpu>
<memory unit='MiB'>8192</memory>
<currentMemory unit='MiB'>2048</currentMemory>
```
Boots 2 vCPU / 2048 MiB online; `setvcpus --live` / `setmem --live` grow up to 8 vCPU / 8192 MiB without a power cycle.

## Verification
- `gofmt -l` clean · `go build ./...` · `golangci-lint run ./internal/providers/libvirt/...` → 0 issues · `go test ./internal/providers/libvirt/...` PASS · `make build` ✓
- Lab E2E (create a VM with both hot-add flags, grow CPU/mem live on an **isolated** provider) to follow at the v0.3.9-rc deploy.

## Notes for the reviewer/merger
- Touches the same `GetCapabilities` block as the still-open **#217 (#202 memory snapshots)** but a *different line* (`SupportsReconfigureOnline` vs `SupportsMemorySnapshots`). Whichever PR merges **second** may need a trivial one-line conflict resolution.
- Online grow is bounded by the ~4× ceiling provisioned at create; growing beyond it still needs a power cycle (the `--live` failure log says so).
- Existing VMs / VMs created without the hot-add flags have **no** headroom and still need a power cycle — headroom only exists for VMs created with the flags *after* this change.
- **Follow-up (out of scope):** the clone path (`clone.go applyClassOverrides`) rewrites `<vcpu>`/`<memory>`/`<currentMemory>` and would drop the `current<max` headroom on a clone; preserving headroom across clone is a separate change.

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (rebuild/redeploy the libvirt provider image)
- [ ] Config change only
- [ ] Documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)