### PR TITLE
fix(build): bump Makefile BUILDER_IMAGE to golang:1.26.4 (match go.mod)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-11 04:07] - Fix stale Makefile builder image (Go version drift)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `Makefile`: Bumped `BUILDER_IMAGE ?= golang:1.25` → `golang:1.26.4` to match `go.mod` (`go 1.26.4`). The Makefile passes `BUILDER_IMAGE` as a `--build-arg` to the Dockerfiles (overriding their already-correct `golang:1.26.4` default), so the stale value made a plain `make docker-build` fail with `go: go.mod requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)`. Added a comment to keep it in lockstep with `go.mod`.
+
+### Why
+Local container builds via `make docker-build`/`make docker-buildx` were broken unless the caller manually passed `BUILDER_IMAGE=`. CI and the release pipeline were unaffected — they build with `docker/build-push-action` against the Dockerfile (whose default is already `golang:1.26.4`) and resolve their Go toolchain from `go.mod` via `go-version-file`.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-10 16:36] - Fix migration PVC-mount handshake: non-blocking, diagnosable, co-location-safe
 **Author:** @wrkode (William Rizzo)
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,12 @@ TAG ?= latest
 PLATFORM ?= linux/amd64
 BUILD_PLATFORMS ?= linux/arm64,linux/amd64
 
-# Base images for building containers
-BUILDER_IMAGE ?= golang:1.25
+# Base images for building containers.
+# BUILDER_IMAGE must satisfy the Go version in go.mod (currently 1.26.4); the
+# Makefile passes it as a --build-arg to the Dockerfiles, overriding their
+# defaults, so a stale value here makes `make docker-build` fail with
+# "go.mod requires go >= 1.26.4". Keep this in lockstep with go.mod.
+BUILDER_IMAGE ?= golang:1.26.4
 BASE_IMAGE ?= gcr.io/distroless/static:nonroot
 
 # Go module proxy configuration


### PR DESCRIPTION
## Summary
The Makefile defaulted `BUILDER_IMAGE ?= golang:1.25` and passes it as a `--build-arg` to the manager/provider Dockerfiles, **overriding** their already-correct `golang:1.26.4` default. Because `go.mod` requires `go 1.26.4` with `GOTOOLCHAIN=local`, a plain `make docker-build` failed at `go mod download`:

```
go: go.mod requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)
```

This bumps the Makefile default to `golang:1.26.4` and adds a comment to keep it in lockstep with `go.mod`.

## Blast radius
- **Local container builds** (`make docker-build` / `make docker-buildx`) were broken unless the caller manually passed `BUILDER_IMAGE=`. Fixed.
- **CI and release are unaffected** — they build with `docker/build-push-action` against the Dockerfile (default already `golang:1.26.4`) and resolve their Go toolchain from `go.mod` via `go-version-file`. That's why releases kept passing.

## Verification
`make docker-build` with **no** `BUILDER_IMAGE` override now completes — `go mod download` and `go build` both pass and the image is produced. Found while building a dev manager image during the #232 lab validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)