### PR TITLE
feat(proxmox): honor ExportDisk Compress for qcow2 + advertise ExportCompression (#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,27 @@ exception — Proxmox export compression, tracked as a low-priority follow-up (#
 
 The detailed per-change entries follow below.
 
+## [2026-06-09 13:10] - proxmox export compression (#219)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/proxmox/server.go`: `exportNeedsConversion` helper — a pure, host-independent decision function that determines when the export path must run a `qemu-img` convert pass. It forces a pass when the target format differs from the source, or when `Compress=true` and the target is `qcow2` (qemu-img applies `-c` only during a convert pass).
+- `internal/providers/proxmox/provider_test.go`: `TestExportNeedsConversion` table test covering qcow2/raw/vmdk × compress combinations (no live Proxmox/qemu required).
+
+### Changed
+- `internal/providers/proxmox/server.go`: `ExportDisk` now honors `ExportDiskRequest.Compress`. Previously it hardcoded `Compression: false` and only converted when the format changed, so qcow2→qcow2 exports never compressed. It now forces a `qemu-img convert -c` pass for qcow2 targets when `Compress=true` and passes `req.Compress` through to `diskutil`.
+- `internal/providers/proxmox/capabilities.go`: advertise `ExportCompression()` and update the stale "does not compress today" comment to describe what is actually compressed (qcow2 only).
+- `internal/providers/proxmox/provider_test.go`: `TestProxmoxProvider_GetCapabilities` now asserts `SupportsExportCompression` is `True`.
+
+### Why
+The Proxmox provider implemented `ExportDisk` but silently ignored the `Compress` request flag, and the capability was deliberately withheld to stay honest (#153/#154/#204 posture: a `true` capability means the provider actually performs the operation). This makes export compression real for the common qcow2 case and only then advertises it. Compression is genuine for qcow2 only; raw has no container to compress into and vmdk stream-optimized output is not produced on this path, so those targets stay uncompressed even when `Compress=true` — documented in both the capability comment and the helper.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-09 08:15] - libvirt clone hardening: UEFI nvram re-point + hot-add headroom preservation (#208, #221)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/proxmox/capabilities.go
+++ b/internal/providers/proxmox/capabilities.go
@@ -31,9 +31,13 @@ func GetProviderCapabilities() *capabilities.Manager {
 		// Disk export/import RPCs are implemented (ExportDisk/ImportDisk/
 		// GetDiskInfo accept qcow2/raw/vmdk); advertise them so capability
 		// gating (#176) doesn't wrongly block Proxmox disk migration (#198).
-		// ExportCompression is intentionally NOT advertised — the export path
-		// does not compress today.
+		// ExportCompression is advertised: ExportDisk honors req.Compress by
+		// forcing a qemu-img convert pass with `-c` for qcow2 targets (#219).
+		// Compression is genuine only for qcow2; raw/vmdk exports remain
+		// uncompressed even when Compress=true, and the default (Compress=false)
+		// stays uncompressed for export speed.
 		DiskExport("qcow2", "raw", "vmdk").
+		ExportCompression().
 		DiskImport("qcow2", "raw", "vmdk").
 		DiskTypes("raw", "qcow2").
 		NetworkTypes("bridge", "vlan").

--- a/internal/providers/proxmox/provider_test.go
+++ b/internal/providers/proxmox/provider_test.go
@@ -239,8 +239,76 @@ func TestProxmoxProvider_GetCapabilities(t *testing.T) {
 	assert.True(t, resp.SupportsDiskImport, "Proxmox implements ImportDisk")
 	assert.Contains(t, resp.SupportedExportFormats, "qcow2")
 	assert.Contains(t, resp.SupportedImportFormats, "vmdk")
-	// Export does not compress today, so it must NOT be advertised.
-	assert.False(t, resp.SupportsExportCompression)
+	// ExportDisk honors req.Compress via a forced qemu-img convert pass with
+	// `-c` for qcow2 targets (#219), so compression is advertised.
+	assert.True(t, resp.SupportsExportCompression, "Proxmox ExportDisk compresses qcow2 targets when Compress=true (#219)")
+}
+
+func TestExportNeedsConversion(t *testing.T) {
+	tests := []struct {
+		name         string
+		sourceFormat string
+		targetFormat string
+		compress     bool
+		want         bool
+	}{
+		{
+			name:         "qcow2 to qcow2 without compression skips pass",
+			sourceFormat: "qcow2",
+			targetFormat: "qcow2",
+			compress:     false,
+			want:         false,
+		},
+		{
+			name:         "qcow2 to qcow2 with compression forces a pass",
+			sourceFormat: "qcow2",
+			targetFormat: "qcow2",
+			compress:     true,
+			want:         true,
+		},
+		{
+			name:         "format change always needs a pass",
+			sourceFormat: "raw",
+			targetFormat: "qcow2",
+			compress:     false,
+			want:         true,
+		},
+		{
+			name:         "format change with compression needs a pass",
+			sourceFormat: "vmdk",
+			targetFormat: "qcow2",
+			compress:     true,
+			want:         true,
+		},
+		{
+			name:         "raw to raw with compression does not force a pass (raw is not compressible)",
+			sourceFormat: "raw",
+			targetFormat: "raw",
+			compress:     true,
+			want:         false,
+		},
+		{
+			name:         "vmdk to vmdk with compression does not force a pass (vmdk compression not produced here)",
+			sourceFormat: "vmdk",
+			targetFormat: "vmdk",
+			compress:     true,
+			want:         false,
+		},
+		{
+			name:         "raw to raw without compression skips pass",
+			sourceFormat: "raw",
+			targetFormat: "raw",
+			compress:     false,
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := exportNeedsConversion(tt.sourceFormat, tt.targetFormat, tt.compress)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 // Helper functions

--- a/internal/providers/proxmox/server.go
+++ b/internal/providers/proxmox/server.go
@@ -1234,6 +1234,28 @@ func (p *Provider) GetDiskInfo(ctx context.Context, req *providerv1.GetDiskInfoR
 	return response, nil
 }
 
+// exportNeedsConversion decides whether the export path must run a qemu-img
+// convert pass over the downloaded disk before upload.
+//
+// A pass is required when:
+//   - the requested target format differs from the source format (a genuine
+//     format conversion), OR
+//   - compression is requested AND the target format is qcow2. qemu-img applies
+//     internal compression (`-c`) only during a convert pass, so even a
+//     qcow2 -> qcow2 export must be forced through a pass to honor Compress.
+//
+// Compression is meaningful only for qcow2 in this provider. raw has no
+// container to compress into, and vmdk stream-optimized compression is not
+// produced on the Proxmox export path today; for those targets a Compress=true
+// request does not force a pass and produces uncompressed output. The advertised
+// ExportCompression capability is therefore honest specifically for qcow2.
+func exportNeedsConversion(sourceFormat, targetFormat string, compress bool) bool {
+	if targetFormat != sourceFormat {
+		return true
+	}
+	return compress && targetFormat == "qcow2"
+}
+
 // ExportDisk exports a VM disk for migration
 func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskRequest) (*providerv1.ExportDiskResponse, error) {
 	if p.client == nil {
@@ -1351,10 +1373,18 @@ func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskReq
 	// Close file to flush writes
 	file.Close()
 
-	// Convert format if needed
+	// Convert format and/or compress if needed.
+	//
+	// A qemu-img convert pass is required when the export format differs from
+	// the source, OR when compression is requested for a compressible target
+	// (qcow2): qemu-img applies `-c` only during a convert pass, so we force one
+	// to honor req.Compress even when the format is unchanged (#219). Raw and
+	// vmdk targets are not given a forced pass for compression here — see
+	// exportNeedsConversion for the exact rule.
 	var uploadPath string
-	if targetFormat != diskInfo.Format {
-		p.logger.Info("Converting disk format", "from", diskInfo.Format, "to", targetFormat)
+	if exportNeedsConversion(diskInfo.Format, targetFormat, req.Compress) {
+		p.logger.Info("Converting disk format",
+			"from", diskInfo.Format, "to", targetFormat, "compress", req.Compress)
 		convertedPath := fmt.Sprintf("/tmp/%s-converted.%s", exportID, targetFormat)
 
 		// Use diskutil for conversion
@@ -1364,7 +1394,9 @@ func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskReq
 			DestinationPath:   convertedPath,
 			SourceFormat:      diskutil.SupportedFormat(diskInfo.Format),
 			DestinationFormat: diskutil.SupportedFormat(targetFormat),
-			Compression:       false, // No compression for migration (faster)
+			// Honor the caller's request (#219). diskutil applies `-c` only to
+			// qcow2; for raw/vmdk targets this is a no-op at the qemu-img layer.
+			Compression: req.Compress,
 		})
 		if err != nil {
 			return nil, errors.NewInternal("failed to convert disk format", err)


### PR DESCRIPTION
## Summary

Closes **#219** (the last residual from the #204 parity umbrella). The Proxmox `ExportDisk` path now genuinely honors `ExportDiskRequest.Compress`, and `GetCapabilities` advertises `SupportsExportCompression` — honestly, only for the format that actually compresses.

## The bug
`ExportDisk` only ran a `qemu-img convert` pass when the target format *differed* from the source, and even then hardcoded `Compression: false` — so the common qcow2→qcow2 export never compressed, and `Compress=true` was silently ignored. The capability was (correctly, at the time) advertised as `false`.

## The fix
- New pure helper **`exportNeedsConversion(sourceFormat, targetFormat, compress)`** — forces a convert pass when the format changes **or** when `compress && targetFormat == "qcow2"` (qemu-img applies `-c` only during a convert pass, so qcow2→qcow2 must be forced through one).
- `ExportDisk` now passes `Compression: req.Compress` to `diskutil.QemuImg.Convert`, which maps it to `qemu-img convert -c` for qcow2 (verified in `internal/diskutil/qemu_img.go`).
- Builder flips to `.ExportCompression()` with an honest comment.

## Honesty scope (deliberate)
- **qcow2** — genuinely compresses (`-c`). The common Proxmox export format.
- **raw** — no container to compress; `Compress=true` is a no-op (no forced pass).
- **vmdk** — not given a forced compression pass on the same-format path (a format-changing pass still applies `streamOptimized`). The capability comment under-claims here rather than over-claiming.

`SupportsExportCompression=true` is honest because the operation is genuinely performed for qcow2; the limits are documented in the helper GoDoc + capability comment (mirrors the #153/#154/#204 "true means we actually do it" posture).

## Verification
- `gofmt` clean · `go build ./...` · `golangci-lint run ./internal/providers/proxmox/...` → 0 issues (proxmox is **not** lint-excluded) · `go test ./internal/providers/proxmox/...` PASS · `make build` ✓
- New host-independent `TestExportNeedsConversion` (qcow2/raw/vmdk × compress); `TestProxmoxProvider_GetCapabilities` assertion flipped to `True`.

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (Proxmox provider image)
- [ ] Config change only
- [ ] Documentation only

No CRD or proto change (consumes the existing `ExportDiskRequest.Compress` bool). Default `Compress=false` export behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)