### PR TITLE
feat(libvirt): clone hardening — UEFI nvram re-point + hot-add headroom + memory-quantity fix (#208, #221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,36 @@ exception — Proxmox export compression, tracked as a low-priority follow-up (#
 
 The detailed per-change entries follow below.
 
+## [2026-06-09 08:15] - libvirt clone hardening: UEFI nvram re-point + hot-add headroom preservation (#208, #221)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/libvirt/clone.go`: `rewriteNVRAMPath` derives a fresh per-clone UEFI varstore path from the SOURCE varstore's directory plus a `<targetName>_VARS.fd` basename, and `copyClonedNVRAM` copies the actual varstore file on the libvirt host (`sudo cp -f -- <src> <dst>` via the `!` direct-exec convention) so the clone gets an independent set of UEFI variables. `rewriteDomainXMLForClone` now also returns the source/target nvram paths it rewrote (empty for a BIOS source).
+- `internal/providers/libvirt/clone.go`: `cloneClassOverride`/`cloneClassPerfProfile` local structs that mirror the **v1beta1 `VMClassSpec`** shape the clone controller actually marshals — `cpu` (int), `memory` (a `resource.Quantity` such as `"8Gi"`, converted to MiB via `Memory.Value()/1MiB` to match the manager), and `performanceProfile.{cpuHotAddEnabled,memoryHotAddEnabled}` — so `applyClassOverrides` reads the real class JSON.
+- `internal/providers/libvirt/clone_test.go`: host-independent tests — UEFI nvram re-point (non-default dirs, `template=` attribute preserved, bare `<nvram/>` and missing-element no-ops), BIOS no-op, and hot-add headroom (hot-add class emits `<vcpu current=...>` ceiling + `<memory>`-ceiling > `<currentMemory>`; no flags = plain form unchanged; CPU-only leaves memory plain).
+
+### Changed
+- `internal/providers/libvirt/clone.go`: for a UEFI source the clone's per-VM `<os>...<nvram>` varstore is re-pointed to the fresh path and the source varstore is copied to it on the host; a failed copy logs a loud WARN rather than silently leaving the clone pointing at the source's varstore. A BIOS source (no `<nvram>`) is unchanged.
+- `internal/providers/libvirt/clone.go`: `applyClassOverrides` now renders `<vcpu>`/`<memory>`/`<currentMemory>` via the create-path `buildCPUMemoryXML` helper (#203), so a clone created with a hot-add-capable class keeps online-reconfigure headroom. When the flags are absent/false the emitted XML is byte-identical to before (no regression).
+
+### Fixed
+- `internal/providers/libvirt/clone.go`: a clone with a class override now actually honors the **memory** override. The previous `applyClassOverrides` unmarshalled into a struct whose memory field expected an int `memoryMiB`, but the clone controller marshals the v1beta1 `VMClassSpec` where memory is `"memory": "<quantity>"` — so the value never bound and the memory override (and, with #221, the memory headroom) silently did nothing. The override is now parsed as a `resource.Quantity`. The previous unit tests masked this by feeding a synthetic `memoryMiB` JSON that never occurs in production; they now use the real `"memory": "8Gi"` shape.
+
+### Why
+The clone XML rewrite was incomplete in three ways: (1) it kept the source's absolute UEFI `<nvram>` varstore path, so a UEFI clone shared the source's varstore — a define-time conflict or silent corruption of boot order / Secure Boot state — and never created its own; (2) `applyClassOverrides` emitted the plain no-headroom resource form, silently stripping a hot-add-capable clone of the live CPU/memory grow capability provisioned for non-clone VMs (#203); (3) the memory override never bound because the parse struct didn't match the v1beta1 memory-quantity shape the controller sends. This closes the clone-headroom follow-up called out in the #203 entry and makes the memory side of #221 actually functional end-to-end.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
+Rebuild/redeploy the libvirt provider image. BIOS clones are unaffected. UEFI clones now get an independent varstore copy. Clones created with a hot-add-capable class now retain online-reconfigure headroom (the emitted XML differs only when the class sets the hot-add flags). No CRD or proto change.
+
+### Notes
+- The nvram path-derivation and resource-XML rewrite stay pure/string-only (fully unit-testable without a host); the side-effecting varstore `cp` happens in `Clone()` next to the disk copy, gated on the non-empty nvram paths returned by the rewrite.
+- Headroom preservation reuses `buildCPUMemoryXML`/the ceiling helpers from `reconfigure_online.go` (#203) — no duplicated policy.
+
 ## [2026-06-09 07:52] - libvirt online CPU/memory reconfigure: hotplug headroom + live setvcpus/setmem (#203)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/clone.go
+++ b/internal/providers/libvirt/clone.go
@@ -26,6 +26,8 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
 )
 
@@ -49,6 +51,11 @@ var (
 	// quotes), capturing nothing — every occurrence is replaced with a fresh
 	// address so the clone never collides with the source on the L2 segment.
 	reMACAddress = regexp.MustCompile(`<mac\s+address=(?:'[^']*'|"[^"]*")\s*/>`)
+	// reNVRAM matches the per-VM UEFI <nvram>...</nvram> varstore element under
+	// <os>, capturing the absolute varstore path in group 1. A BIOS domain has
+	// no such element, so a non-match means "no nvram to re-point" (issue #208).
+	// The (?s) flag lets . span newlines; the path is captured non-greedily.
+	reNVRAM = regexp.MustCompile(`(?s)<nvram[^>]*>\s*(.*?)\s*</nvram>`)
 )
 
 // Clone clones the source VM identified by req.SourceVmID into a new libvirt
@@ -141,9 +148,19 @@ func (p *Provider) Clone(ctx context.Context, req contracts.CloneRequest) (contr
 		return contracts.CloneResponse{}, contracts.NewRetryableError("failed to dump source domain XML", err)
 	}
 
-	targetXML, err := rewriteDomainXMLForClone(srcXML.Stdout, req.TargetName, srcDiskPath, targetDiskPath)
+	targetXML, srcNvramPath, targetNvramPath, err := rewriteDomainXMLForClone(srcXML.Stdout, req.TargetName, srcDiskPath, targetDiskPath)
 	if err != nil {
 		return contracts.CloneResponse{}, contracts.NewInvalidSpecError("rewrite source domain XML for clone", err)
+	}
+
+	// For a UEFI source the domain XML carries a per-VM <nvram> varstore that was
+	// just re-pointed to a fresh per-clone path. Copy the actual varstore file on
+	// the libvirt host so the clone gets an independent set of UEFI variables
+	// (issue #208); otherwise two domains would share one varstore. This is the
+	// side-effecting counterpart to the pure XML rewrite, performed here next to
+	// the disk copy so rewriteDomainXMLForClone stays testable without a host.
+	if srcNvramPath != "" && targetNvramPath != "" {
+		p.copyClonedNVRAM(ctx, srcNvramPath, targetNvramPath)
 	}
 
 	// Apply best-effort CPU/memory overrides from ClassJSON.
@@ -277,6 +294,36 @@ func (p *Provider) finalizeClonedDisk(ctx context.Context, targetDiskPath string
 	}
 }
 
+// copyClonedNVRAM copies a UEFI source domain's nvram varstore to the clone's
+// fresh per-clone path on the libvirt host, so the clone boots with its own
+// independent UEFI variables rather than sharing (and corrupting) the source's
+// varstore (issue #208).
+//
+// The copy runs host-side via the "!" direct-exec convention, mirroring the
+// disk copy. The nvram directory (typically /var/lib/libvirt/qemu/nvram) is
+// root-owned, so sudo is used as elsewhere in this provider. The varstore is a
+// small fixed-size firmware-variable image; "cp -f --" overwrites any stale
+// target and stops option parsing at the paths. Failure is non-fatal but logged
+// loudly: the clone may fail to boot UEFI correctly because its <nvram> now
+// points at a path that was never populated.
+func (p *Provider) copyClonedNVRAM(ctx context.Context, srcNvramPath, targetNvramPath string) {
+	log.Printf("INFO Copying UEFI varstore %s -> %s for clone", srcNvramPath, targetNvramPath)
+	if res, err := p.virshProvider.runVirshCommand(ctx, "!", "sudo", "cp", "-f", "--", srcNvramPath, targetNvramPath); err != nil {
+		log.Printf("WARN Failed to copy UEFI varstore %s -> %s for clone: %v (output: %s). "+
+			"The clone's <nvram> points at an unpopulated path and may fail to boot UEFI/Secure Boot correctly.",
+			srcNvramPath, targetNvramPath, err, res.Stderr)
+		return
+	}
+	// Fix ownership/SELinux so libvirt-qemu can open the varstore, mirroring the
+	// clone-disk finalization. Best-effort: hosts vary in their mechanisms.
+	if _, e := p.virshProvider.runVirshCommand(ctx, "!", "sudo", "chown", "libvirt-qemu:kvm", targetNvramPath); e != nil {
+		log.Printf("WARN Failed to set clone varstore ownership: %v", e)
+	}
+	if _, e := p.virshProvider.runVirshCommand(ctx, "!", "sudo", "restorecon", targetNvramPath); e != nil {
+		log.Printf("WARN Failed to restore clone varstore SELinux context: %v", e)
+	}
+}
+
 // rewriteDomainXMLForClone produces a new domain XML from the source domain XML
 // with a fresh identity so the clone never collides with the source:
 //
@@ -288,11 +335,17 @@ func (p *Provider) finalizeClonedDisk(ctx context.Context, targetDiskPath string
 //   - the primary disk <source file='<srcDiskPath>'/> is re-pointed at
 //     targetDiskPath (the cloned/overlay volume). Only the matching source path
 //     is rewritten, so a cloud-init CD-ROM source is left untouched.
+//   - for a UEFI source, the per-VM <nvram>...</nvram> varstore path is
+//     re-pointed to a fresh per-clone path derived from the SOURCE varstore's
+//     directory and the target name (issue #208). The returned srcNvramPath /
+//     targetNvramPath let the caller copy the actual varstore file on the host
+//     (the XML rewrite stays pure and side-effect-free). A BIOS source has no
+//     <nvram> element: both returned paths are empty and the XML is unchanged.
 //
 // It does NOT shell out and is therefore fully unit-testable.
-func rewriteDomainXMLForClone(sourceXML, targetName, srcDiskPath, targetDiskPath string) (string, error) {
+func rewriteDomainXMLForClone(sourceXML, targetName, srcDiskPath, targetDiskPath string) (targetXML, srcNvramPath, targetNvramPath string, err error) {
 	if strings.TrimSpace(sourceXML) == "" {
-		return "", fmt.Errorf("source domain XML is empty")
+		return "", "", "", fmt.Errorf("source domain XML is empty")
 	}
 
 	out := sourceXML
@@ -302,18 +355,18 @@ func rewriteDomainXMLForClone(sourceXML, targetName, srcDiskPath, targetDiskPath
 	if reDomainName.MatchString(out) {
 		out = replaceFirst(reDomainName, out, fmt.Sprintf("<name>%s</name>", targetName))
 	} else {
-		return "", fmt.Errorf("source domain XML has no <name> element")
+		return "", "", "", fmt.Errorf("source domain XML has no <name> element")
 	}
 
 	// Rewrite the domain UUID with a fresh one.
-	newUUID, err := generateRandomUUID()
-	if err != nil {
-		return "", fmt.Errorf("generate clone UUID: %w", err)
+	newUUID, gerr := generateRandomUUID()
+	if gerr != nil {
+		return "", "", "", fmt.Errorf("generate clone UUID: %w", gerr)
 	}
 	if reDomainUUID.MatchString(out) {
 		out = replaceFirst(reDomainUUID, out, fmt.Sprintf("<uuid>%s</uuid>", newUUID))
 	} else {
-		return "", fmt.Errorf("source domain XML has no <uuid> element")
+		return "", "", "", fmt.Errorf("source domain XML has no <uuid> element")
 	}
 
 	// Replace every NIC MAC with a fresh locally-administered address. Each
@@ -335,38 +388,132 @@ func rewriteDomainXMLForClone(sourceXML, targetName, srcDiskPath, targetDiskPath
 			replaced = strings.Replace(out, fmt.Sprintf("file=\"%s\"", srcDiskPath), fmt.Sprintf("file=\"%s\"", targetDiskPath), 1)
 		}
 		if replaced == out {
-			return "", fmt.Errorf("primary disk source %q not found in source domain XML", srcDiskPath)
+			return "", "", "", fmt.Errorf("primary disk source %q not found in source domain XML", srcDiskPath)
 		}
 		out = replaced
 	}
 
-	return out, nil
+	// Re-point the per-VM UEFI <nvram> varstore (issue #208). On a UEFI source
+	// the <nvram> element holds an absolute varstore path
+	// (e.g. /var/lib/libvirt/qemu/nvram/<domain>_VARS.fd); if the clone kept it,
+	// both domains would share one varstore -> define conflict or corrupted boot
+	// order / Secure Boot state. Derive the new path from the SOURCE varstore's
+	// directory (do not hardcode the default dir) and the target name. A BIOS
+	// source has no <nvram>: this is a no-op and both nvram paths stay empty.
+	out, srcNvramPath, targetNvramPath = rewriteNVRAMPath(out, targetName)
+
+	return out, srcNvramPath, targetNvramPath, nil
+}
+
+// rewriteNVRAMPath re-points a UEFI domain's <nvram> varstore path to a fresh
+// per-clone path and returns (rewrittenXML, srcNvramPath, targetNvramPath).
+//
+// The new path keeps the SOURCE varstore's directory (so a non-default nvram
+// location is preserved) and uses "<targetName>_VARS.fd" as the basename — the
+// libvirt/QEMU convention. For a BIOS source (no <nvram> element, or an empty
+// path) it returns the XML unchanged and empty paths, signalling the caller to
+// skip the host-side varstore copy.
+func rewriteNVRAMPath(domainXML, targetName string) (out, srcPath, dstPath string) {
+	m := reNVRAM.FindStringSubmatchIndex(domainXML)
+	if m == nil {
+		return domainXML, "", "" // BIOS: no nvram element.
+	}
+	// Group 1 is the captured varstore path (indices m[2]:m[3]).
+	srcPath = strings.TrimSpace(domainXML[m[2]:m[3]])
+	if srcPath == "" {
+		// Templated <nvram/> with no inline path (libvirt fills it from the
+		// firmware feature). Nothing to copy or re-point.
+		return domainXML, "", ""
+	}
+	dstPath = filepath.Join(filepath.Dir(srcPath), fmt.Sprintf("%s_VARS.fd", targetName))
+	if dstPath == srcPath {
+		// Degenerate: target basename already equals source. Leave as-is.
+		return domainXML, srcPath, dstPath
+	}
+	// Splice the new path into the captured path span only, preserving any
+	// attributes on the opening <nvram ...> tag (e.g. template=).
+	out = domainXML[:m[2]] + dstPath + domainXML[m[3]:]
+	return out, srcPath, dstPath
+}
+
+// cloneClassOverride is the subset of a JSON-encoded VM class that the clone
+// path consumes. The clone controller (VMCloneReconciler.classJSON) marshals the
+// **v1beta1 VMClassSpec**, so the field names and shapes here mirror that type
+// exactly: `cpu` (int), `memory` (a resource.Quantity string such as "8Gi"), and
+// `performanceProfile.{cpuHotAddEnabled,memoryHotAddEnabled}`. In particular,
+// memory is a quantity — NOT an int `memoryMiB` — so it must be parsed via
+// resource.Quantity and converted to MiB (matching the manager's
+// `Memory.Value() / (1024*1024)` convention); a plain int field would silently
+// fail to bind and the memory override (and its #221 headroom) would never fire.
+type cloneClassOverride struct {
+	// CPU is the target vCPU count (0 = inherit the source's).
+	CPU int32 `json:"cpu"`
+	// Memory is the target memory as a resource.Quantity (e.g. "8Gi"); the
+	// zero value means "inherit the source's". Converted to MiB via memoryMiB().
+	Memory resource.Quantity `json:"memory"`
+	// PerformanceProfile carries the hot-add flags that decide whether the clone
+	// keeps online-reconfigure headroom (#221).
+	PerformanceProfile *cloneClassPerfProfile `json:"performanceProfile,omitempty"`
+}
+
+// memoryMiB converts the class's memory quantity to MiB, matching the manager's
+// conversion (Memory.Value() bytes / 1 MiB). Returns 0 when unset, which the
+// caller treats as "inherit the source's memory".
+func (c cloneClassOverride) memoryMiB() int64 {
+	return c.Memory.Value() / (1024 * 1024)
+}
+
+// cloneClassPerfProfile is the slice of a class's performance profile that the
+// clone path needs: the CPU/memory hot-add toggles (#221).
+type cloneClassPerfProfile struct {
+	// CPUHotAddEnabled requests online CPU grow headroom on the clone.
+	CPUHotAddEnabled bool `json:"cpuHotAddEnabled,omitempty"`
+	// MemoryHotAddEnabled requests online memory grow headroom on the clone.
+	MemoryHotAddEnabled bool `json:"memoryHotAddEnabled,omitempty"`
 }
 
 // applyClassOverrides applies best-effort CPU/memory overrides from a
-// JSON-encoded contracts.VMClass onto a domain XML. Unparseable or empty input
-// is a no-op (the clone inherits the source's resources). Only vcpu and memory
-// are adjusted; this is intentionally minimal for the MVP (issue #153).
+// JSON-encoded VM class onto a domain XML. Unparseable or empty input is a
+// no-op (the clone inherits the source's resources). Only vcpu and memory are
+// adjusted; this is intentionally minimal for the MVP (issue #153).
+//
+// When the override class opts into CPU/memory hot-add (performanceProfile.
+// {cpuHotAddEnabled,memoryHotAddEnabled}), the resource elements are rendered
+// via buildCPUMemoryXML so the clone keeps online-reconfigure headroom — a
+// vcpu current=<initial> ceiling and a <memory> balloon maximum above
+// <currentMemory> — instead of the plain no-headroom form that would silently
+// strip the clone of live-grow capability (#221). When the flags are
+// absent/false the plain form is emitted, byte-identical to the historical
+// behavior (no regression).
 func applyClassOverrides(domainXML, classJSON string) string {
 	if strings.TrimSpace(classJSON) == "" {
 		return domainXML
 	}
-	var class contracts.VMClass
+	var class cloneClassOverride
 	if err := json.Unmarshal([]byte(classJSON), &class); err != nil {
 		log.Printf("WARN Clone: ignoring unparseable ClassJSON override: %v", err)
 		return domainXML
 	}
 
+	cpuHotAdd := class.PerformanceProfile != nil && class.PerformanceProfile.CPUHotAddEnabled
+	memHotAdd := class.PerformanceProfile != nil && class.PerformanceProfile.MemoryHotAddEnabled
+
+	// Render the resource elements once, reusing the create-path headroom logic
+	// (#203) so the policy lives in exactly one place. The fields are only used
+	// when the corresponding override value is set below.
+	memMiB := class.memoryMiB()
+	res := buildCPUMemoryXML(class.CPU, memMiB, cpuHotAdd, memHotAdd)
+
 	out := domainXML
-	if class.MemoryMiB > 0 {
+	if memMiB > 0 {
 		reMem := regexp.MustCompile(`<memory[^>]*>.*?</memory>`)
 		reCur := regexp.MustCompile(`<currentMemory[^>]*>.*?</currentMemory>`)
-		out = replaceFirst(reMem, out, fmt.Sprintf("<memory unit='MiB'>%d</memory>", class.MemoryMiB))
-		out = replaceFirst(reCur, out, fmt.Sprintf("<currentMemory unit='MiB'>%d</currentMemory>", class.MemoryMiB))
+		out = replaceFirst(reMem, out, res.Memory)
+		out = replaceFirst(reCur, out, res.CurrentMemory)
 	}
 	if class.CPU > 0 {
 		reVCPU := regexp.MustCompile(`<vcpu[^>]*>.*?</vcpu>`)
-		out = replaceFirst(reVCPU, out, fmt.Sprintf("<vcpu placement='static'>%d</vcpu>", class.CPU))
+		out = replaceFirst(reVCPU, out, res.VCPU)
 	}
 	return out
 }

--- a/internal/providers/libvirt/clone_test.go
+++ b/internal/providers/libvirt/clone_test.go
@@ -62,8 +62,12 @@ func TestRewriteDomainXMLForClone_FreshIdentity(t *testing.T) {
 	const srcDisk = "/var/lib/libvirt/images/vm-source-disk.qcow2"
 	const tgtDisk = "/var/lib/libvirt/images/vm-target-disk.qcow2"
 
-	out, err := rewriteDomainXMLForClone(sourceDomainXML, "vm-target", srcDisk, tgtDisk)
+	out, srcNvram, tgtNvram, err := rewriteDomainXMLForClone(sourceDomainXML, "vm-target", srcDisk, tgtDisk)
 	require.NoError(t, err)
+
+	// BIOS source (no <nvram>): both nvram paths are empty, signalling no copy.
+	assert.Empty(t, srcNvram)
+	assert.Empty(t, tgtNvram)
 
 	// Name is rewritten.
 	assert.Contains(t, out, "<name>vm-target</name>")
@@ -101,7 +105,7 @@ func TestRewriteDomainXMLForClone_MultiNIC(t *testing.T) {
   </devices>
 </domain>`
 
-	out, err := rewriteDomainXMLForClone(xml, "t", "/p/s-disk.qcow2", "/p/t-disk.qcow2")
+	out, _, _, err := rewriteDomainXMLForClone(xml, "t", "/p/s-disk.qcow2", "/p/t-disk.qcow2")
 	require.NoError(t, err)
 
 	assert.NotContains(t, out, "52:54:00:11:11:11")
@@ -153,7 +157,7 @@ func TestRewriteDomainXMLForClone_Errors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := rewriteDomainXMLForClone(tt.xml, "t", tt.srcDisk, tt.tgtDisk)
+			_, _, _, err := rewriteDomainXMLForClone(tt.xml, "t", tt.srcDisk, tt.tgtDisk)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errSubstr)
 		})
@@ -170,7 +174,10 @@ func TestApplyClassOverrides(t *testing.T) {
 </domain>`
 
 	t.Run("cpu and memory override", func(t *testing.T) {
-		out := applyClassOverrides(base, `{"CPU":4,"MemoryMiB":8192}`)
+		// Production shape: VMCloneReconciler.classJSON marshals the v1beta1
+		// VMClassSpec, where memory is a resource.Quantity string ("8Gi"), not an
+		// int memoryMiB. 8Gi == 8192 MiB.
+		out := applyClassOverrides(base, `{"cpu":4,"memory":"8Gi"}`)
 		assert.Contains(t, out, "<memory unit='MiB'>8192</memory>")
 		assert.Contains(t, out, "<currentMemory unit='MiB'>8192</currentMemory>")
 		assert.Contains(t, out, "<vcpu placement='static'>4</vcpu>")
@@ -185,8 +192,159 @@ func TestApplyClassOverrides(t *testing.T) {
 	})
 
 	t.Run("zero values are ignored", func(t *testing.T) {
-		out := applyClassOverrides(base, `{"CPU":0,"MemoryMiB":0}`)
+		out := applyClassOverrides(base, `{"cpu":0,"memory":"0"}`)
 		assert.Equal(t, base, out, "zero CPU/memory must not overwrite inherited values")
+	})
+}
+
+// uefiDomainXML is a representative virsh dumpxml output for a UEFI source: a
+// pflash <loader> plus a per-VM <nvram> varstore under <os>, one disk and one
+// NIC. The clone must re-point the nvram to a fresh per-clone path (#208).
+const uefiDomainXML = `<domain type='kvm'>
+  <name>vm-uefi</name>
+  <uuid>99999999-8888-7777-6666-555555555555</uuid>
+  <memory unit='MiB'>2048</memory>
+  <currentMemory unit='MiB'>2048</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <os firmware='efi'>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.fd</loader>
+    <nvram>/var/lib/libvirt/qemu/nvram/vm-uefi_VARS.fd</nvram>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/vm-uefi-disk.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <interface type='bridge'>
+      <mac address='52:54:00:de:ad:be'/>
+      <source bridge='virbr0'/>
+    </interface>
+  </devices>
+</domain>`
+
+// TestRewriteDomainXMLForClone_UEFINvramRepoint verifies a UEFI source's per-VM
+// <nvram> varstore is re-pointed to a fresh per-clone path derived from the
+// source varstore's directory and the target name, and that the returned src/
+// target paths drive the host-side varstore copy (#208).
+func TestRewriteDomainXMLForClone_UEFINvramRepoint(t *testing.T) {
+	const srcDisk = "/var/lib/libvirt/images/vm-uefi-disk.qcow2"
+	const tgtDisk = "/var/lib/libvirt/images/vm-target-disk.qcow2"
+
+	out, srcNvram, tgtNvram, err := rewriteDomainXMLForClone(uefiDomainXML, "vm-target", srcDisk, tgtDisk)
+	require.NoError(t, err)
+
+	// The reported source varstore is the source's path; the target keeps the
+	// source's directory but uses the target-name basename.
+	assert.Equal(t, "/var/lib/libvirt/qemu/nvram/vm-uefi_VARS.fd", srcNvram)
+	assert.Equal(t, "/var/lib/libvirt/qemu/nvram/vm-target_VARS.fd", tgtNvram)
+
+	// The XML <nvram> now points at the fresh path, not the source's.
+	assert.Contains(t, out, "<nvram>/var/lib/libvirt/qemu/nvram/vm-target_VARS.fd</nvram>")
+	assert.NotContains(t, out, "<nvram>/var/lib/libvirt/qemu/nvram/vm-uefi_VARS.fd</nvram>")
+
+	// The read-only OVMF code loader (shared, not per-VM) is left untouched.
+	assert.Contains(t, out, "<loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.fd</loader>")
+}
+
+// TestRewriteDomainXMLForClone_BIOSNoNvram verifies a BIOS source (no <nvram>
+// element) is a no-op for the nvram re-point: empty src/target paths and no
+// stray <nvram> introduced into the clone XML (#208).
+func TestRewriteDomainXMLForClone_BIOSNoNvram(t *testing.T) {
+	const srcDisk = "/var/lib/libvirt/images/vm-source-disk.qcow2"
+	const tgtDisk = "/var/lib/libvirt/images/vm-target-disk.qcow2"
+
+	out, srcNvram, tgtNvram, err := rewriteDomainXMLForClone(sourceDomainXML, "vm-target", srcDisk, tgtDisk)
+	require.NoError(t, err)
+
+	assert.Empty(t, srcNvram, "BIOS source must report no source varstore")
+	assert.Empty(t, tgtNvram, "BIOS source must report no target varstore")
+	assert.NotContains(t, out, "<nvram>", "no <nvram> may be introduced for a BIOS clone")
+}
+
+// TestRewriteNVRAMPath covers the path-derivation helper in isolation: a
+// non-default source directory is preserved, a non-default nvram dir is honored,
+// a missing element is a no-op, and a bare/templated <nvram/> with no inline
+// path is left alone.
+func TestRewriteNVRAMPath(t *testing.T) {
+	t.Run("non-default dir preserved", func(t *testing.T) {
+		in := `<os><nvram>/data/uefi/vm-src_VARS.fd</nvram></os>`
+		out, src, dst := rewriteNVRAMPath(in, "vm-tgt")
+		assert.Equal(t, "/data/uefi/vm-src_VARS.fd", src)
+		assert.Equal(t, "/data/uefi/vm-tgt_VARS.fd", dst)
+		assert.Contains(t, out, "<nvram>/data/uefi/vm-tgt_VARS.fd</nvram>")
+	})
+
+	t.Run("nvram with template attribute keeps attribute", func(t *testing.T) {
+		in := `<os><nvram template='/usr/share/OVMF/OVMF_VARS.fd'>/var/lib/libvirt/qemu/nvram/s_VARS.fd</nvram></os>`
+		out, src, dst := rewriteNVRAMPath(in, "t")
+		assert.Equal(t, "/var/lib/libvirt/qemu/nvram/s_VARS.fd", src)
+		assert.Equal(t, "/var/lib/libvirt/qemu/nvram/t_VARS.fd", dst)
+		assert.Contains(t, out, "template='/usr/share/OVMF/OVMF_VARS.fd'")
+		assert.Contains(t, out, ">/var/lib/libvirt/qemu/nvram/t_VARS.fd</nvram>")
+	})
+
+	t.Run("no nvram element is a no-op", func(t *testing.T) {
+		in := `<os><loader>/x</loader></os>`
+		out, src, dst := rewriteNVRAMPath(in, "t")
+		assert.Equal(t, in, out)
+		assert.Empty(t, src)
+		assert.Empty(t, dst)
+	})
+
+	t.Run("bare nvram with no inline path is a no-op", func(t *testing.T) {
+		in := `<os><nvram template='/usr/share/OVMF/OVMF_VARS.fd'></nvram></os>`
+		out, src, dst := rewriteNVRAMPath(in, "t")
+		assert.Equal(t, in, out)
+		assert.Empty(t, src)
+		assert.Empty(t, dst)
+	})
+}
+
+// TestApplyClassOverrides_HotAddHeadroom verifies that a hot-add-capable class
+// preserves online-reconfigure headroom on the clone — a vcpu current=<initial>
+// ceiling and a <memory> balloon maximum above <currentMemory> — while a class
+// without the flags emits the plain no-headroom form unchanged (#221).
+func TestApplyClassOverrides_HotAddHeadroom(t *testing.T) {
+	base := `<domain>
+  <memory unit='MiB'>2048</memory>
+  <currentMemory unit='MiB'>2048</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+</domain>`
+
+	t.Run("hot-add class emits headroom", func(t *testing.T) {
+		// Production shape: v1beta1 memory quantity "8Gi" == 8192 MiB.
+		classJSON := `{"cpu":4,"memory":"8Gi","performanceProfile":{"cpuHotAddEnabled":true,"memoryHotAddEnabled":true}}`
+		out := applyClassOverrides(base, classJSON)
+
+		// vCPU: initial 4 boots online, ceiling 16 (4x) is the maximum.
+		assert.Contains(t, out, "<vcpu placement='static' current='4'>16</vcpu>")
+		// Memory: <memory> is the balloon ceiling (32768, 4x) strictly above the
+		// initial <currentMemory> (8192).
+		assert.Contains(t, out, "<memory unit='MiB'>32768</memory>")
+		assert.Contains(t, out, "<currentMemory unit='MiB'>8192</currentMemory>")
+	})
+
+	t.Run("no hot-add flags emits plain form unchanged", func(t *testing.T) {
+		classJSON := `{"cpu":4,"memory":"8Gi"}`
+		out := applyClassOverrides(base, classJSON)
+
+		assert.Contains(t, out, "<vcpu placement='static'>4</vcpu>")
+		assert.NotContains(t, out, "current=", "no headroom without the hot-add flags")
+		assert.Contains(t, out, "<memory unit='MiB'>8192</memory>")
+		assert.Contains(t, out, "<currentMemory unit='MiB'>8192</currentMemory>")
+	})
+
+	t.Run("cpu-only hot-add leaves memory plain", func(t *testing.T) {
+		classJSON := `{"cpu":2,"memory":"4Gi","performanceProfile":{"cpuHotAddEnabled":true}}`
+		out := applyClassOverrides(base, classJSON)
+
+		assert.Contains(t, out, "<vcpu placement='static' current='2'>8</vcpu>")
+		// Memory hot-add OFF: <memory> == <currentMemory> == initial.
+		assert.Contains(t, out, "<memory unit='MiB'>4096</memory>")
+		assert.Contains(t, out, "<currentMemory unit='MiB'>4096</currentMemory>")
 	})
 }
 


### PR DESCRIPTION
## Summary

Closes **#208** and **#221**. Makes the libvirt clone XML rewrite a faithful, independent copy of the source's per-VM state — two completeness gaps plus a latent memory-override bug surfaced during implementation.

## #208 — re-point the per-VM UEFI `<nvram>` varstore
`rewriteDomainXMLForClone` previously rewrote `<name>`/`<uuid>`/MACs/disk-source but left the `<os>/<nvram>` varstore pointing at the **source's** absolute path — so a UEFI clone shared the source's varstore (define-time conflict or silent corruption of boot order / Secure Boot state).
- New `rewriteNVRAMPath` derives a fresh per-clone path from the **source** varstore's directory + `<targetName>_VARS.fd` (preserves non-default nvram dirs; keeps a `template=` attribute).
- `Clone()` copies the actual varstore file on the host (`sudo cp -f -- <src> <dst>` via the `!` exec convention) so the clone gets independent UEFI vars. Failure → loud WARN, never silent sharing.
- BIOS sources (no `<nvram>`) are a no-op. The path rewrite stays pure/string-only (unit-testable); the side-effecting copy lives in `Clone()` next to the disk copy.

## #221 — preserve hot-add headroom across clone
`applyClassOverrides` emitted the plain no-headroom resource form, silently stripping a hot-add-capable clone of online-reconfigure capability. It now renders `<vcpu>/<memory>/<currentMemory>` via the create-path `buildCPUMemoryXML` helper (#203), so a clone from a hot-add VMClass keeps its `<vcpu current=...>` ceiling + `<memory>` balloon maximum. Without the flags → plain form, byte-identical to before.

## Latent bug fixed (folded in — it makes #221's memory half real)
The override parse struct expected an int `memoryMiB`, but `VMCloneReconciler.classJSON` marshals the **v1beta1 `VMClassSpec`**, where memory is `"memory": "<quantity>"` (e.g. `"8Gi"`). The value never bound → the memory override **and** #221's memory headroom silently did nothing in production. Now parsed as a `resource.Quantity` → MiB (matching the manager's `Memory.Value()/1MiB`). **The prior unit tests masked this** by feeding a synthetic `memoryMiB` JSON that never occurs live; they now assert against the real `"memory": "8Gi"` shape.

## Verification
- `gofmt -l` clean · `go build ./...` · `golangci-lint run ./internal/providers/libvirt/...` → 0 issues · `go test ./internal/providers/libvirt/...` PASS · `make build` ✓
- Tests are host-independent: UEFI re-point (non-default dirs, `template=` preserved, bare `<nvram/>`/missing-element no-ops), BIOS no-op, headroom (hot-add emits ceilings; no-flags plain; CPU-only leaves memory plain), all using the production JSON shape.
- Lab E2E (clone a UEFI VM + a hot-add VM on an **isolated** provider) to follow at the v0.3.9-rc deploy.

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (libvirt provider image)
- [ ] Config change only
- [ ] Documentation only

No CRD or proto change. BIOS clones unaffected; UEFI clones get an independent varstore; hot-add-class clones retain headroom; memory class override on clones now actually applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)