### PR TITLE
fix(image-prepare): don't hold VM create for already-present image sources (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-11 04:34] - Don't hold VM create for already-present image sources (#227)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/controller/virtualmachine_image_prepare.go`: A VM referencing a **reference-style** `VMImage` source — a libvirt pool-file `path`, an existing vSphere `templateName`/`contentLibrary`, or an existing Proxmox `templateID`/`templateName` — with `prepare.onMissing: Fail` was held in `WaitingForDependencies` forever, waiting for an import that has nothing to import. `EnsureImageOnProvider` now classifies the source via a new `imageSourceNeedsPrepare` helper and proceeds straight to create for already-present references (the by-reference create path consumes them directly). Import-style sources (libvirt/vSphere URLs, HTTP/registry/DataVolume pulls) are unchanged — they still prepare, and `onMissing: Fail` still holds them. Ambiguous sources (e.g. a libvirt source with both a path and a URL) prefer running the idempotent prepare, so no real import is ever silently skipped.
+- `internal/controller/virtualmachine_image_prepare_test.go`: Added a source-classification table test plus #227 regression tests (libvirt path + vSphere template with `onMissing: Fail` now skip the hold).
+
+### Why
+Discovered during the v0.3.9 lab E2E: a libvirt path-based image (the qcow2 already sits on the host) was held even though there is nothing to prepare. A wrong path/template now fails honestly at create time — where a missing backing artifact belongs — instead of being pre-held by the prepare gate.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-11 04:07] - Fix stale Makefile builder image (Go version drift)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/controller/virtualmachine_image_prepare.go
+++ b/internal/controller/virtualmachine_image_prepare.go
@@ -125,6 +125,22 @@ func (r *VirtualMachineReconciler) EnsureImageOnProvider(
 		return false, nil
 	}
 
+	// Reference-style sources need no import. A libvirt pool-file path, an
+	// existing vSphere template / content-library item, or an existing Proxmox
+	// template is already present on the provider — there is nothing to download
+	// or convert, so it is "available" by construction. Proceed straight to create
+	// using the source as-is, even when Prepare.OnMissing=Fail, rather than holding
+	// the VM for a prepare that need not (and will not) happen (issue #227). The
+	// by-reference create path already consumes these directly — see
+	// overrideImageWithPreparedLocation's fallback — and a wrong path/template
+	// still fails honestly at create time, which is where a missing backing
+	// artifact belongs.
+	if !imageSourceNeedsPrepare(vmImage) {
+		logger.V(1).Info("Image source is already present on the provider (no import needed); proceeding to create",
+			"provider", provider.Name, "image", vmImage.Name)
+		return false, nil
+	}
+
 	// Honor OnMissing. Default (and explicit Import) prepares. Fail records a
 	// terminal-ish condition and holds; Wait holds pending an out-of-band
 	// preparer without erroring. Both return errImagePrepareHold so reconcileVM
@@ -288,6 +304,49 @@ func imageMissingAction(vmImage *infravirtrigaudiov1beta1.VMImage) infravirtriga
 		return infravirtrigaudiov1beta1.ImageMissingActionImport
 	}
 	return vmImage.Spec.Prepare.OnMissing
+}
+
+// imageSourceNeedsPrepare reports whether the VMImage's source must be imported
+// onto the provider before a VM can use it.
+//
+// Import-style sources produce a NEW artifact on the provider and DO need
+// preparing: a libvirt download URL, a vSphere OVA URL, and any HTTP / container
+// registry / DataVolume pull.
+//
+// Reference-style sources point at something ALREADY PRESENT on the provider and
+// need NO preparation — a libvirt pool-file path, an existing vSphere template or
+// content-library item, or an existing Proxmox template (by id or name). These
+// are exactly the locations the by-reference create path already consumes
+// directly (see overrideImageWithPreparedLocation), so returning false for them
+// lets such an image create normally instead of being held for an import that
+// need not happen (issue #227).
+//
+// Ambiguous or unrecognized sources return true (prefer running the idempotent
+// prepare over silently skipping a real import): a libvirt source carrying BOTH a
+// path and a URL, an HTTP/Registry/DataVolume source, or an entirely empty
+// source.
+func imageSourceNeedsPrepare(vmImage *infravirtrigaudiov1beta1.VMImage) bool {
+	src := vmImage.Spec.Source
+	switch {
+	case src.Libvirt != nil:
+		// A pool-file path is already present; a URL must be downloaded. A source
+		// carrying both is treated as an import (URL wins) to avoid skipping a
+		// real download.
+		return src.Libvirt.URL != "" || src.Libvirt.Path == ""
+	case src.VSphere != nil:
+		// An OVA URL imports; an existing template or content-library item does not.
+		if src.VSphere.OVAURL != "" {
+			return true
+		}
+		return src.VSphere.TemplateName == "" && src.VSphere.ContentLibrary == nil
+	case src.Proxmox != nil:
+		// Proxmox sources only ever reference an existing template (by id or name);
+		// there is no import URL. Anything with a template reference is present.
+		return src.Proxmox.TemplateID == nil && src.Proxmox.TemplateName == ""
+	default:
+		// HTTP / Registry / DataVolume (always a fetch) or an unset source.
+		return true
+	}
 }
 
 // markImagePreparing records the in-progress (Importing) state on the VMImage

--- a/internal/controller/virtualmachine_image_prepare_test.go
+++ b/internal/controller/virtualmachine_image_prepare_test.go
@@ -499,3 +499,99 @@ func TestOverrideImageWithPreparedLocation_Consume(t *testing.T) {
 		assert.Equal(t, "https://x/y.qcow2", image.URL)
 	})
 }
+
+// imageWithLibvirtPath returns a VMImage whose libvirt source is a concrete
+// pool-file PATH (already present on the host), with the given OnMissing action.
+func imageWithLibvirtPath(name string, onMissing infrav1beta1.ImageMissingAction) *infrav1beta1.VMImage {
+	img := &infrav1beta1.VMImage{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: infrav1beta1.VMImageSpec{
+			Source: infrav1beta1.ImageSource{
+				Libvirt: &infrav1beta1.LibvirtImageSource{
+					Path:   "/vm-pool01/noble-server-cloudimg-amd64.img",
+					Format: infrav1beta1.ImageFormatQCOW2,
+				},
+			},
+		},
+	}
+	if onMissing != "" {
+		img.Spec.Prepare = &infrav1beta1.ImagePrepare{OnMissing: onMissing}
+	}
+	return img
+}
+
+// TestImageSourceNeedsPrepare classifies every source kind into import-style
+// (needs prepare) vs reference-style / already-present (issue #227).
+func TestImageSourceNeedsPrepare(t *testing.T) {
+	proxmoxTmplID := 9000
+	tests := []struct {
+		name string
+		src  infrav1beta1.ImageSource
+		want bool
+	}{
+		{"libvirt path (present)", infrav1beta1.ImageSource{Libvirt: &infrav1beta1.LibvirtImageSource{Path: "/p/a.qcow2"}}, false},
+		{"libvirt url (import)", infrav1beta1.ImageSource{Libvirt: &infrav1beta1.LibvirtImageSource{URL: "https://x/a.qcow2"}}, true},
+		{"libvirt path+url (import wins)", infrav1beta1.ImageSource{Libvirt: &infrav1beta1.LibvirtImageSource{Path: "/p/a.qcow2", URL: "https://x/a.qcow2"}}, true},
+		{"libvirt empty (ambiguous)", infrav1beta1.ImageSource{Libvirt: &infrav1beta1.LibvirtImageSource{}}, true},
+		{"vsphere template (present)", infrav1beta1.ImageSource{VSphere: &infrav1beta1.VSphereImageSource{TemplateName: "ubuntu-tmpl"}}, false},
+		{"vsphere content library (present)", infrav1beta1.ImageSource{VSphere: &infrav1beta1.VSphereImageSource{ContentLibrary: &infrav1beta1.ContentLibraryRef{}}}, false},
+		{"vsphere ova (import)", infrav1beta1.ImageSource{VSphere: &infrav1beta1.VSphereImageSource{OVAURL: "https://x/a.ova"}}, true},
+		{"vsphere template+ova (import wins)", infrav1beta1.ImageSource{VSphere: &infrav1beta1.VSphereImageSource{TemplateName: "t", OVAURL: "https://x/a.ova"}}, true},
+		{"proxmox templateID (present)", infrav1beta1.ImageSource{Proxmox: &infrav1beta1.ProxmoxImageSource{TemplateID: &proxmoxTmplID}}, false},
+		{"proxmox templateName (present)", infrav1beta1.ImageSource{Proxmox: &infrav1beta1.ProxmoxImageSource{TemplateName: "ubuntu"}}, false},
+		{"proxmox empty (ambiguous)", infrav1beta1.ImageSource{Proxmox: &infrav1beta1.ProxmoxImageSource{}}, true},
+		{"http (import)", infrav1beta1.ImageSource{HTTP: &infrav1beta1.HTTPImageSource{}}, true},
+		{"registry (import)", infrav1beta1.ImageSource{Registry: &infrav1beta1.RegistryImageSource{}}, true},
+		{"datavolume (import)", infrav1beta1.ImageSource{DataVolume: &infrav1beta1.DataVolumeImageSource{}}, true},
+		{"empty source", infrav1beta1.ImageSource{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			img := &infrav1beta1.VMImage{Spec: infrav1beta1.VMImageSpec{Source: tc.src}}
+			assert.Equal(t, tc.want, imageSourceNeedsPrepare(img))
+		})
+	}
+}
+
+// TestEnsureImageOnProvider_PathSourceSkipsHold is the #227 regression: a libvirt
+// PATH source (already present on the host) with Prepare.OnMissing=Fail must NOT
+// be held for an import — it has nothing to import — so create proceeds and no
+// Failed status is written.
+func TestEnsureImageOnProvider_PathSourceSkipsHold(t *testing.T) {
+	img := imageWithLibvirtPath("ubuntu-path", infrav1beta1.ImageMissingActionFail)
+	r, _ := newEnsureReconciler(t, img)
+	provider := importCapableProvider("libvirt-1") // implements ImagePreparer + advertises import
+	inst := &preparerProvider{}
+	vm := vmForImage(provider.Name, img.Name)
+
+	requeue, err := r.EnsureImageOnProvider(context.Background(), vm, img, provider, inst)
+	require.NoError(t, err, "path source must not return the hold sentinel")
+	assert.False(t, errors.Is(err, errImagePrepareHold))
+	assert.False(t, requeue, "path source needs no prepare; proceed to create")
+	assert.Equal(t, 0, inst.calls(), "path source must not trigger a prepare RPC")
+
+	persisted := reloadImage(t, r, img.Name)
+	assert.NotEqual(t, infrav1beta1.ImagePhaseFailed, persisted.Status.Phase,
+		"a present path source must not be recorded as Failed")
+}
+
+// TestEnsureImageOnProvider_VSphereTemplateSkipsHold mirrors #227 for an existing
+// vSphere template reference with OnMissing=Fail.
+func TestEnsureImageOnProvider_VSphereTemplateSkipsHold(t *testing.T) {
+	img := &infrav1beta1.VMImage{
+		ObjectMeta: metav1.ObjectMeta{Name: "win-tmpl", Namespace: "default"},
+		Spec: infrav1beta1.VMImageSpec{
+			Source:  infrav1beta1.ImageSource{VSphere: &infrav1beta1.VSphereImageSource{TemplateName: "win2022"}},
+			Prepare: &infrav1beta1.ImagePrepare{OnMissing: infrav1beta1.ImageMissingActionFail},
+		},
+	}
+	r, _ := newEnsureReconciler(t, img)
+	provider := importCapableProvider("vsphere-1")
+	inst := &preparerProvider{}
+	vm := vmForImage(provider.Name, img.Name)
+
+	requeue, err := r.EnsureImageOnProvider(context.Background(), vm, img, provider, inst)
+	require.NoError(t, err)
+	assert.False(t, requeue)
+	assert.Equal(t, 0, inst.calls())
+}


### PR DESCRIPTION
## Summary
Fixes #227. A new VM referencing a **reference-style** `VMImage` source with `prepare.onMissing: Fail` was held in `WaitingForDependencies` forever — waiting for an import that has nothing to import:

```
Ready=False (WaitingForDependencies) — Image <name> not prepared on provider <provider>
```

The image-prepare flow (#154) exists to **import** new artifacts (download a URL, import an OVA). But a source that points at something **already present** on the provider needs no preparation at all:
- libvirt `path` (a qcow2 already on the host)
- vSphere `templateName` / `contentLibrary` (existing template/item)
- Proxmox `templateID` / `templateName` (existing template)

`EnsureImageOnProvider` now classifies the source via a new `imageSourceNeedsPrepare` helper and proceeds straight to create for already-present references — the by-reference create path already consumes them directly (it's the fallback in `overrideImageWithPreparedLocation`). A wrong path/template now fails **honestly at create time**, where a missing backing artifact belongs, instead of being pre-held by the prepare gate.

## What's unchanged (no regression)
- **Import-style sources** — libvirt/vSphere URLs, HTTP, registry, DataVolume — still prepare, and `onMissing: Fail`/`Wait` still hold them. The existing `OnMissingFail`/`OnMissingWait` tests (URL sources) stay green.
- **Ambiguous sources** (e.g. a libvirt source carrying *both* a path and a URL, or an empty source) return `needsPrepare=true` — preferring the idempotent prepare so a real import is never silently skipped.

## Tests
- `TestImageSourceNeedsPrepare` — table over every source kind (libvirt path/url/both/empty, vSphere template/content-library/ova/both, proxmox id/name/empty, http/registry/datavolume, empty).
- `TestEnsureImageOnProvider_PathSourceSkipsHold` — #227 regression: libvirt path + `onMissing: Fail` → no hold, no prepare RPC, no `Failed` status.
- `TestEnsureImageOnProvider_VSphereTemplateSkipsHold` — same for an existing vSphere template.

## Verification
`make fmt` clean · `make lint` 0 issues · `make test` pass · `make build` OK. No `*_types.go`/proto changes → no CRD/proto regen.

This also unblocks the full migration E2E that #232's lab validation couldn't complete (a path-based source VM can now provision).

Closes #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)