### PR TITLE
fix(crd): include VMMigration CRD in kustomize resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,6 +643,11 @@ jobs:
           echo "🔍 Verifying single v1beta1 version in CRDs..."
           ./hack/verify-single-version.sh
 
+      - name: Verify CRD kustomization is in sync
+        run: |
+          echo "🔍 Verifying every CRD base is referenced in kustomization..."
+          ./hack/verify-crd-kustomization.sh
+
       - name: Verify CRD generation
         run: |
           echo "🔍 Verifying CRD generation..."

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - bases/infra.virtrigaud.io_vmclones.yaml
 - bases/infra.virtrigaud.io_vmsets.yaml
 - bases/infra.virtrigaud.io_vmplacementpolicies.yaml
+- bases/infra.virtrigaud.io_vmmigrations.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 # +kubebuilder:scaffold:crdkustomizewebhookpatch

--- a/hack/verify-crd-kustomization.sh
+++ b/hack/verify-crd-kustomization.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Verify that every generated CRD base in config/crd/bases/ is referenced in
+# config/crd/kustomization.yaml (and vice-versa).
+#
+# Why this exists:
+#   `make gen-crds` (controller-gen) writes one file per CRD into
+#   config/crd/bases/, but it does NOT touch the kustomize `resources:` list.
+#   That list is only appended to by `kubebuilder create api` at the
+#   `# +kubebuilder:scaffold:crdkustomizeresource` marker. If a new CRD is added
+#   without updating kustomization.yaml, `kustomize build config/default`
+#   silently ships fewer CRDs than exist (so `make install`, `make deploy` and
+#   `make build-installer`/dist/install.yaml are all incomplete), and any
+#   controller for the missing kind crash-loops the manager at startup with
+#   `no matches for kind "..."`. The Helm path is unaffected because
+#   `make gen-helm-crds` runs controller-gen directly over ./api, bypassing
+#   this list — which is exactly why such drift can go unnoticed.
+
+set -e
+
+CRD_DIR="config/crd/bases"
+KUSTOMIZATION="config/crd/kustomization.yaml"
+
+if [ ! -d "$CRD_DIR" ]; then
+    echo "ERROR: CRD directory $CRD_DIR not found"
+    exit 1
+fi
+if [ ! -f "$KUSTOMIZATION" ]; then
+    echo "ERROR: $KUSTOMIZATION not found"
+    exit 1
+fi
+
+echo "Verifying CRD bases are in sync with $KUSTOMIZATION..."
+
+exit_code=0
+
+# 1) Every base file on disk must be referenced in the resources list.
+for crd_file in "$CRD_DIR"/*.yaml; do
+    base_name=$(basename "$crd_file")
+    if grep -qF -- "bases/${base_name}" "$KUSTOMIZATION"; then
+        echo "✅ ${base_name} is referenced"
+    else
+        echo "❌ ${base_name} exists but is NOT referenced in $KUSTOMIZATION"
+        exit_code=1
+    fi
+done
+
+# 2) Every referenced base must exist on disk (catch stale/renamed/typo entries).
+while IFS= read -r ref; do
+    if [ ! -f "$CRD_DIR/$ref" ]; then
+        echo "❌ $KUSTOMIZATION references bases/$ref but $CRD_DIR/$ref does not exist"
+        exit_code=1
+    fi
+done < <(grep -oE 'bases/[A-Za-z0-9._-]+\.yaml' "$KUSTOMIZATION" | sed 's#bases/##' | sort -u)
+
+if [ $exit_code -eq 0 ]; then
+    echo ""
+    echo "✅ All $(ls -1 "$CRD_DIR"/*.yaml | wc -l | tr -d ' ') CRD bases are referenced in kustomization.yaml"
+else
+    echo ""
+    echo "❌ CRD kustomization is out of sync."
+    echo "   For each missing CRD, add a line under 'resources:' in $KUSTOMIZATION"
+    echo "   (before the '# +kubebuilder:scaffold:crdkustomizeresource' marker):"
+    echo "     - bases/<group>_<plural>.yaml"
+fi
+
+exit $exit_code


### PR DESCRIPTION
## Problem

`config/crd/kustomization.yaml` references only 9 of the 10 generated CRD bases — `bases/infra.virtrigaud.io_vmmigrations.yaml` is missing from the `resources:` list. So `kustomize build config/default` renders only 9 CRDs, and the **VMMigration** CRD is never installed by:

- `make install`
- `make deploy`
- `make build-installer` → `dist/install.yaml`

With the CRD absent, the manager crash-loops its VMMigration controller at startup:

```
ERROR controller-runtime.source.EventHandler if kind is a CRD, it should be installed before calling Start
{"kind": "VMMigration.infra.virtrigaud.io", "error": "no matches for kind \"VMMigration\" in version \"infra.virtrigaud.io/v1beta1\""}
```

The **Helm chart is unaffected**: `make gen-helm-crds` runs controller-gen directly over `./api`, bypassing the kustomize `resources:` list — which is why this drift went unnoticed in the Helm-first install path.

## Root cause

`make gen-crds` (controller-gen) writes one file per CRD into `config/crd/bases/`, but it does **not** update the kustomize `resources:` list. That list is only appended to by `kubebuilder create api` at the `# +kubebuilder:scaffold:crdkustomizeresource` marker. When VMMigration was added, the base file was generated but the kustomization entry was never added.

## Changes

1. **`fix(crd)`** — add the missing `- bases/infra.virtrigaud.io_vmmigrations.yaml` line at the scaffold position.
2. **`test(crd)`** — add `hack/verify-crd-kustomization.sh` (run in the `api-conversion-tests` CI job next to `verify-single-version.sh`). It asserts every `config/crd/bases/*.yaml` is referenced in `kustomization.yaml`, and that every referenced base exists, to prevent recurrence for future CRDs.

## Verification

On a kind cluster (manager `v0.3.9`):

- **Before:** `kustomize build config/default` → 9 CRDs; manager logs `no matches for kind "VMMigration"`.
- **After:** `kustomize build config/default` → 10 CRDs. Reproduced the broken state (deleted the CRD), applied the fixed kustomize → CRD recreated; fresh manager start → VMMigration controller starts cleanly (`Starting workers ... worker count: 3`), 0 errors.
- **Guard:** passes on the fixed tree; fails (exit 1) flagging `vmmigrations` when the line is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
