### PR TITLE
Set upload-release-assets: false on the Generate SBOM step.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -523,6 +523,13 @@ jobs:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_PREFIX }}/${{ matrix.component }}:${{ needs.prepare.outputs.tag }}
           format: spdx-json
           output-file: sbom-${{ matrix.component }}.spdx.json
+          # This job is intentionally scoped to contents: read (see permissions
+          # above). The SBOM is uploaded as a workflow artifact below and then
+          # attached to the GitHub Release by the create-release job, so the
+          # action's own release upload is redundant — and would fail with
+          # "Resource not accessible by integration" since it needs
+          # contents: write. Disable it.
+          upload-release-assets: false
 
       - name: Upload SBOM
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
Set upload-release-assets: false on the Generate SBOM step.

This is safe because the SBOM is already:
1. Uploaded as a workflow artifact (Upload SBOM step), then
2. Attached to the GitHub Release by the create-release job (files: release-files/* at line 823, picking up *.spdx.json copied at line 804).

So nothing is lost — we just stop the action from doing a duplicate upload that needed a permission the job intentionally doesn't grant. Keeps the least-privilege contents: read scope intact.