### PR TITLE
fix(migration): non-blocking PVC-mount handshake + co-location fail-fast + diagnosable discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-10 16:36] - Fix migration PVC-mount handshake: non-blocking, diagnosable, co-location-safe
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/controller/vmmigration_controller.go`: Replaced the blocking 5-minute `time.Sleep` poll (`waitForProvidersReady`/`waitForProviderReady`/`waitForProviderBasicReady`) that waited for both providers to mount the migration storage PVC with a single-shot, non-blocking check (`migrationProvidersMounted`/`providerMountReady`) plus `RequeueAfter`. The wait deadline is now derived from the PVC's creation timestamp so it survives requeues, and a timeout fails with an actionable message (the exact `kubectl` command to inspect) instead of an opaque "timeout waiting for provider pods" error. Removes a reconcile-worker-blocking anti-pattern that could wedge the migration.
+- `internal/controller/vmmigration_controller.go`: Added a fail-fast co-location guard for PVC-based migrations (#229). A migration whose source provider, target provider, and the migration itself are not all in one namespace now fails immediately with a clear message — a Kubernetes pod cannot mount a PVC across namespaces, so the transfer could never succeed and previously hung for the full timeout.
+- `internal/controller/provider_controller.go`: `discoverMigrationPVCs`/`discoverMigrationVolumeMounts` no longer swallow the PVC `List` error silently; a denied List (missing RBAC) or an unsynced cache is now logged at error level with the namespace and label selector, so an un-mountable migration PVC is diagnosable instead of silently stranding the VMMigration controller (#231 hardening).
+- `internal/controller/vmmigration_mount_test.go`: New table-driven unit tests for the single-shot mount evaluation, the source/target aggregate, the PVC-age deadline, and the cross-namespace fail-fast path.
+
+### Why
+Live cross-provider migration could hang for five minutes and then fail with an opaque timeout. The mount handshake blocked a reconcile worker with `time.Sleep` (violating the project's no-`time.Sleep`-for-synchronization rule), the cross-namespace topology was structurally impossible yet un-guarded, and a failed PVC `List` in the provider controller was invisible. Manager PVC RBAC is already present at HEAD (chart commits `40a6b26`/`ed852c6`), so this is the handshake reliability + diagnosability fix layered on top of it.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-09] - v0.3.9: libvirt feature parity + end-to-end image preparation
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -1078,7 +1078,13 @@ func (r *ProviderReconciler) discoverMigrationPVCs(ctx context.Context, namespac
 	)
 
 	if err != nil {
-		// Log error but don't fail - migrations might not be active
+		// Don't fail the deployment build — providers must keep running when no
+		// migration is active. But never swallow this silently: a denied List
+		// (missing RBAC) or an unsynced cache makes migration PVCs invisible, so
+		// the VMMigration controller would wait indefinitely for a mount that the
+		// provider can never apply. Surface it so the failure is diagnosable.
+		log.FromContext(ctx).Error(err, "failed to list migration PVCs; migration storage will not be mounted",
+			"namespace", namespace, "labelSelector", fmt.Sprintf("%s=%s", migrationPVCLabelKey, migrationPVCLabelValue))
 		return volumes
 	}
 
@@ -1119,7 +1125,10 @@ func (r *ProviderReconciler) discoverMigrationVolumeMounts(ctx context.Context, 
 	)
 
 	if err != nil {
-		// Log error but don't fail - migrations might not be active
+		// See discoverMigrationPVCs: never swallow this silently — an invisible
+		// migration PVC strands the VMMigration controller waiting for a mount.
+		log.FromContext(ctx).Error(err, "failed to list migration PVCs; migration storage will not be mounted",
+			"namespace", namespace, "labelSelector", fmt.Sprintf("%s=%s", migrationPVCLabelKey, migrationPVCLabelValue))
 		return mounts
 	}
 

--- a/internal/controller/vmmigration_controller.go
+++ b/internal/controller/vmmigration_controller.go
@@ -326,30 +326,67 @@ func (r *VMMigrationReconciler) handleValidatingPhase(ctx context.Context, migra
 			return r.transitionToFailed(ctx, migration, fmt.Sprintf("Invalid storage configuration: %v", err))
 		}
 
+		// Fail fast on a cross-namespace topology (#229). The migration transfer
+		// PVC is mounted into both the source and target provider pods, and a
+		// Kubernetes pod can only mount a PVC from its own namespace. If either
+		// provider lives in a different namespace than the migration (and thus the
+		// PVC), the mount can never happen — reject it up front with an actionable
+		// message instead of letting the handshake time out opaquely.
+		if sourceProvider.Namespace != migration.Namespace || targetProvider.Namespace != migration.Namespace {
+			return r.transitionToFailed(ctx, migration, fmt.Sprintf(
+				"PVC-based migration requires the migration (%s), source provider (%s/%s) and target provider (%s/%s) "+
+					"to share one namespace; a pod cannot mount a PVC across namespaces",
+				migration.Namespace, sourceProvider.Namespace, sourceProvider.Name,
+				targetProvider.Namespace, targetProvider.Name))
+		}
+
 		// Ensure PVC exists or create it
 		pvcName, err := r.ensureMigrationPVC(ctx, migration)
 		if err != nil {
 			return r.transitionToFailed(ctx, migration, fmt.Sprintf("Failed to ensure migration PVC: %v", err))
 		}
 
-		// Store PVC name in migration status for later use
-		pvcJustCreated := migration.Status.StoragePVCName == ""
-		if pvcJustCreated {
+		// Record the PVC name so later phases can find it.
+		if migration.Status.StoragePVCName == "" {
 			migration.Status.StoragePVCName = pvcName
 			if err := r.updateStatus(ctx, migration); err != nil {
 				return ctrl.Result{}, err
 			}
-
-			// Wait for providers to restart with new PVC mount
-			// This gives providers time to update their deployments and restart pods
-			logger.Info("Waiting for providers to restart with PVC mount", "pvc", pvcName)
-			if err := r.waitForProvidersReady(ctx, migration, pvcName); err != nil {
-				return r.transitionToFailed(ctx, migration, fmt.Sprintf("Providers not ready after PVC mount: %v", err))
-			}
-			logger.Info("Providers ready with PVC mounted", "pvc", pvcName)
 		}
 
-		logger.Info("Migration storage PVC ready", "pvc", pvcName)
+		// Non-blocking wait for both providers to roll a pod with the PVC mounted.
+		// The provider controller watches migration PVCs and re-rolls its
+		// Deployment to attach them; rather than blocking a reconcile worker with
+		// a time.Sleep poll, evaluate the mount state once and requeue until it
+		// settles or the deadline (derived from the PVC's age) elapses.
+		ready, reason, err := r.migrationProvidersMounted(ctx, sourceProvider, targetProvider, pvcName)
+		if err != nil {
+			return r.transitionToFailed(ctx, migration, fmt.Sprintf("Failed to check migration storage mount: %v", err))
+		}
+		if !ready {
+			exceeded, mErr := r.migrationMountDeadlineExceeded(ctx, migration, pvcName)
+			if mErr != nil {
+				return r.transitionToFailed(ctx, migration, fmt.Sprintf("Failed to check migration storage mount: %v", mErr))
+			}
+			if exceeded {
+				return r.transitionToFailed(ctx, migration, fmt.Sprintf(
+					"timed out after %s waiting for providers to mount migration PVC %s (%s); "+
+						"verify the provider Deployments rolled new pods and that those pods are Ready "+
+						"(kubectl -n %s get deploy,pod -l app.kubernetes.io/name=virtrigaud-provider)",
+					migrationMountTimeout, pvcName, reason, migration.Namespace))
+			}
+
+			k8s.SetCondition(&migration.Status.Conditions, infrav1beta1.VMMigrationConditionValidating,
+				metav1.ConditionFalse, "WaitingForStorageMount", reason)
+			migration.Status.Message = fmt.Sprintf("Waiting for providers to mount migration storage: %s", reason)
+			if err := r.updateStatus(ctx, migration); err != nil {
+				return ctrl.Result{}, err
+			}
+			logger.Info("Waiting for providers to mount migration PVC", "pvc", pvcName, "reason", reason)
+			return ctrl.Result{RequeueAfter: migrationMountPollInterval}, nil
+		}
+
+		logger.Info("Migration storage PVC mounted on both providers", "pvc", pvcName)
 	}
 
 	// Validation complete, transition to next phase
@@ -1653,275 +1690,127 @@ func (r *VMMigrationReconciler) triggerProviderReconciliation(ctx context.Contex
 	return nil
 }
 
-// waitForProvidersReady waits for both source and target providers to be ready
-// after a PVC mount update (which triggers pod restart)
-func (r *VMMigrationReconciler) waitForProvidersReady(ctx context.Context, migration *infrav1beta1.VMMigration, pvcName string) error {
-	logger := logging.FromContext(ctx)
-	timeout := 5 * time.Minute
-	pollInterval := 5 * time.Second
+// migrationMountTimeout bounds how long the VMMigration controller waits for
+// both providers to roll a pod with the migration PVC mounted before failing
+// with a diagnosable error. It is measured from the PVC's creation time so the
+// budget is stable across reconciles and controller restarts.
+const migrationMountTimeout = 5 * time.Minute
 
-	logger.Info("Waiting for providers to be ready after PVC mount update", "pvc", pvcName)
+// migrationMountPollInterval is the requeue cadence while waiting for the
+// provider controller to apply and roll out the migration PVC mount.
+const migrationMountPollInterval = 5 * time.Second
 
-	// Wait for source provider
-	sourceProvider, err := r.getSourceProvider(ctx, migration)
+// migrationProvidersMounted reports whether BOTH the source and target provider
+// pods have rolled with the migration PVC mounted and Ready. It is a single,
+// non-blocking evaluation: callers requeue rather than sleep. When ready is
+// false, reason describes (with a source/target prefix) what it is waiting on.
+func (r *VMMigrationReconciler) migrationProvidersMounted(ctx context.Context, source, target *infrav1beta1.Provider, pvcName string) (bool, string, error) {
+	ready, reason, err := r.providerMountReady(ctx, source, pvcName)
 	if err != nil {
-		return fmt.Errorf("failed to get source provider: %w", err)
+		return false, "", fmt.Errorf("source provider %s: %w", source.Name, err)
+	}
+	if !ready {
+		return false, "source: " + reason, nil
 	}
 
-	if err := r.waitForProviderReady(ctx, sourceProvider, pvcName, timeout, pollInterval); err != nil {
-		return fmt.Errorf("source provider not ready: %w", err)
-	}
-
-	// Wait for target provider
-	targetProvider, err := r.getTargetProvider(ctx, migration)
+	ready, reason, err = r.providerMountReady(ctx, target, pvcName)
 	if err != nil {
-		return fmt.Errorf("failed to get target provider: %w", err)
+		return false, "", fmt.Errorf("target provider %s: %w", target.Name, err)
+	}
+	if !ready {
+		return false, "target: " + reason, nil
 	}
 
-	if err := r.waitForProviderReady(ctx, targetProvider, pvcName, timeout, pollInterval); err != nil {
-		return fmt.Errorf("target provider not ready: %w", err)
-	}
-
-	logger.Info("All providers are ready")
-	return nil
+	return true, "", nil
 }
 
-// waitForProviderReady waits for a single provider to be ready with PVC mounted
-// This function ensures that:
-// 1. The provider deployment has been updated with the migration PVC
-// 2. New pods with the PVC mount are Running and Ready
-// 3. Old pods without the PVC have been terminated
-func (r *VMMigrationReconciler) waitForProviderReady(ctx context.Context, provider *infrav1beta1.Provider, pvcName string, timeout, pollInterval time.Duration) error {
-	logger := logging.FromContext(ctx)
-	deadline := time.Now().Add(timeout)
-
-	// If no PVC name provided, just check basic readiness
-	if pvcName == "" {
-		logger.Info("No migration PVC specified, checking basic readiness", "provider", provider.Name)
-		return r.waitForProviderBasicReady(ctx, provider, timeout, pollInterval)
-	}
-
-	logger.Info("Waiting for provider pods with PVC mount to be ready",
-		"provider", provider.Name,
-		"pvc", pvcName,
-		"timeout", timeout)
-
+// providerMountReady performs a single, non-blocking check that the given
+// provider's Deployment has rolled a Running, Ready pod carrying the migration
+// PVC. The provider controller is responsible for discovering migration PVCs
+// (label virtrigaud.io/component=migration-storage) and attaching them to its
+// Deployment; this only observes the result. The returned reason explains what
+// is still pending when ready is false.
+func (r *VMMigrationReconciler) providerMountReady(ctx context.Context, provider *infrav1beta1.Provider, pvcName string) (bool, string, error) {
 	deploymentName := fmt.Sprintf("virtrigaud-provider-%s-%s", provider.Namespace, provider.Name)
 
-	for {
-		// Check if context is cancelled
-		if ctx.Err() != nil {
-			return ctx.Err()
+	deployment := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: provider.Namespace}, deployment); err != nil {
+		if errors.IsNotFound(err) {
+			return false, fmt.Sprintf("provider deployment %s not found yet", deploymentName), nil
 		}
-
-		// Check timeout
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout waiting for provider %s pods with PVC %s to be ready", provider.Name, pvcName)
-		}
-
-		// Check deployment status
-		deployment := &appsv1.Deployment{}
-		if err := r.Get(ctx, types.NamespacedName{
-			Name:      deploymentName,
-			Namespace: provider.Namespace,
-		}, deployment); err != nil {
-			logger.Error(err, "Failed to get provider deployment", "deployment", deploymentName)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		// Verify deployment has the PVC volume
-		hasPVC := false
-		for _, vol := range deployment.Spec.Template.Spec.Volumes {
-			if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvcName {
-				hasPVC = true
-				break
-			}
-		}
-
-		if !hasPVC {
-			logger.Info("Deployment doesn't have PVC yet, waiting for provider controller to update",
-				"deployment", deploymentName,
-				"pvc", pvcName)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		// Check if deployment rollout is complete
-		// All replicas must be updated and ready
-		if deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-			logger.Info("Waiting for deployment to update all replicas",
-				"deployment", deploymentName,
-				"updated", deployment.Status.UpdatedReplicas,
-				"desired", *deployment.Spec.Replicas)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		if deployment.Status.ReadyReplicas < *deployment.Spec.Replicas {
-			logger.Info("Waiting for all replicas to be ready",
-				"deployment", deploymentName,
-				"ready", deployment.Status.ReadyReplicas,
-				"desired", *deployment.Spec.Replicas)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		// Verify actual pods have the PVC mounted and are ready
-		podList := &corev1.PodList{}
-		labelSelector := client.MatchingLabels{
-			"app.kubernetes.io/name":     "virtrigaud-provider",
-			"app.kubernetes.io/instance": provider.Name,
-		}
-
-		if err := r.List(ctx, podList, client.InNamespace(provider.Namespace), labelSelector); err != nil {
-			logger.Error(err, "Failed to list provider pods", "provider", provider.Name)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		if len(podList.Items) == 0 {
-			logger.Info("No pods found for provider yet", "provider", provider.Name)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		// Check each pod
-		allPodsReady := true
-		podsWithPVC := 0
-
-		for i := range podList.Items {
-			pod := &podList.Items[i]
-
-			// Skip terminating pods
-			if pod.DeletionTimestamp != nil {
-				logger.Info("Skipping terminating pod",
-					"pod", pod.Name,
-					"deletionTimestamp", pod.DeletionTimestamp)
-				continue
-			}
-
-			// Check if pod has the PVC mounted
-			podHasPVC := false
-			for _, vol := range pod.Spec.Volumes {
-				if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvcName {
-					podHasPVC = true
-					break
-				}
-			}
-
-			if !podHasPVC {
-				logger.Info("Pod doesn't have PVC mount, waiting for new pod",
-					"pod", pod.Name,
-					"pvc", pvcName)
-				allPodsReady = false
-				continue
-			}
-
-			podsWithPVC++
-
-			// Check pod phase
-			if pod.Status.Phase != corev1.PodRunning {
-				logger.Info("Pod not running yet",
-					"pod", pod.Name,
-					"phase", pod.Status.Phase)
-				allPodsReady = false
-				continue
-			}
-
-			// Check pod ready condition
-			podReady := false
-			for _, cond := range pod.Status.Conditions {
-				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-					podReady = true
-					break
-				}
-			}
-
-			if !podReady {
-				logger.Info("Pod not ready yet",
-					"pod", pod.Name,
-					"conditions", pod.Status.Conditions)
-				allPodsReady = false
-				continue
-			}
-
-			// Check container statuses
-			for _, cs := range pod.Status.ContainerStatuses {
-				if !cs.Ready {
-					logger.Info("Container not ready",
-						"pod", pod.Name,
-						"container", cs.Name,
-						"ready", cs.Ready)
-					allPodsReady = false
-				}
-			}
-		}
-
-		if podsWithPVC == 0 {
-			logger.Info("No pods with PVC mount found yet, waiting", "pvc", pvcName)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		if !allPodsReady {
-			logger.Info("Some pods not ready yet, waiting",
-				"podsWithPVC", podsWithPVC)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		// All checks passed - pods are ready
-		// Add grace period for NFS mounts to fully stabilize
-		// Even though pod is "Ready", NFS mounts can take a few extra seconds
-		logger.Info("Provider pods ready, waiting for NFS mount to stabilize",
-			"provider", provider.Name,
-			"pvc", pvcName,
-			"podsReady", podsWithPVC,
-			"gracePeriod", "10s")
-
-		time.Sleep(10 * time.Second)
-
-		logger.Info("Provider pods with PVC are ready",
-			"provider", provider.Name,
-			"pvc", pvcName,
-			"podsReady", podsWithPVC)
-		return nil
+		return false, "", fmt.Errorf("get provider deployment %s: %w", deploymentName, err)
 	}
+
+	// The provider controller must have applied the PVC to the Deployment template.
+	if !volumesContainPVC(deployment.Spec.Template.Spec.Volumes, pvcName) {
+		return false, "deployment not yet updated with the migration PVC volume", nil
+	}
+
+	// The rollout that attaches the PVC must be complete.
+	replicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		replicas = *deployment.Spec.Replicas
+	}
+	if deployment.Status.UpdatedReplicas < replicas || deployment.Status.ReadyReplicas < replicas {
+		return false, fmt.Sprintf("provider rollout in progress (updated %d/%d, ready %d/%d)",
+			deployment.Status.UpdatedReplicas, replicas, deployment.Status.ReadyReplicas, replicas), nil
+	}
+
+	// At least one non-terminating pod must be Running, Ready and actually carry
+	// the PVC (the old pods without it must be draining/gone).
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList, client.InNamespace(provider.Namespace), client.MatchingLabels{
+		"app.kubernetes.io/name":     "virtrigaud-provider",
+		"app.kubernetes.io/instance": provider.Name,
+	}); err != nil {
+		return false, "", fmt.Errorf("list provider %s pods: %w", provider.Name, err)
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.DeletionTimestamp != nil {
+			continue // ignore pods that are terminating
+		}
+		if !volumesContainPVC(pod.Spec.Volumes, pvcName) {
+			continue // an old pod without the PVC, still draining
+		}
+		if pod.Status.Phase == corev1.PodRunning && podConditionTrue(pod, corev1.PodReady) {
+			return true, "", nil
+		}
+	}
+
+	return false, "no Ready pod with the migration PVC mounted yet", nil
 }
 
-// waitForProviderBasicReady performs basic provider readiness check (fallback when no PVC)
-func (r *VMMigrationReconciler) waitForProviderBasicReady(ctx context.Context, provider *infrav1beta1.Provider, timeout, pollInterval time.Duration) error {
-	logger := logging.FromContext(ctx)
-	deadline := time.Now().Add(timeout)
-
-	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout waiting for provider %s to be ready", provider.Name)
-		}
-
-		currentProvider := &infrav1beta1.Provider{}
-		if err := r.Get(ctx, types.NamespacedName{
-			Name:      provider.Name,
-			Namespace: provider.Namespace,
-		}, currentProvider); err != nil {
-			logger.Error(err, "Failed to get provider status", "provider", provider.Name)
-			time.Sleep(pollInterval)
-			continue
-		}
-
-		if r.isProviderReady(currentProvider) {
-			logger.Info("Provider is ready", "provider", provider.Name)
-			return nil
-		}
-
-		logger.Info("Waiting for provider to be ready", "provider", provider.Name)
-		time.Sleep(pollInterval)
+// migrationMountDeadlineExceeded reports whether the migration PVC has existed
+// longer than migrationMountTimeout without both providers mounting it. The
+// budget is anchored on the PVC's creation time so it survives requeues.
+func (r *VMMigrationReconciler) migrationMountDeadlineExceeded(ctx context.Context, migration *infrav1beta1.VMMigration, pvcName string) (bool, error) {
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: migration.Namespace}, pvc); err != nil {
+		return false, fmt.Errorf("get migration PVC %s: %w", pvcName, err)
 	}
+	return time.Since(pvc.CreationTimestamp.Time) > migrationMountTimeout, nil
+}
+
+// volumesContainPVC reports whether any volume in the slice binds the named PVC.
+func volumesContainPVC(volumes []corev1.Volume, pvcName string) bool {
+	for i := range volumes {
+		if src := volumes[i].PersistentVolumeClaim; src != nil && src.ClaimName == pvcName {
+			return true
+		}
+	}
+	return false
+}
+
+// podConditionTrue reports whether the pod has the given condition set to True.
+func podConditionTrue(pod *corev1.Pod, condType corev1.PodConditionType) bool {
+	for i := range pod.Status.Conditions {
+		if pod.Status.Conditions[i].Type == condType {
+			return pod.Status.Conditions[i].Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // gateProviderCapability enforces a single provider capability for a

--- a/internal/controller/vmmigration_mount_test.go
+++ b/internal/controller/vmmigration_mount_test.go
@@ -1,0 +1,355 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+)
+
+// mountTestScheme builds a scheme with the apps + core + infra types the
+// migration mount-handshake checks read.
+func mountTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, appsv1.AddToScheme(s))
+	require.NoError(t, infravirtrigaudiov1beta1.AddToScheme(s))
+	return s
+}
+
+// mountPVCVolume builds the volume the provider controller attaches for a
+// migration PVC (name scheme mirrors discoverMigrationPVCs).
+func mountPVCVolume(pvcName string) corev1.Volume {
+	return corev1.Volume{
+		Name: "migration-" + pvcName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+		},
+	}
+}
+
+// providerDeployment builds a provider Deployment named like the one the
+// provider controller reconciles.
+func providerDeployment(ns, name string, replicas, updated, ready int32, withPVC bool, pvcName string) *appsv1.Deployment {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("virtrigaud-provider-%s-%s", ns, name),
+			Namespace: ns,
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{
+			UpdatedReplicas: updated,
+			ReadyReplicas:   ready,
+		},
+	}
+	if withPVC {
+		d.Spec.Template.Spec.Volumes = []corev1.Volume{mountPVCVolume(pvcName)}
+	}
+	return d
+}
+
+// providerPod builds a provider pod with the standard selector labels.
+func providerPod(ns, providerName, podName string, phase corev1.PodPhase, ready, withPVC bool, pvcName string) *corev1.Pod {
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "virtrigaud-provider",
+				"app.kubernetes.io/instance": providerName,
+			},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+	if withPVC {
+		p.Spec.Volumes = []corev1.Volume{mountPVCVolume(pvcName)}
+	}
+	if ready {
+		p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	}
+	return p
+}
+
+func readyProvider(ns, name string) *infravirtrigaudiov1beta1.Provider {
+	return &infravirtrigaudiov1beta1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status: infravirtrigaudiov1beta1.ProviderStatus{
+			Conditions: []metav1.Condition{{
+				Type:               "ProviderAvailable",
+				Status:             metav1.ConditionTrue,
+				Reason:             "RemoteAvailable",
+				Message:            "ready",
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+}
+
+// TestProviderMountReady covers the single-shot mount evaluation that replaced
+// the blocking time.Sleep poll.
+func TestProviderMountReady(t *testing.T) {
+	const ns, provName, pvc = "default", "vsphere-lab", "mig-1-storage"
+
+	tests := []struct {
+		name       string
+		objs       []client.Object
+		deleting   string // pod name to Delete (sets DeletionTimestamp via finalizer)
+		wantReady  bool
+		wantReason string
+	}{
+		{
+			name:       "deployment missing",
+			objs:       nil,
+			wantReady:  false,
+			wantReason: "not found yet",
+		},
+		{
+			name:       "deployment without PVC volume",
+			objs:       []client.Object{providerDeployment(ns, provName, 1, 1, 1, false, pvc)},
+			wantReady:  false,
+			wantReason: "not yet updated with the migration PVC volume",
+		},
+		{
+			name:       "rollout in progress",
+			objs:       []client.Object{providerDeployment(ns, provName, 1, 0, 1, true, pvc)},
+			wantReady:  false,
+			wantReason: "rollout in progress",
+		},
+		{
+			name: "rolled out but only old pod without PVC",
+			objs: []client.Object{
+				providerDeployment(ns, provName, 1, 1, 1, true, pvc),
+				providerPod(ns, provName, "old-pod", corev1.PodRunning, true, false, pvc),
+			},
+			wantReady:  false,
+			wantReason: "no Ready pod with the migration PVC mounted yet",
+		},
+		{
+			name: "pod with PVC not yet Ready",
+			objs: []client.Object{
+				providerDeployment(ns, provName, 1, 1, 1, true, pvc),
+				providerPod(ns, provName, "new-pod", corev1.PodPending, false, true, pvc),
+			},
+			wantReady:  false,
+			wantReason: "no Ready pod with the migration PVC mounted yet",
+		},
+		{
+			name: "ready pod with PVC mounted",
+			objs: []client.Object{
+				providerDeployment(ns, provName, 1, 1, 1, true, pvc),
+				providerPod(ns, provName, "new-pod", corev1.PodRunning, true, true, pvc),
+			},
+			wantReady: true,
+		},
+		{
+			name: "ready PVC pod is terminating -> ignored",
+			objs: []client.Object{
+				providerDeployment(ns, provName, 1, 1, 1, true, pvc),
+				providerPod(ns, provName, "dying-pod", corev1.PodRunning, true, true, pvc),
+			},
+			deleting:   "dying-pod",
+			wantReady:  false,
+			wantReason: "no Ready pod with the migration PVC mounted yet",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			scheme := mountTestScheme(t)
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if len(tc.objs) > 0 {
+				builder = builder.WithObjects(tc.objs...)
+			}
+			c := builder.Build()
+
+			if tc.deleting != "" {
+				// Give the pod a finalizer then Delete it so the fake client
+				// retains it with a DeletionTimestamp (Terminating).
+				pod := &corev1.Pod{}
+				require.NoError(t, c.Get(ctx, types.NamespacedName{Name: tc.deleting, Namespace: ns}, pod))
+				pod.Finalizers = []string{"test/keep"}
+				require.NoError(t, c.Update(ctx, pod))
+				require.NoError(t, c.Delete(ctx, pod))
+			}
+
+			r := &VMMigrationReconciler{Client: c, Scheme: scheme}
+			provider := &infravirtrigaudiov1beta1.Provider{
+				ObjectMeta: metav1.ObjectMeta{Name: provName, Namespace: ns},
+			}
+
+			ready, reason, err := r.providerMountReady(ctx, provider, pvc)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantReady, ready)
+			if tc.wantReason != "" {
+				assert.Contains(t, reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestMigrationProvidersMounted verifies both providers must be mounted and the
+// reason is prefixed with which side is pending.
+func TestMigrationProvidersMounted(t *testing.T) {
+	const ns, pvc = "default", "mig-1-storage"
+	ctx := context.Background()
+	scheme := mountTestScheme(t)
+
+	source := &infravirtrigaudiov1beta1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: ns}}
+	target := &infravirtrigaudiov1beta1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "tgt", Namespace: ns}}
+
+	t.Run("target still pending", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			// source fully mounted
+			providerDeployment(ns, "src", 1, 1, 1, true, pvc),
+			providerPod(ns, "src", "src-pod", corev1.PodRunning, true, true, pvc),
+			// target deployment not yet updated
+			providerDeployment(ns, "tgt", 1, 1, 1, false, pvc),
+		).Build()
+		r := &VMMigrationReconciler{Client: c, Scheme: scheme}
+
+		ready, reason, err := r.migrationProvidersMounted(ctx, source, target, pvc)
+		require.NoError(t, err)
+		assert.False(t, ready)
+		assert.Contains(t, reason, "target:")
+	})
+
+	t.Run("both mounted", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			providerDeployment(ns, "src", 1, 1, 1, true, pvc),
+			providerPod(ns, "src", "src-pod", corev1.PodRunning, true, true, pvc),
+			providerDeployment(ns, "tgt", 1, 1, 1, true, pvc),
+			providerPod(ns, "tgt", "tgt-pod", corev1.PodRunning, true, true, pvc),
+		).Build()
+		r := &VMMigrationReconciler{Client: c, Scheme: scheme}
+
+		ready, reason, err := r.migrationProvidersMounted(ctx, source, target, pvc)
+		require.NoError(t, err)
+		assert.True(t, ready)
+		assert.Empty(t, reason)
+	})
+}
+
+// TestMigrationMountDeadlineExceeded verifies the wait is bounded by the PVC's age.
+func TestMigrationMountDeadlineExceeded(t *testing.T) {
+	const ns, pvcName = "default", "mig-1-storage"
+	ctx := context.Background()
+	scheme := mountTestScheme(t)
+
+	migration := &infravirtrigaudiov1beta1.VMMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "mig-1", Namespace: ns},
+	}
+
+	newPVC := func(age time.Duration) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              pvcName,
+				Namespace:         ns,
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+			},
+		}
+	}
+
+	t.Run("fresh PVC is within deadline", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newPVC(10 * time.Second)).Build()
+		r := &VMMigrationReconciler{Client: c, Scheme: scheme}
+		exceeded, err := r.migrationMountDeadlineExceeded(ctx, migration, pvcName)
+		require.NoError(t, err)
+		assert.False(t, exceeded)
+	})
+
+	t.Run("old PVC has exceeded the deadline", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newPVC(migrationMountTimeout + time.Minute)).Build()
+		r := &VMMigrationReconciler{Client: c, Scheme: scheme}
+		exceeded, err := r.migrationMountDeadlineExceeded(ctx, migration, pvcName)
+		require.NoError(t, err)
+		assert.True(t, exceeded)
+	})
+}
+
+// TestHandleValidatingPhase_CrossNamespaceFailsFast verifies a PVC-based
+// migration whose providers are not co-located with the migration fails fast
+// with an actionable message instead of waiting for a mount that can never
+// happen (#229).
+func TestHandleValidatingPhase_CrossNamespaceFailsFast(t *testing.T) {
+	ctx := context.Background()
+	scheme := mountTestScheme(t)
+
+	migration := &infravirtrigaudiov1beta1.VMMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: "mig-x", Namespace: "default"},
+		Spec: infravirtrigaudiov1beta1.VMMigrationSpec{
+			Source: infravirtrigaudiov1beta1.MigrationSource{
+				VMRef:       infravirtrigaudiov1beta1.LocalObjectReference{Name: "src-vm"},
+				ProviderRef: &infravirtrigaudiov1beta1.ObjectRef{Name: "src-prov", Namespace: "team-a"},
+			},
+			Target: infravirtrigaudiov1beta1.MigrationTarget{
+				Name:        "tgt-vm",
+				ProviderRef: infravirtrigaudiov1beta1.ObjectRef{Name: "tgt-prov"},
+			},
+			Storage: &infravirtrigaudiov1beta1.MigrationStorage{
+				Type: "pvc",
+				PVC: &infravirtrigaudiov1beta1.PVCStorageConfig{
+					StorageClassName: "std",
+					Size:             "10Gi",
+				},
+			},
+		},
+		Status: infravirtrigaudiov1beta1.VMMigrationStatus{Phase: infravirtrigaudiov1beta1.MigrationPhaseValidating},
+	}
+
+	srcVM := &infravirtrigaudiov1beta1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "src-vm", Namespace: "default"},
+		Status:     infravirtrigaudiov1beta1.VirtualMachineStatus{ID: "vm-1"},
+	}
+	srcProv := readyProvider("team-a", "src-prov") // different namespace than the migration
+	tgtProv := readyProvider("default", "tgt-prov")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(migration, srcVM, srcProv, tgtProv).
+		WithStatusSubresource(&infravirtrigaudiov1beta1.VMMigration{}).
+		Build()
+
+	r := &VMMigrationReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+
+	_, err := r.handleValidatingPhase(ctx, migration)
+	require.NoError(t, err)
+
+	updated := &infravirtrigaudiov1beta1.VMMigration{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "mig-x", Namespace: "default"}, updated))
+	assert.Equal(t, infravirtrigaudiov1beta1.MigrationPhaseFailed, updated.Status.Phase)
+	assert.Contains(t, updated.Status.Message, "share one namespace")
+}


### PR DESCRIPTION
## Summary

Live cross-provider VM migration could hang for **five minutes** and then fail with an opaque `timeout waiting for provider pods` error. Root-causing the lab failures showed the storage-mount **handshake** between the VMMigration controller and the Provider controller has three real defects — none of them RBAC (manager PVC RBAC is already present at HEAD via chart commits `40a6b26`/`ed852c6`).

This PR fixes the handshake itself.

### 1. Non-blocking mount wait (the "wedge")
`waitForProvidersReady`/`waitForProviderReady`/`waitForProviderBasicReady` blocked a reconcile worker for up to **5 minutes per provider** in a `time.Sleep` poll loop — a worker-blocking anti-pattern that also violates the project's *no `time.Sleep` for synchronization* rule. Replaced with a single-shot, non-blocking evaluation (`migrationProvidersMounted` → `providerMountReady`) plus `RequeueAfter`. The wait deadline is now derived from the **PVC's creation timestamp** so it survives requeues/restarts, and a timeout fails with an **actionable** message (the exact `kubectl` command to inspect the rollout) instead of an opaque timeout.

### 2. Co-location fail-fast (#229)
The transfer PVC (RWX) is mounted into *both* the source and target provider pods, and a Kubernetes pod can only mount a PVC from its **own namespace**. A migration whose source provider, target provider, and the migration itself are not all co-located is therefore structurally impossible — yet it was un-guarded and hung for the full timeout. It now fails immediately with a clear message.

### 3. Diagnosable discovery (#231 hardening)
`discoverMigrationPVCs`/`discoverMigrationVolumeMounts` silently swallowed the PVC `List` error. A denied List (missing RBAC) or an unsynced cache made migration PVCs invisible, stranding the VMMigration controller waiting for a mount the provider could never apply — with **zero signal**. It now logs at error level with the namespace + label selector.

## Tests
New table-driven unit tests (`vmmigration_mount_test.go`):
- `providerMountReady` — deployment missing / no PVC volume / rollout in progress / old-pod-only / pod-not-ready / ready+mounted / terminating-pod-ignored
- `migrationProvidersMounted` — source/target aggregate + which-side reason prefix
- `migrationMountDeadlineExceeded` — PVC-age bound
- `handleValidatingPhase` cross-namespace → fail fast

## Verification
- `make fmt` — clean
- `make lint` — 0 issues
- `make test` — all packages pass
- `make build` — succeeds
- No `*_types.go` / proto changes → no CRD/proto regen

## Not in scope / known limitations
- **Cross-namespace migration is rejected, not enabled** — sharing one RWX PVC across namespaces is impossible in Kubernetes; enabling cross-namespace transfer would need a different mechanism (separate follow-up).
- The mount mechanism still re-rolls the *shared* provider Deployment to attach a per-migration PVC; that remains heavyweight (disruptive to other VMs on the same provider) and is worth re-architecting separately.

Relates to #229, #231. Lab E2E (isolated same-namespace provider pair) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)