### PR TITLE
fix(migration): honor CleanupPolicy + reliably remove source snapshot (await task, clean on Failed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-16 11:14] - Honor CleanupPolicy + reliably remove the migration source snapshot
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/controller/vmmigration_controller.go`: `deleteSourceSnapshot` now **awaits** the provider snapshot-delete task instead of fire-and-forget. After `SnapshotDelete` returns a `taskRef`, it polls `IsTaskComplete` with a bounded `wait.PollUntilContextTimeout(ctx, 3s, 2m, immediate)` (no `time.Sleep`), then checks `TaskStatus` and returns an error if `.Error != ""` — mirroring the existing `handleExportingPhase` await. The previous code logged "best effort — don't wait" and returned `nil`, so on CR deletion (`handleDeletion` calls it then removes the finalizer) the async delete was orphaned and the snapshot survived. This was the primary cause of the **4 accumulated `*-migration-*` snapshots** observed on the source VM after a live vSphere→libvirt run.
+- `internal/controller/vmmigration_controller.go`: `CleanupPolicy` is now consulted. New helper `cleanupAllowed(m)` returns `false` only when `Spec.Options.CleanupPolicy == "Never"`. `handleReadyPhase` gates both the intermediate-storage cleanup and the source-snapshot deletion behind `cleanupAllowed`, and `handleDeletion` gates the snapshot deletion the same way. Previously all three ran unconditionally, so `Never` was silently ignored. `DeleteAfterMigration` stays independent of policy (it is an explicit user action).
+- `internal/controller/vmmigration_controller.go`: `handleFailedPhase` now performs **best-effort** source-snapshot cleanup at both terminal exits (no-retry-policy and max-retries-exceeded) via new `cleanupSnapshotOnTerminalFailure`, gated on `cleanupAllowed && Status.SnapshotID != "" && Spec.Source.SnapshotRef == nil`. A migration that fails before `Ready` (the lab had no retry policy → immediately terminal) previously left its snapshot until the CR was deleted (and even then was orphaned by the bug above). A cleanup failure here is logged and swallowed so it cannot wedge an already-terminal migration; the await makes it usually succeed on the first pass.
+- `internal/controller/vmmigration_controller.go`: on a successful delete, `deleteSourceSnapshot` clears `Status.SnapshotID = ""` as an idempotency latch, so re-reconciles and `handleDeletion` skip a now-absent snapshot instead of re-issuing a delete against a stale ID.
+
+### Added
+- `api/infra.virtrigaud.io/v1beta1/vmmigration_types.go`: exported Go constants `CleanupPolicyAlways`, `CleanupPolicyOnSuccess`, `CleanupPolicyNever` mirroring the existing `+kubebuilder:validation:Enum` on `MigrationOptions.CleanupPolicy`. Purely additive — **no CRD schema change** (regen produces zero diff); they remove bare string literals from the controller per the CLAUDE.md global-constants rule.
+- `internal/controller/vmmigration_snapshot_cleanup_test.go`: unit tests (counting fake provider, `providerInstanceFn` seam) proving `deleteSourceSnapshot` polls the task to completion and surfaces a task error, clears `SnapshotID` on success, `Never` skips snapshot deletion on `Ready`, a terminally-failed migration deletes its snapshot under `OnSuccess`/`Always` but not `Never`, and terminal cleanup is best-effort (a delete failure does not wedge the migration). Plus a table test for `cleanupAllowed`.
+
+### Why
+A live vSphere→libvirt migration accumulated 4 source snapshots on real hardware, traced to three defects in the migration controller's snapshot cleanup: an orphaned async delete on CR deletion, an ignored `CleanupPolicy`, and no snapshot cleanup at terminal failure. The migration-created snapshot is an internal artifact left on the user's LIVE source VM, so it must be removed at any terminal state (Ready or Failed) unless the user opted out with `Never`. This is PR-1 of ADR-0006 Slice 2 prep and also fixes the FORWARD path; scope is the snapshot only (intermediate-storage-on-failure policy is out of scope). Refs #236.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager image — the reconciler runs in the manager)
+- [ ] Config change only
+- [ ] Documentation only
+
+---
+
 ## [2026-06-16 06:55] - Fix VMMigration reconcile race issuing a duplicate ExportDisk/ImportDisk
 **Author:** @wrkode (William Rizzo)
 

--- a/api/infra.virtrigaud.io/v1beta1/vmmigration_types.go
+++ b/api/infra.virtrigaud.io/v1beta1/vmmigration_types.go
@@ -454,6 +454,21 @@ const (
 	MigrationPhaseFailed MigrationPhase = "Failed"
 )
 
+// Cleanup policy values for MigrationOptions.CleanupPolicy. These mirror the
+// +kubebuilder:validation:Enum on that field; they exist as Go constants so the
+// controller never compares against bare string literals (CLAUDE.md rule).
+const (
+	// CleanupPolicyAlways removes migration-created artifacts regardless of the
+	// migration's terminal outcome.
+	CleanupPolicyAlways = "Always"
+	// CleanupPolicyOnSuccess removes migration-created artifacts only when the
+	// migration completes successfully. This is the default.
+	CleanupPolicyOnSuccess = "OnSuccess"
+	// CleanupPolicyNever retains all migration-created artifacts; the user opts
+	// out of cleanup entirely.
+	CleanupPolicyNever = "Never"
+)
+
 // MigrationProgress shows the migration operation progress
 type MigrationProgress struct {
 	// CurrentPhase is the current phase being executed

--- a/internal/controller/vmmigration_controller.go
+++ b/internal/controller/vmmigration_controller.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1311,26 +1312,32 @@ func (r *VMMigrationReconciler) handleReadyPhase(ctx context.Context, migration 
 	// Perform post-migration cleanup
 	cleanupPerformed := false
 
-	// 1. Cleanup intermediate storage
-	if migration.Spec.Storage != nil {
-		if err := r.cleanupIntermediateStorage(ctx, migration); err != nil {
-			logger.Error(err, "Failed to cleanup intermediate storage, will retry")
-			// Don't fail the migration, just log and retry
-			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+	// CleanupPolicy=Never opts out of removing migration-created artifacts
+	// (intermediate storage + source snapshot). DeleteAfterMigration is handled
+	// independently below because it is an explicit user action, not policy.
+	if cleanupAllowed(migration) {
+		// 1. Cleanup intermediate storage
+		if migration.Spec.Storage != nil {
+			if err := r.cleanupIntermediateStorage(ctx, migration); err != nil {
+				logger.Error(err, "Failed to cleanup intermediate storage, will retry")
+				// Don't fail the migration, just log and retry
+				return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+			}
+			cleanupPerformed = true
+			logger.Info("Intermediate storage cleaned up")
 		}
-		cleanupPerformed = true
-		logger.Info("Intermediate storage cleaned up")
-	}
 
-	// 2. Delete source snapshot if it was created for migration
-	if migration.Status.SnapshotID != "" && migration.Spec.Source.SnapshotRef == nil {
-		// Only delete if we created the snapshot (not if user provided one)
-		if err := r.deleteSourceSnapshot(ctx, migration); err != nil {
-			logger.Error(err, "Failed to delete source snapshot, will retry")
-			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+		// 2. Delete source snapshot if it was created for migration
+		if migration.Status.SnapshotID != "" && migration.Spec.Source.SnapshotRef == nil {
+			// Only delete if we created the snapshot (not if user provided one)
+			snapshotID := migration.Status.SnapshotID
+			if err := r.deleteSourceSnapshot(ctx, migration); err != nil {
+				logger.Error(err, "Failed to delete source snapshot, will retry")
+				return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+			}
+			cleanupPerformed = true
+			logger.Info("Source snapshot deleted", "snapshot_id", snapshotID)
 		}
-		cleanupPerformed = true
-		logger.Info("Source snapshot deleted", "snapshot_id", migration.Status.SnapshotID)
 	}
 
 	// 3. Delete source VM if requested
@@ -1369,6 +1376,7 @@ func (r *VMMigrationReconciler) handleFailedPhase(ctx context.Context, migration
 	// Check if retry is configured and allowed
 	if migration.Spec.Options == nil || migration.Spec.Options.RetryPolicy == nil {
 		logger.Info("No retry policy configured, migration remains failed")
+		r.cleanupSnapshotOnTerminalFailure(ctx, migration)
 		return ctrl.Result{}, nil
 	}
 
@@ -1385,6 +1393,7 @@ func (r *VMMigrationReconciler) handleFailedPhase(ctx context.Context, migration
 			"max_retries", maxRetries)
 		migration.Status.Message = fmt.Sprintf("Migration failed after %d retries: %s",
 			migration.Status.RetryCount, migration.Status.Message)
+		r.cleanupSnapshotOnTerminalFailure(ctx, migration)
 		if err := r.updateStatus(ctx, migration); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1459,6 +1468,34 @@ func (r *VMMigrationReconciler) handleFailedPhase(ctx context.Context, migration
 	return ctrl.Result{Requeue: true}, nil
 }
 
+// cleanupSnapshotOnTerminalFailure best-effort removes the migration-created
+// source snapshot when the migration has reached a terminal Failed state and is
+// not going to be retried.
+//
+// Without this, a migration that fails before Ready (e.g. no retry policy, so it
+// is immediately terminal) leaves its snapshot on the LIVE source VM until the
+// CR is deleted — which, combined with the await fix in deleteSourceSnapshot, is
+// the accumulation observed on real hardware. The deletion is best-effort: a
+// cleanup error is logged and swallowed so a transient provider failure cannot
+// wedge a migration that is already terminal. Because deleteSourceSnapshot now
+// awaits the task, this usually succeeds on the first pass. Skipped when the
+// user opted out (CleanupPolicy=Never), when there is no migration-created
+// snapshot, or when the user supplied their own snapshot (SnapshotRef set).
+func (r *VMMigrationReconciler) cleanupSnapshotOnTerminalFailure(ctx context.Context, migration *infrav1beta1.VMMigration) {
+	if !cleanupAllowed(migration) || migration.Status.SnapshotID == "" || migration.Spec.Source.SnapshotRef != nil {
+		return
+	}
+
+	logger := logging.FromContext(ctx)
+	snapshotID := migration.Status.SnapshotID
+	if err := r.deleteSourceSnapshot(ctx, migration); err != nil {
+		logger.Error(err, "Failed to delete source snapshot on terminal failure (best-effort, continuing)",
+			"snapshot_id", snapshotID)
+		return
+	}
+	logger.Info("Source snapshot deleted on terminal failure", "snapshot_id", snapshotID)
+}
+
 // handleDeletion handles deletion of VMMigration resources
 func (r *VMMigrationReconciler) handleDeletion(ctx context.Context, migration *infrav1beta1.VMMigration) (ctrl.Result, error) {
 	logger := logging.FromContext(ctx)
@@ -1500,8 +1537,9 @@ func (r *VMMigrationReconciler) handleDeletion(ctx context.Context, migration *i
 		}
 	}
 
-	// 3. Delete migration-created snapshot if exists
-	if migration.Status.SnapshotID != "" && migration.Spec.Source.SnapshotRef == nil {
+	// 3. Delete migration-created snapshot if exists (unless the user opted out
+	// with CleanupPolicy=Never).
+	if cleanupAllowed(migration) && migration.Status.SnapshotID != "" && migration.Spec.Source.SnapshotRef == nil {
 		if err := r.deleteSourceSnapshot(ctx, migration); err != nil {
 			logger.Error(err, "Failed to delete source snapshot during deletion")
 			cleanupErrors = append(cleanupErrors, fmt.Errorf("snapshot cleanup: %w", err))
@@ -2432,6 +2470,23 @@ func (r *VMMigrationReconciler) cleanupIntermediateStorage(ctx context.Context, 
 	return nil
 }
 
+// cleanupAllowed reports whether the controller may remove migration-created
+// artifacts for the given migration.
+//
+// The source snapshot the migration creates is an internal artifact left on the
+// user's LIVE source VM; it is not something the user asked to keep, so we
+// remove it at any terminal state (Ready or Failed) by default. The only way to
+// retain it is to opt out explicitly with CleanupPolicy=Never. Always and
+// OnSuccess both permit cleanup here: at a terminal state OnSuccess and Always
+// are equivalent for this internal snapshot (a snapshot left on the source VM
+// has no value after the migration has terminated either way). The distinction
+// between Always and OnSuccess is reserved for future artifact classes; PR-1
+// only governs the snapshot.
+func cleanupAllowed(m *infrav1beta1.VMMigration) bool {
+	// Allowed unless the user explicitly opted out with CleanupPolicy=Never.
+	return m.Spec.Options == nil || m.Spec.Options.CleanupPolicy != infrav1beta1.CleanupPolicyNever
+}
+
 // deleteSourceSnapshot deletes the migration-created snapshot
 func (r *VMMigrationReconciler) deleteSourceSnapshot(ctx context.Context, migration *infrav1beta1.VMMigration) error {
 	logger := logging.FromContext(ctx)
@@ -2468,12 +2523,45 @@ func (r *VMMigrationReconciler) deleteSourceSnapshot(ctx context.Context, migrat
 		return fmt.Errorf("failed to delete snapshot: %w", err)
 	}
 
-	// If there's a task, wait for it to complete
+	// If the provider returned a task, AWAIT it to completion before returning.
+	// A fire-and-forget delete (the previous behavior) orphans the task on CR
+	// deletion: handleDeletion calls this then removes the finalizer, so the
+	// async snapshot delete never lands and the snapshot accumulates on the
+	// source VM. We poll with a bounded wait, mirroring the IsTaskComplete /
+	// TaskStatus await pattern in handleExportingPhase.
 	if taskRef != "" {
 		logger.Info("Snapshot deletion task started, waiting for completion", "task_id", taskRef)
-		// For cleanup, we'll do best effort - don't wait indefinitely
-		// The task will complete asynchronously
+
+		waitErr := wait.PollUntilContextTimeout(ctx, 3*time.Second, 2*time.Minute, true,
+			func(pollCtx context.Context) (bool, error) {
+				done, pollErr := providerInstance.IsTaskComplete(pollCtx, taskRef)
+				if pollErr != nil {
+					// Treat a transient poll error as "keep polling" rather than
+					// aborting the wait; the bounded timeout still caps total time.
+					logger.V(1).Info("Transient error polling snapshot delete task, retrying",
+						"task_id", taskRef, "error", pollErr.Error())
+					return false, nil
+				}
+				return done, nil
+			})
+		if waitErr != nil {
+			return fmt.Errorf("await snapshot delete task %s: %w", taskRef, waitErr)
+		}
+
+		// Task reported complete: verify it did not complete with an error.
+		taskStatus, statusErr := providerInstance.TaskStatus(ctx, taskRef)
+		if statusErr != nil {
+			return fmt.Errorf("get snapshot delete task %s status: %w", taskRef, statusErr)
+		}
+		if taskStatus.Error != "" {
+			return fmt.Errorf("snapshot delete task %s failed: %s", taskRef, taskStatus.Error)
+		}
 	}
+
+	// Idempotency latch: the snapshot is gone, so clear the recorded ID. A
+	// re-reconcile (or handleDeletion) then skips deleting a now-absent snapshot
+	// rather than issuing a second delete against a stale ID.
+	migration.Status.SnapshotID = ""
 
 	return nil
 }

--- a/internal/controller/vmmigration_snapshot_cleanup_test.go
+++ b/internal/controller/vmmigration_snapshot_cleanup_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+)
+
+// countingSnapshotProvider embeds stubProvider (defined in
+// virtualmachine_controller_test.go) and instruments the snapshot-delete +
+// task-await path exercised by deleteSourceSnapshot. It counts SnapshotDelete
+// invocations, counts IsTaskComplete polls until it reports "done", and returns
+// a configurable TaskStatus so a task that completes WITH an error can be
+// simulated.
+type countingSnapshotProvider struct {
+	stubProvider
+
+	// snapshotTaskRef is returned from every SnapshotDelete call. An empty value
+	// models a synchronous (no-task) delete.
+	snapshotTaskRef string
+
+	// pollsUntilDone is the number of IsTaskComplete calls that report "not yet"
+	// before one reports "done". 0 means the very first poll reports done.
+	pollsUntilDone int32
+
+	// taskError, when non-empty, is surfaced via TaskStatus.Error after the task
+	// reports complete, modeling a task that finished but failed.
+	taskError string
+
+	snapshotDeleteCalls atomic.Int32
+	isTaskCompleteCalls atomic.Int32
+	taskStatusCalls     atomic.Int32
+}
+
+// SnapshotDelete records the call and returns the configured task ref.
+func (p *countingSnapshotProvider) SnapshotDelete(_ context.Context, _, _ string) (string, error) {
+	p.snapshotDeleteCalls.Add(1)
+	return p.snapshotTaskRef, nil
+}
+
+// IsTaskComplete reports "not done" for the first pollsUntilDone calls, then
+// "done" for every call thereafter.
+func (p *countingSnapshotProvider) IsTaskComplete(_ context.Context, _ string) (bool, error) {
+	n := p.isTaskCompleteCalls.Add(1)
+	return n > p.pollsUntilDone, nil
+}
+
+// TaskStatus records the call and returns the configured terminal status.
+func (p *countingSnapshotProvider) TaskStatus(_ context.Context, _ string) (contracts.TaskStatus, error) {
+	p.taskStatusCalls.Add(1)
+	return contracts.TaskStatus{IsCompleted: true, Error: p.taskError}, nil
+}
+
+var _ contracts.Provider = (*countingSnapshotProvider)(nil)
+
+// newSnapshotReconciler builds a VMMigrationReconciler whose provider resolution
+// is pinned to the supplied fake, seeded with the supplied objects and status
+// subresource support. Mirrors newRaceReconciler.
+func newSnapshotReconciler(t *testing.T, prov contracts.Provider, objs ...client.Object) (*VMMigrationReconciler, client.Client) {
+	t.Helper()
+	scheme := capGatingScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(objs...).
+		Build()
+
+	r := &VMMigrationReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(50),
+		providerInstanceFn: func(_ context.Context, _ *infrav1beta1.Provider) (contracts.Provider, error) {
+			return prov, nil
+		},
+	}
+	return r, c
+}
+
+// snapshotFixture returns a source VM, a source Provider, and a VMMigration that
+// has a migration-created snapshot recorded in status (SnapshotID set,
+// SnapshotRef nil). The migration's phase/options are left to the caller.
+func snapshotFixture() (*infrav1beta1.VirtualMachine, *infrav1beta1.Provider, *infrav1beta1.VMMigration) {
+	sourceVM := &infrav1beta1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "source-vm", Namespace: "default"},
+		Spec: infrav1beta1.VirtualMachineSpec{
+			ProviderRef: infrav1beta1.ObjectRef{Name: "source-provider"},
+		},
+	}
+	sourceVM.Status.ID = "vm-123"
+
+	sourceProvider := &infrav1beta1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: "source-provider", Namespace: "default"},
+	}
+
+	migration := &infrav1beta1.VMMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "snap-migration",
+			Namespace:  "default",
+			UID:        "uid-snap-1",
+			Generation: 1,
+		},
+		Spec: infrav1beta1.VMMigrationSpec{
+			Source: infrav1beta1.MigrationSource{
+				VMRef: infrav1beta1.LocalObjectReference{Name: "source-vm"},
+			},
+			Target: infrav1beta1.MigrationTarget{
+				Name:        "target-vm",
+				ProviderRef: infrav1beta1.ObjectRef{Name: "target-provider"},
+			},
+		},
+	}
+	migration.Status.SnapshotID = "snap-abc"
+	return sourceVM, sourceProvider, migration
+}
+
+// TestDeleteSourceSnapshot_AwaitsTaskAndClearsID proves the primary fix: when
+// SnapshotDelete returns a task ref, deleteSourceSnapshot polls the task to
+// completion (instead of fire-and-forget) and clears Status.SnapshotID as an
+// idempotency latch on success.
+func TestDeleteSourceSnapshot_AwaitsTaskAndClearsID(t *testing.T) {
+	ctx := context.Background()
+	prov := &countingSnapshotProvider{
+		snapshotTaskRef: "task-del-1",
+		pollsUntilDone:  2, // first two polls report "not done"
+	}
+	sourceVM, sourceProvider, migration := snapshotFixture()
+	r, _ := newSnapshotReconciler(t, prov, sourceVM, sourceProvider, migration)
+
+	err := r.deleteSourceSnapshot(ctx, migration)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, prov.snapshotDeleteCalls.Load(), "exactly one SnapshotDelete RPC")
+	// The await must have polled past the not-done responses (proves it waited,
+	// rather than returning immediately on the first poll).
+	assert.GreaterOrEqual(t, prov.isTaskCompleteCalls.Load(), int32(3),
+		"must poll IsTaskComplete until the task reports done")
+	assert.EqualValues(t, 1, prov.taskStatusCalls.Load(), "must verify final TaskStatus")
+
+	// Idempotency latch: a completed delete clears the recorded snapshot ID.
+	assert.Equal(t, "", migration.Status.SnapshotID, "SnapshotID must be cleared after a successful delete")
+}
+
+// TestDeleteSourceSnapshot_SurfacesTaskError proves the await path checks the
+// final TaskStatus and returns an error when the task completed but failed; the
+// snapshot ID is NOT cleared because the snapshot may still exist.
+func TestDeleteSourceSnapshot_SurfacesTaskError(t *testing.T) {
+	ctx := context.Background()
+	prov := &countingSnapshotProvider{
+		snapshotTaskRef: "task-del-err",
+		taskError:       "device or resource busy",
+	}
+	sourceVM, sourceProvider, migration := snapshotFixture()
+	r, _ := newSnapshotReconciler(t, prov, sourceVM, sourceProvider, migration)
+
+	err := r.deleteSourceSnapshot(ctx, migration)
+	require.Error(t, err, "a task that completes with an error must surface as an error")
+	assert.Contains(t, err.Error(), "device or resource busy")
+
+	// The snapshot may still exist, so the latch must NOT clear the ID.
+	assert.Equal(t, "snap-abc", migration.Status.SnapshotID, "SnapshotID must be retained on task failure")
+}
+
+// TestHandleReadyPhase_NeverSkipsSnapshotDeletion proves CleanupPolicy=Never is
+// honored on the Ready path: the source snapshot is NOT deleted.
+func TestHandleReadyPhase_NeverSkipsSnapshotDeletion(t *testing.T) {
+	ctx := context.Background()
+	prov := &countingSnapshotProvider{snapshotTaskRef: "task-x"}
+	sourceVM, sourceProvider, migration := snapshotFixture()
+	migration.Spec.Options = &infrav1beta1.MigrationOptions{
+		CleanupPolicy: infrav1beta1.CleanupPolicyNever,
+	}
+	migration.Status.Phase = infrav1beta1.MigrationPhaseReady
+	r, _ := newSnapshotReconciler(t, prov, sourceVM, sourceProvider, migration)
+
+	_, err := r.handleReadyPhase(ctx, migration)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 0, prov.snapshotDeleteCalls.Load(),
+		"CleanupPolicy=Never must NOT delete the source snapshot on Ready")
+	assert.Equal(t, "snap-abc", migration.Status.SnapshotID, "SnapshotID must be retained under Never")
+}
+
+// TestHandleReadyPhase_OnSuccessDeletesSnapshot is the positive control for the
+// Ready path: the default OnSuccess policy deletes the snapshot and clears the
+// latch.
+func TestHandleReadyPhase_OnSuccessDeletesSnapshot(t *testing.T) {
+	ctx := context.Background()
+	prov := &countingSnapshotProvider{snapshotTaskRef: "task-x"}
+	sourceVM, sourceProvider, migration := snapshotFixture()
+	migration.Spec.Options = &infrav1beta1.MigrationOptions{
+		CleanupPolicy: infrav1beta1.CleanupPolicyOnSuccess,
+	}
+	migration.Status.Phase = infrav1beta1.MigrationPhaseReady
+	r, _ := newSnapshotReconciler(t, prov, sourceVM, sourceProvider, migration)
+
+	_, err := r.handleReadyPhase(ctx, migration)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, prov.snapshotDeleteCalls.Load(),
+		"OnSuccess must delete the source snapshot on Ready")
+	assert.Equal(t, "", migration.Status.SnapshotID, "SnapshotID must be cleared after deletion")
+}
+
+// TestHandleFailedPhase_TerminalCleansSnapshot proves the terminal-failure
+// cleanup: a migration that fails with no retry policy (immediately terminal)
+// deletes its source snapshot under OnSuccess/Always but NOT under Never.
+func TestHandleFailedPhase_TerminalCleansSnapshot(t *testing.T) {
+	cases := []struct {
+		name        string
+		policy      string
+		wantDeletes int32
+		wantID      string
+	}{
+		{"OnSuccess deletes on terminal failure", infrav1beta1.CleanupPolicyOnSuccess, 1, ""},
+		{"Always deletes on terminal failure", infrav1beta1.CleanupPolicyAlways, 1, ""},
+		{"Never retains on terminal failure", infrav1beta1.CleanupPolicyNever, 0, "snap-abc"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			prov := &countingSnapshotProvider{snapshotTaskRef: "task-fail"}
+			sourceVM, sourceProvider, migration := snapshotFixture()
+			migration.Spec.Options = &infrav1beta1.MigrationOptions{
+				CleanupPolicy: tc.policy,
+				// No RetryPolicy => immediately terminal (the lab scenario).
+			}
+			migration.Status.Phase = infrav1beta1.MigrationPhaseFailed
+			migration.Status.Message = "export failed"
+			r, _ := newSnapshotReconciler(t, prov, sourceVM, sourceProvider, migration)
+
+			_, err := r.handleFailedPhase(ctx, migration)
+			require.NoError(t, err)
+
+			assert.EqualValues(t, tc.wantDeletes, prov.snapshotDeleteCalls.Load())
+			assert.Equal(t, tc.wantID, migration.Status.SnapshotID)
+		})
+	}
+}
+
+// TestHandleFailedPhase_TerminalCleanupBestEffort proves a snapshot-cleanup
+// failure on terminal failure does NOT wedge the migration: handleFailedPhase
+// still returns without error.
+func TestHandleFailedPhase_TerminalCleanupBestEffort(t *testing.T) {
+	ctx := context.Background()
+	prov := &countingSnapshotProvider{
+		snapshotTaskRef: "task-fail",
+		taskError:       "snapshot delete failed on host",
+	}
+	sourceVM, sourceProvider, migration := snapshotFixture()
+	migration.Spec.Options = &infrav1beta1.MigrationOptions{
+		CleanupPolicy: infrav1beta1.CleanupPolicyOnSuccess,
+	}
+	migration.Status.Phase = infrav1beta1.MigrationPhaseFailed
+	migration.Status.Message = "export failed"
+	r, _ := newSnapshotReconciler(t, prov, sourceVM, sourceProvider, migration)
+
+	_, err := r.handleFailedPhase(ctx, migration)
+	require.NoError(t, err, "a best-effort cleanup failure must not wedge a terminal migration")
+
+	assert.EqualValues(t, 1, prov.snapshotDeleteCalls.Load(), "cleanup was attempted")
+	// The delete failed, so the latch must retain the ID for a later retry/delete.
+	assert.Equal(t, "snap-abc", migration.Status.SnapshotID)
+}
+
+// TestCleanupAllowed exercises the policy gate directly.
+func TestCleanupAllowed(t *testing.T) {
+	cases := []struct {
+		name    string
+		options *infrav1beta1.MigrationOptions
+		want    bool
+	}{
+		{"nil options allows cleanup", nil, true},
+		{"empty policy allows cleanup", &infrav1beta1.MigrationOptions{}, true},
+		{"OnSuccess allows cleanup", &infrav1beta1.MigrationOptions{CleanupPolicy: infrav1beta1.CleanupPolicyOnSuccess}, true},
+		{"Always allows cleanup", &infrav1beta1.MigrationOptions{CleanupPolicy: infrav1beta1.CleanupPolicyAlways}, true},
+		{"Never blocks cleanup", &infrav1beta1.MigrationOptions{CleanupPolicy: infrav1beta1.CleanupPolicyNever}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &infrav1beta1.VMMigration{Spec: infrav1beta1.VMMigrationSpec{Options: tc.options}}
+			assert.Equal(t, tc.want, cleanupAllowed(m))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

PR-1 of ADR-0006 Slice 2 prep — independent and also fixes the FORWARD path. A live vSphere→libvirt migration left **4 accumulated `*-migration-*` snapshots** on the source VM. Root-caused on real hardware to **three** defects in the migration controller's snapshot cleanup.

Scope is the **snapshot** only (intermediate-storage-on-failure policy is explicitly out of scope). No `internal/providers/*` touched. No CRD schema change.

## The three defects (all in `internal/controller/vmmigration_controller.go`)

1. **`deleteSourceSnapshot` never awaited the delete task.** It issued `SnapshotDelete` and, when a `taskRef` came back, logged "best effort — don't wait" and returned `nil`. On CR deletion, `handleDeletion` calls it and then removes the finalizer, so the async task was **orphaned** → the snapshot survived. This is the primary accumulation cause. Now the helper polls `IsTaskComplete` with a bounded `wait.PollUntilContextTimeout(ctx, 3s, 2m, immediate)` (transient poll errors = keep polling; no `time.Sleep`), then checks `TaskStatus` and returns an error if `.Error != ""` — mirroring the `handleExportingPhase` await. On success it clears `Status.SnapshotID` as an idempotency latch.

2. **`CleanupPolicy` was never consulted.** `handleReadyPhase` (storage + snapshot) and `handleDeletion` (snapshot) ran cleanup unconditionally, so `Never` was silently ignored. New helper `cleanupAllowed(m)` returns `false` only for `CleanupPolicy=Never`; both paths now gate on it. `DeleteAfterMigration` stays independent (explicit user action, not policy).

3. **Terminal failure did no snapshot cleanup.** `handleFailedPhase`'s two terminal exits (no-retry-policy, max-retries-exceeded) both returned without deleting the snapshot. A migration that fails before `Ready` (the lab had no retry policy → immediately terminal) left its snapshot until CR deletion (and even then defect #1 orphaned it). Now both exits do a **best-effort** `cleanupSnapshotOnTerminalFailure` (gated on `cleanupAllowed && SnapshotID != "" && SnapshotRef == nil`); a cleanup error is logged and swallowed so it cannot wedge an already-terminal migration.

## Semantics decision

The migration-created source snapshot is an **internal artifact** left on the user's **LIVE** source VM. It is removed at **any terminal state (Ready or Failed)** unless the user opted out with `CleanupPolicy=Never`. `Always` and `OnSuccess` both permit removal here — for an internal snapshot on the source VM they are equivalent at a terminal state; the `Always`/`OnSuccess` distinction is reserved for future artifact classes.

## Additive types change (no schema change)

`api/infra.virtrigaud.io/v1beta1/vmmigration_types.go`: exported `CleanupPolicyAlways` / `CleanupPolicyOnSuccess` / `CleanupPolicyNever` Go consts, mirroring the existing `+kubebuilder:validation:Enum` already on the field. `make generate manifests gen-helm-crds` produces **zero** diff under `config/`, `charts/`, and `zz_generated.deepcopy.go`.

## Tests

`internal/controller/vmmigration_snapshot_cleanup_test.go` (counting fake provider via the `providerInstanceFn` seam):
- `deleteSourceSnapshot` polls the task to completion and surfaces a task error.
- `Never` skips snapshot deletion on `Ready`; `OnSuccess` deletes it (positive control).
- A terminally-failed migration deletes its snapshot under `OnSuccess`/`Always` but **not** `Never`.
- Terminal cleanup is best-effort (a delete failure does not wedge the migration).
- `SnapshotID` is cleared after a successful delete; retained on failure.
- Table test for `cleanupAllowed`.

## Lab evidence

Live vSphere→libvirt run accumulated **4** `*-migration-*` snapshots on the source VM; the no-retry-policy → immediately-terminal path plus the orphaned async delete on CR deletion reproduces exactly that accumulation.

## Gate (CLAUDE.md)

- `make fmt` — no diff
- `make lint` — 0 issues
- `make test` — all packages pass
- `make build` — succeeds
- `make generate manifests gen-helm-crds` — zero schema diff

Refs #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)