### PR TITLE
ci(runtime-chart): opt the Kind-test mock provider into plaintext (fixes #224, unblocks #175)

### DIFF
--- a/.github/workflows/runtime-chart.yml
+++ b/.github/workflows/runtime-chart.yml
@@ -140,6 +140,13 @@ jobs:
               value: "false"
             - name: MOCK_FAILURE_MODE
               value: ""
+            # The mock provider is a test fixture with no real credentials, so
+            # opt it into plaintext gRPC. Without this it correctly fail-closes
+            # on the secure-by-default TLS requirement (#148, v0.3.7) and the pod
+            # crash-loops. Scoped to this Kind test only; the production
+            # fail-closed default is untouched (#224).
+            - name: VIRTRIGAUD_PROVIDER_INSECURE
+              value: "true"
 
           # Minimal resource requirements for testing
           resources:


### PR DESCRIPTION
## Summary

Closes **#224**, unblocks **#175**. The `runtime-chart.yml` Kind integration test's mock provider was crash-looping because its generated test values never set `VIRTRIGAUD_PROVIDER_INSECURE` — so it correctly **fail-closed** on the secure-by-default TLS requirement (#148, v0.3.7):

```
ERROR Failed to resolve TLS configuration — TLS material missing at /etc/virtrigaud/tls
and VIRTRIGAUD_PROVIDER_INSECURE is not set to "true"
```

The job is **path-triggered** (`charts/virtrigaud-provider-runtime/**`), so it ran only on PRs touching the runtime chart or workflow — which is why it sat silently red since v0.3.7 and resurfaced on the `actions/checkout` 4→6 bump (#175). The checkout bump itself is innocent.

## Fix
Add `VIRTRIGAUD_PROVIDER_INSECURE=true` to the **mock provider** env in the Kind test's generated `/tmp/test-values.yaml`. The mock is a test fixture with no real credentials; plaintext gRPC is correct for it. **Scoped to this Kind test only** — the production fail-closed default (and every other chart values file) is untouched.

## Verification
- Workflow YAML parses; the embedded `test-values.yaml` heredoc parses and now carries the insecure opt-out (`env: [LOG_LEVEL, MOCK_SLOW_MODE, MOCK_FAILURE_MODE, VIRTRIGAUD_PROVIDER_INSECURE]`).
- The Kind Integration Test job will exercise the real fix on this PR (it touches the workflow path).

## Impact
- [ ] Breaking change
- [ ] Requires cluster rollout
- [ ] Config change only
- [x] Documentation only — CI-only; no product behavior change.

After merge, #175 needs a rebase to pick up this fix so its Kind test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)