### PR TITLE
fix(libvirt): support SSH private-key auth end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-17 08:57] - libvirt SSH private-key authentication works end-to-end
+**Author:** @jing2uo (Komh)
+
+### Fixed
+- `internal/providers/libvirt/virsh.go`: `setupConnection` now materialises the SSH private key to `/tmp/virtrigaud-libvirt/ssh-privatekey` (0600 in a 0700 dir) and pins `keyfile=&sshauth=privkey` on the `qemu+ssh://` URI, so libvirt's own transport authenticates with the key. The `~/.ssh/config` is written for **every** ssh URI (previously only when a password was set), and a write failure is a hard error on the key path. The `!` direct-exec handler and the standard virsh wrapper now branch password→`sshpass` / key→`ssh -i <keyfile>` / else local through a shared `sshKeyAuthOptions()` + `resolveSSHKeyFile()`; previously the key case fell through to **local** execution inside the pod, so every host command silently ran in the container.
+- `internal/providers/libvirt/sshhostkey.go`: `sshConfigStanza` emits `PubkeyAuthentication yes` (was `no`), which had disabled key auth for the config-reading transport.
+- `internal/providers/libvirt/server.go`: `copyDiskToRemote`'s key branch passes `-i <keyfile>` instead of a bare `scp` that could never authenticate; `ImportDisk` runs `qemu-img info` against the remote copy (`finalSourcePath`) rather than the pod-local `sourcePath`.
+- `internal/providers/libvirt/s3import.go`: `runSSHStdin`'s key branch passes `-i <keyfile>`.
+- `internal/providers/libvirt/storage.go` + `internal/providers/libvirt/provider_virsh.go`: `pool-define` and `define` run on the remote host via `runRemoteVirshCommand` (so `virsh` reads the host-local XML the provider wrote); they failed client-side under key auth before.
+- `internal/providers/libvirt/cloudinit.go`: `copyISOToRemote` uses host-side `! cp`/`! mkdir`/`! chmod` instead of hand-rolled `! ssh`/`! scp`; removed the now-unused `getSSHTarget()`.
+
+### Added
+- `internal/providers/libvirt/virsh.go`: `remoteVirshConnectURI` derives `qemu:///{system,session}` from the connection URI and `runRemoteVirshCommand` pins it with `-c`, so a remote `virsh` targets the same libvirtd whether the ssh user is root (system default) or non-root (session default) — also fixes the pre-existing password + non-root case.
+- `internal/providers/libvirt/sshkeyauth_test.go`: unit tests for key materialisation (content + 0600/0700 perms), `setupConnection` pinning `keyfile=`/`sshauth=privkey` on the key path and NOT on the password path, the `sshKeyAuthOptions` arg list, `resolveSSHKeyFile`, the `PubkeyAuthentication` flip, and `remoteVirshConnectURI` across the root/non-root × system/session quadrants.
+
+### Why
+The libvirt provider's private-key auth path was broken end-to-end (key never written, URI missing `keyfile=`, `PubkeyAuthentication no`, direct ssh/scp missing `-i`, and `define`/`pool-define` reading host files client-side). Only the password path worked, so a key-only Provider could not connect, import disks, or define VMs. This is the authentication counterpart to ADR-0004's host-key verification work on the same transport. Closes #248.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (provider image — the fix is in the libvirt provider)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-16 20:15] - Remove dead parseStorageSize (orphaned by the Bug G GetDiskInfo rewrite)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/cloudinit.go
+++ b/internal/providers/libvirt/cloudinit.go
@@ -208,71 +208,21 @@ func (c *CloudInitProvider) copyISOToRemote(ctx context.Context, localPath, doma
 	remoteDir := "/var/lib/libvirt/images/cloud-init"
 	remotePath := fmt.Sprintf("%s/%s-cloud-init.iso", remoteDir, domainName)
 
-	// Get SSH connection string from provider credentials
-	sshTarget, err := c.getSSHTarget()
-	if err != nil {
-		return "", fmt.Errorf("failed to get SSH target: %w", err)
-	}
-
 	// Create remote directory
-	_, err = c.virshProvider.runVirshCommand(ctx, "!", "ssh", sshTarget,
-		"mkdir", "-p", remoteDir)
-	if err != nil {
-		log.Printf("WARN Failed to create remote directory (may already exist): %v", err)
+	if _, err := c.virshProvider.runVirshCommand(ctx, "!", "mkdir", "-p", remoteDir); err != nil {
+		return "", fmt.Errorf("failed to create remote cloud-init directory: %w", err)
 	}
 
-	// Copy ISO file using scp
-	result, err := c.virshProvider.runVirshCommand(ctx, "!", "scp", localPath,
-		fmt.Sprintf("%s:%s", sshTarget, remotePath))
-
+	result, err := c.virshProvider.runVirshCommand(ctx, "!", "cp", "-f", localPath, remotePath)
 	if err != nil {
-		return "", fmt.Errorf("scp failed: %w, output: %s", err, result.Stderr)
+		return "", fmt.Errorf("failed to copy cloud-init ISO on remote host: %w, output: %s", err, result.Stderr)
+	}
+	if _, err := c.virshProvider.runVirshCommand(ctx, "!", "chmod", "0644", remotePath); err != nil {
+		return "", fmt.Errorf("failed to chmod remote cloud-init ISO: %w", err)
 	}
 
-	log.Printf("INFO Copied cloud-init ISO to remote server: %s", remotePath)
+	log.Printf("INFO Copied cloud-init ISO on remote server: %s", remotePath)
 	return remotePath, nil
-}
-
-// getSSHTarget extracts the SSH connection target (user@host) from the provider configuration
-func (c *CloudInitProvider) getSSHTarget() (string, error) {
-	// Get credentials
-	if c.virshProvider.credentials == nil {
-		return "", fmt.Errorf("provider credentials not initialized")
-	}
-
-	username := c.virshProvider.credentials.Username
-	if username == "" {
-		return "", fmt.Errorf("username not configured in provider credentials")
-	}
-
-	// Extract hostname from endpoint URI
-	// Expected format: qemu+ssh://172.16.56.8/system or similar
-	endpoint := c.virshProvider.config.Spec.Endpoint
-	if endpoint == "" {
-		return "", fmt.Errorf("endpoint not configured")
-	}
-
-	// Parse the endpoint to extract the host
-	host := endpoint
-	// Remove protocol prefix if present
-	if strings.Contains(endpoint, "://") {
-		parts := strings.SplitN(endpoint, "://", 2)
-		if len(parts) == 2 {
-			host = parts[1]
-		}
-	}
-	// Remove path suffix if present (e.g., /system)
-	if strings.Contains(host, "/") {
-		host = strings.Split(host, "/")[0]
-	}
-	// Remove port if present
-	if strings.Contains(host, ":") {
-		host = strings.Split(host, ":")[0]
-	}
-
-	sshTarget := fmt.Sprintf("%s@%s", username, host)
-	log.Printf("INFO Using SSH target: %s", sshTarget)
-	return sshTarget, nil
 }
 
 // ExtractHostnameFromCloudInit extracts hostname from cloud-init YAML (like vSphere)

--- a/internal/providers/libvirt/provider_virsh.go
+++ b/internal/providers/libvirt/provider_virsh.go
@@ -501,7 +501,7 @@ func (p *Provider) syncPersistentXML(ctx context.Context, domainName string) err
 	}
 
 	// Define the domain again with the running XML (this updates the persistent definition)
-	_, err = p.virshProvider.runVirshCommand(ctx, "define", remotePath)
+	_, err = p.virshProvider.runRemoteVirshCommand(ctx, "define", remotePath)
 	if err != nil {
 		return fmt.Errorf("failed to redefine domain: %w", err)
 	}
@@ -1417,7 +1417,7 @@ func (p *Provider) defineDomain(ctx context.Context, domainName string) error {
 	// Define domain from XML file
 	remotePath := fmt.Sprintf("/tmp/%s-domain.xml", domainName)
 
-	result, err := p.virshProvider.runVirshCommand(ctx, "define", remotePath)
+	result, err := p.virshProvider.runRemoteVirshCommand(ctx, "define", remotePath)
 	if err != nil {
 		return fmt.Errorf("failed to define domain: %w, output: %s", err, result.Stderr)
 	}

--- a/internal/providers/libvirt/s3import.go
+++ b/internal/providers/libvirt/s3import.go
@@ -240,6 +240,9 @@ func runSSHStdin(ctx context.Context, vp *VirshProvider, r io.Reader, remoteCmd 
 		cmd.Env = append(os.Environ(), fmt.Sprintf("SSHPASS=%s", vp.credentials.Password))
 	} else {
 		sshArgs := []string{"-o", "LogLevel=ERROR"}
+		if strings.TrimSpace(vp.credentials.SSHPrivateKey) != "" {
+			sshArgs = append(sshArgs, sshKeyAuthOptions(resolveSSHKeyFile(parsedURI))...)
+		}
 		sshArgs = append(sshArgs, vp.hostKey.sshHostKeyOptions()...)
 		sshArgs = append(sshArgs, sshMultiplexOptions()...)
 		sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host), remoteCmd)

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -708,7 +708,7 @@ func (s *Server) ImportDisk(ctx context.Context, req *providerv1.ImportDiskReque
 	}
 
 	// Get source disk info using qemu-img
-	infoResult, err := libvirtProvider.virshProvider.runVirshCommand(ctx, "!", "qemu-img", "info", "--output=json", sourcePath)
+	infoResult, err := libvirtProvider.virshProvider.runVirshCommand(ctx, "!", "qemu-img", "info", "--output=json", finalSourcePath)
 	if err != nil {
 		log.Printf("WARN Failed to get source disk info: %v", err)
 	} else {
@@ -883,8 +883,12 @@ func (s *Server) copyDiskToRemote(ctx context.Context, virshProvider *VirshProvi
 		cmd = exec.CommandContext(ctx, "sshpass", scpArgs...)
 		// Set password via environment variable for sshpass
 		cmd.Env = append(os.Environ(), fmt.Sprintf("SSHPASS=%s", virshProvider.credentials.Password))
+	} else if strings.TrimSpace(virshProvider.credentials.SSHPrivateKey) != "" {
+		scpArgs := sshKeyAuthOptions(resolveSSHKeyFile(parsedURI))
+		scpArgs = append(scpArgs, hostKeyOpts...)
+		scpArgs = append(scpArgs, localPath, fmt.Sprintf("%s:%s", sshTarget, remotePath))
+		cmd = exec.CommandContext(ctx, "scp", scpArgs...)
 	} else {
-		// Fallback to scp without sshpass (for key-based auth)
 		scpArgs := append([]string{}, hostKeyOpts...)
 		scpArgs = append(scpArgs, localPath, fmt.Sprintf("%s:%s", sshTarget, remotePath))
 		cmd = exec.CommandContext(ctx, "scp", scpArgs...)

--- a/internal/providers/libvirt/sshhostkey.go
+++ b/internal/providers/libvirt/sshhostkey.go
@@ -179,7 +179,7 @@ func (p hostKeyPolicy) sshConfigStanza() string {
 	stanza := fmt.Sprintf(`Host *
     StrictHostKeyChecking %s
     PasswordAuthentication yes
-    PubkeyAuthentication no
+    PubkeyAuthentication yes
     UserKnownHostsFile %s
     LogLevel ERROR
 `, p.strictHostKeyChecking(), p.knownHostsFile())

--- a/internal/providers/libvirt/sshkeyauth_test.go
+++ b/internal/providers/libvirt/sshkeyauth_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSSHKeyAuthOptions pins the exact ssh/scp flag list used by every key-based
+// call site. This is the regression guard for the bug class that motivated the
+// fix: a hand-rolled ssh/scp that "supports key auth" but silently omits -i (the
+// key lives at a non-default path with no IdentityFile in the config).
+func TestSSHKeyAuthOptions(t *testing.T) {
+	assert.Equal(t,
+		[]string{
+			"-i", "/tmp/k",
+			"-o", "IdentitiesOnly=yes",
+			"-o", "PasswordAuthentication=no",
+			"-o", "PubkeyAuthentication=yes",
+		},
+		sshKeyAuthOptions("/tmp/k"),
+	)
+}
+
+// TestResolveSSHKeyFile covers both sources of the key path: the keyfile= pinned
+// on the libvirt URI (preferred) and the well-known fallback.
+func TestResolveSSHKeyFile(t *testing.T) {
+	withKeyfile, err := url.Parse("qemu+ssh://u@h/system?keyfile=/custom/key&sshauth=privkey")
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/key", resolveSSHKeyFile(withKeyfile))
+
+	noKeyfile, err := url.Parse("qemu+ssh://u@h/system")
+	require.NoError(t, err)
+	assert.Equal(t, sshPrivateKeyPath, resolveSSHKeyFile(noKeyfile))
+}
+
+// TestWriteSSHPrivateKey asserts the key is persisted (trimmed, single trailing
+// newline) at the well-known path with 0600 perms in a 0700 dir, so both the
+// direct ssh/scp (-i) paths and libvirt's own keyfile= transport can read it.
+func TestWriteSSHPrivateKey(t *testing.T) {
+	require.NoError(t, os.RemoveAll(sshPrivateKeyDir))
+	t.Cleanup(func() { _ = os.RemoveAll(sshPrivateKeyDir) })
+
+	const pem = "-----BEGIN OPENSSH PRIVATE KEY-----\nabc123\n-----END OPENSSH PRIVATE KEY-----"
+	v := &VirshProvider{credentials: &Credentials{SSHPrivateKey: pem}}
+
+	path, err := v.writeSSHPrivateKey()
+	require.NoError(t, err)
+	assert.Equal(t, sshPrivateKeyPath, path)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, pem+"\n", string(got))
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), fi.Mode().Perm())
+
+	di, err := os.Stat(sshPrivateKeyDir)
+	require.NoError(t, err)
+	assert.Zero(t, di.Mode().Perm()&0o077, "key dir must not be group/other accessible")
+}
+
+// TestSetupConnection_KeyAuth_WritesKeyAndPinsURI is the integration point for the
+// key path: with a private key configured, setupConnection must (a) write the key
+// to disk and (b) pin keyfile=/sshauth=privkey on the URI so libvirt's own
+// qemu+ssh transport authenticates with it.
+func TestSetupConnection_KeyAuth_WritesKeyAndPinsURI(t *testing.T) {
+	t.Setenv(EnvInsecureSkipHostKeyVerification, "true") // skip known_hosts hard-fail
+	require.NoError(t, os.RemoveAll(sshPrivateKeyDir))
+	t.Cleanup(func() { _ = os.RemoveAll(sshPrivateKeyDir) })
+
+	v := &VirshProvider{
+		config:      &ProviderConfig{Spec: ProviderSpec{Endpoint: "qemu+ssh://virtrigaud@172.16.56.8/system"}},
+		credentials: &Credentials{Username: "virtrigaud", SSHPrivateKey: "FAKE-KEY"},
+	}
+
+	require.NoError(t, v.setupConnection())
+
+	assert.Contains(t, v.uri, "keyfile="+url.QueryEscape(sshPrivateKeyPath))
+	assert.Contains(t, v.uri, "sshauth=privkey")
+
+	got, err := os.ReadFile(sshPrivateKeyPath)
+	require.NoError(t, err)
+	assert.Equal(t, "FAKE-KEY\n", string(got))
+}
+
+// TestSetupConnection_PasswordAuth_NoKeyfile is the negative guard: the key logic
+// is gated on SSHPrivateKey, so a password-only connection must NOT pin keyfile=
+// on the URI nor leave a key file behind.
+func TestSetupConnection_PasswordAuth_NoKeyfile(t *testing.T) {
+	t.Setenv(EnvInsecureSkipHostKeyVerification, "true")
+	require.NoError(t, os.RemoveAll(sshPrivateKeyDir))
+	t.Cleanup(func() { _ = os.RemoveAll(sshPrivateKeyDir) })
+
+	v := &VirshProvider{
+		config:      &ProviderConfig{Spec: ProviderSpec{Endpoint: "qemu+ssh://virtrigaud@172.16.56.8/system"}},
+		credentials: &Credentials{Username: "virtrigaud", Password: "secret"},
+	}
+
+	require.NoError(t, v.setupConnection())
+
+	assert.NotContains(t, v.uri, "keyfile=")
+	assert.NotContains(t, v.uri, "sshauth=")
+
+	_, err := os.Stat(sshPrivateKeyPath)
+	assert.True(t, os.IsNotExist(err), "no private key file should be written for password auth")
+}
+
+// TestSSHConfigStanza_EnablesPubkeyAuth guards the no->yes flip: the key-based
+// qemu+ssh transport reads ~/.ssh/config, so PubkeyAuthentication must be on for
+// both host-key policies.
+func TestSSHConfigStanza_EnablesPubkeyAuth(t *testing.T) {
+	for _, insecure := range []bool{false, true} {
+		stanza := hostKeyPolicy{insecure: insecure}.sshConfigStanza()
+		assert.Contains(t, stanza, "PubkeyAuthentication yes")
+		assert.NotContains(t, stanza, "PubkeyAuthentication no")
+	}
+}
+
+// TestRemoteVirshConnectURI pins the driver+path a remote-side `virsh -c` must
+// target, so a remote virsh hits the SAME libvirtd as the rest of the provider
+// regardless of whether the ssh user is root (default system) or non-root
+// (default session). Query params (keyfile/no_tty/…) and the ssh transport/host
+// must all be stripped.
+func TestRemoteVirshConnectURI(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"root system", "qemu+ssh://root@host/system", "qemu:///system"},
+		{"non-root session", "qemu+ssh://user@host/session", "qemu:///session"},
+		{"non-root system in libvirt group", "qemu+ssh://libvirtuser@host/system", "qemu:///system"},
+		{"strips query", "qemu+ssh://host/system?keyfile=%2Fk&no_tty=1&sshauth=privkey", "qemu:///system"},
+		{"local uri", "qemu:///system", "qemu:///system"},
+		{"other driver", "test+ssh://host/default", "test:///default"},
+		{"no path -> empty (legacy fallback)", "qemu+ssh://host", ""},
+		{"empty path -> empty", "qemu+ssh://host/", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, remoteVirshConnectURI(tc.in))
+		})
+	}
+}

--- a/internal/providers/libvirt/storage.go
+++ b/internal/providers/libvirt/storage.go
@@ -146,7 +146,7 @@ func (s *StorageProvider) createDefaultStoragePool(ctx context.Context) error {
 	}
 
 	// Define the pool
-	if _, err := s.virshProvider.runVirshCommand(ctx, "pool-define", poolFile); err != nil {
+	if _, err := s.virshProvider.runRemoteVirshCommand(ctx, "pool-define", poolFile); err != nil {
 		return fmt.Errorf("failed to define storage pool: %w", err)
 	}
 

--- a/internal/providers/libvirt/virsh.go
+++ b/internal/providers/libvirt/virsh.go
@@ -29,6 +29,11 @@ import (
 	"time"
 )
 
+const (
+	sshPrivateKeyDir  = "/tmp/virtrigaud-libvirt"
+	sshPrivateKeyPath = sshPrivateKeyDir + "/ssh-privatekey"
+)
+
 // VirshProvider implements a virsh command-line based libvirt provider
 type VirshProvider struct {
 	config      *ProviderConfig
@@ -183,14 +188,25 @@ func (v *VirshProvider) setupConnection() error {
 		}
 	}
 
+	isSSHURI := strings.Contains(parsedURI.Scheme, "ssh")
+
 	// Add SSH options for container environments. Host-key handling is delegated
 	// to the centralized policy: insecure path restores no_verify=1, the
 	// verifying path omits it and relies on the verifying ~/.ssh/config +
 	// known_hosts written below.
-	if strings.Contains(parsedURI.Scheme, "ssh") {
+	if isSSHURI {
 		query := parsedURI.Query()
 		v.hostKey.applyURIHostKeyOptions(query)
 		query.Set("no_tty", "1") // Non-interactive mode
+		if strings.TrimSpace(v.credentials.SSHPrivateKey) != "" {
+			keyPath, err := v.writeSSHPrivateKey()
+			if err != nil {
+				return fmt.Errorf("failed to write SSH private key for libvirt transport: %w", err)
+			}
+			query.Set("keyfile", keyPath)
+			query.Set("sshauth", "privkey")
+			log.Printf("INFO Configured key-based SSH authentication for libvirt transport keyfile=%s", keyPath)
+		}
 		parsedURI.RawQuery = query.Encode()
 
 		// Emit the one-line host-key verification-mode audit log (WARN on the
@@ -210,6 +226,15 @@ func (v *VirshProvider) setupConnection() error {
 	v.env = os.Environ()
 	v.env = append(v.env, fmt.Sprintf("LIBVIRT_DEFAULT_URI=%s", v.uri))
 
+	if isSSHURI {
+		if err := v.createSSHConfig(); err != nil {
+			if strings.TrimSpace(v.credentials.SSHPrivateKey) != "" {
+				return fmt.Errorf("failed to create SSH config for key-based libvirt transport: %w", err)
+			}
+			log.Printf("WARN Failed to create SSH config: %v", err)
+		}
+	}
+
 	// Set SSH authentication via environment variables for non-interactive use
 	if v.credentials.Password != "" {
 		// Use sshpass for non-interactive password authentication
@@ -218,16 +243,89 @@ func (v *VirshProvider) setupConnection() error {
 		// Set SSH options for non-interactive authentication
 		v.env = append(v.env, "SSH_ASKPASS_REQUIRE=never")
 
-		// Create SSH config for automatic host key acceptance
-		if err := v.createSSHConfig(); err != nil {
-			log.Printf("WARN Failed to create SSH config: %v", err)
-		}
-
 		log.Printf("INFO Configured non-interactive SSH authentication via sshpass")
 	}
 
 	log.Printf("INFO Configured virsh environment with URI: %s", v.uri)
 	return nil
+}
+
+func (v *VirshProvider) writeSSHPrivateKey() (string, error) {
+	if err := os.MkdirAll(sshPrivateKeyDir, 0700); err != nil {
+		return "", fmt.Errorf("failed to create SSH private key directory: %w", err)
+	}
+
+	key := strings.TrimSpace(v.credentials.SSHPrivateKey) + "\n"
+	if err := os.WriteFile(sshPrivateKeyPath, []byte(key), 0600); err != nil {
+		return "", fmt.Errorf("failed to write SSH private key: %w", err)
+	}
+	if err := os.Chmod(sshPrivateKeyPath, 0600); err != nil {
+		return "", fmt.Errorf("failed to chmod SSH private key: %w", err)
+	}
+	return sshPrivateKeyPath, nil
+}
+
+// sshKeyAuthOptions returns the ssh/scp flags that force key-based authentication
+// using keyFile. Shared by the direct-ssh ("!"), scp, and stdin-stream call sites
+// so the key is offered identically everywhere: the key lives at a non-default
+// path with no IdentityFile in ~/.ssh/config, so -i is mandatory, and
+// IdentitiesOnly + the explicit auth toggles stop ssh from wandering onto an agent
+// key or a password prompt.
+func sshKeyAuthOptions(keyFile string) []string {
+	return []string{
+		"-i", keyFile,
+		"-o", "IdentitiesOnly=yes",
+		"-o", "PasswordAuthentication=no",
+		"-o", "PubkeyAuthentication=yes",
+	}
+}
+
+// resolveSSHKeyFile picks the private-key path for a direct ssh/scp invocation:
+// the keyfile= pinned on the libvirt URI by setupConnection, falling back to the
+// well-known path writeSSHPrivateKey persists to.
+func resolveSSHKeyFile(parsedURI *url.URL) string {
+	if kf := parsedURI.Query().Get("keyfile"); kf != "" {
+		return kf
+	}
+	return sshPrivateKeyPath
+}
+
+// remoteVirshConnectURI derives the libvirt connection URI to hand to a `virsh`
+// process running ON the remote hypervisor host. The transport URI
+// qemu+ssh://user@host/system means "manage qemu:///system on host", so a
+// remote-side virsh must target that exact driver+path via -c. Without it the
+// command falls back to the ssh user's default (qemu:///system for root,
+// qemu:///session for non-root), which silently splits reads and writes across
+// two libvirtd instances. Returns "" when no driver/path can be derived, in which
+// case the caller omits -c and keeps the legacy (remote-default) behaviour.
+func remoteVirshConnectURI(rawURI string) string {
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		return ""
+	}
+	driver := parsed.Scheme
+	if i := strings.IndexByte(driver, '+'); i >= 0 {
+		driver = driver[:i] // qemu+ssh -> qemu
+	}
+	path := strings.Trim(parsed.Path, "/") // /system -> system
+	if driver == "" || path == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:///%s", driver, path)
+}
+
+// runRemoteVirshCommand runs `virsh <args>` ON the remote hypervisor host over SSH
+// (used for subcommands that must read a host-local file the provider wrote there,
+// e.g. define / pool-define). It pins -c to the connection URI's driver+path so the
+// command targets the same libvirtd as the rest of the provider whether the ssh
+// user is root (qemu:///system) or non-root (qemu:///session).
+func (v *VirshProvider) runRemoteVirshCommand(ctx context.Context, args ...string) (*VirshResult, error) {
+	cmd := []string{"!", "virsh"}
+	if uri := remoteVirshConnectURI(v.uri); uri != "" {
+		cmd = append(cmd, "-c", uri)
+	}
+	cmd = append(cmd, args...)
+	return v.runVirshCommand(ctx, cmd...)
 }
 
 // testConnection verifies that virsh can connect to the libvirt hypervisor
@@ -361,28 +459,45 @@ func (v *VirshProvider) runVirshCommandOnce(ctx context.Context, args ...string)
 			return nil, fmt.Errorf("no command specified after '!' prefix")
 		}
 
-		if v.credentials.Password != "" && strings.Contains(v.uri, "ssh://") {
-			// For remote execution, use SSH
+		if strings.Contains(v.uri, "ssh://") {
 			parsedURI, _ := url.Parse(v.uri)
 			host := parsedURI.Host
 			user := parsedURI.User.Username()
 
-			sshArgs := []string{
-				"-e", // Read password from SSHPASS environment variable
-				"ssh",
-				"-o", "PasswordAuthentication=yes",
-				"-o", "PubkeyAuthentication=no",
-				"-o", "LogLevel=ERROR",
-			}
-			// Host-key options come from the centralized policy (#149/ADR-0004);
-			// ControlMaster multiplexing reuses one connection (#194).
-			sshArgs = append(sshArgs, v.hostKey.sshHostKeyOptions()...)
-			sshArgs = append(sshArgs, sshMultiplexOptions()...)
-			sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host))
-			sshArgs = append(sshArgs, directArgs...)
+			if v.credentials.Password != "" {
+				// For remote execution with password authentication, use SSH via sshpass.
+				sshArgs := []string{
+					"-e", // Read password from SSHPASS environment variable
+					"ssh",
+					"-o", "PasswordAuthentication=yes",
+					"-o", "PubkeyAuthentication=no",
+					"-o", "LogLevel=ERROR",
+				}
+				// Host-key options come from the centralized policy (#149/ADR-0004);
+				// ControlMaster multiplexing reuses one connection (#194).
+				sshArgs = append(sshArgs, v.hostKey.sshHostKeyOptions()...)
+				sshArgs = append(sshArgs, sshMultiplexOptions()...)
+				sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host))
+				sshArgs = append(sshArgs, directArgs...)
 
-			cmd = exec.CommandContext(ctx, "sshpass", sshArgs...)
-			command = fmt.Sprintf("sshpass -e ssh %s@%s %s", user, host, strings.Join(directArgs, " "))
+				cmd = exec.CommandContext(ctx, "sshpass", sshArgs...)
+				command = fmt.Sprintf("sshpass -e ssh %s@%s %s", user, host, strings.Join(directArgs, " "))
+			} else if strings.TrimSpace(v.credentials.SSHPrivateKey) != "" {
+				keyFile := resolveSSHKeyFile(parsedURI)
+				sshArgs := sshKeyAuthOptions(keyFile)
+				sshArgs = append(sshArgs, "-o", "LogLevel=ERROR")
+				sshArgs = append(sshArgs, v.hostKey.sshHostKeyOptions()...)
+				sshArgs = append(sshArgs, sshMultiplexOptions()...)
+				sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host))
+				sshArgs = append(sshArgs, directArgs...)
+
+				cmd = exec.CommandContext(ctx, "ssh", sshArgs...)
+				command = fmt.Sprintf("ssh -i %s %s@%s %s", keyFile, user, host, strings.Join(directArgs, " "))
+			} else {
+				// Local execution
+				cmd = exec.CommandContext(ctx, directArgs[0], directArgs[1:]...)
+				command = strings.Join(directArgs, " ")
+			}
 		} else {
 			// Local execution
 			cmd = exec.CommandContext(ctx, directArgs[0], directArgs[1:]...)
@@ -413,10 +528,16 @@ func (v *VirshProvider) runVirshCommandOnce(ctx context.Context, args ...string)
 			sshArgs = append(sshArgs, v.hostKey.sshHostKeyOptions()...)
 			sshArgs = append(sshArgs, sshMultiplexOptions()...)
 			sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", user, host), "virsh")
-			sshArgs = append(sshArgs, args...)
+			// Pin the remote virsh to the connection URI's libvirtd (root → system,
+			// non-root → session) instead of letting it pick the ssh user's default.
+			remoteVirshArgs := args
+			if uri := remoteVirshConnectURI(v.uri); uri != "" {
+				remoteVirshArgs = append([]string{"-c", uri}, args...)
+			}
+			sshArgs = append(sshArgs, remoteVirshArgs...)
 
 			cmd = exec.CommandContext(ctx, "sshpass", sshArgs...)
-			command = fmt.Sprintf("sshpass -e ssh %s@%s virsh %s", user, host, strings.Join(args, " "))
+			command = fmt.Sprintf("sshpass -e ssh %s@%s virsh %s", user, host, strings.Join(remoteVirshArgs, " "))
 			cmd.Env = v.env
 		} else {
 			// Standard virsh command for local or key-based connections
@@ -592,36 +713,40 @@ func (v *VirshProvider) getDomainInfo(ctx context.Context, domainName string) (m
 // key-based path), so the config must enforce the same StrictHostKeyChecking +
 // UserKnownHostsFile that the explicit-argv password/scp paths use.
 func (v *VirshProvider) createSSHConfig() error {
-	sshDir := "/home/app/.ssh"
-	configPath := sshDir + "/config"
-
-	// Ensure SSH directory exists
-	if err := os.MkdirAll(sshDir, 0700); err != nil {
-		log.Printf("DEBUG Failed to create SSH directory: %v", err)
-		// Try a different location if home directory is read-only
-		sshDir = "/tmp/.ssh"
-		configPath = sshDir + "/config"
-		if err := os.MkdirAll(sshDir, 0700); err != nil {
-			return fmt.Errorf("failed to create SSH directory: %w", err)
-		}
-		// Set SSH config path in environment
-		v.env = append(v.env, "HOME=/tmp")
-		log.Printf("INFO Using /tmp as HOME for SSH config")
-	}
-
 	// SSH config content honouring the centralized host-key policy
 	// (#149/ADR-0004). Verifying by default (StrictHostKeyChecking yes +
 	// credentials-mounted known_hosts); legacy accept-new + /tmp/known_hosts
 	// only on the explicit escape-hatch path.
 	sshConfig := v.hostKey.sshConfigStanza()
 
-	// Write SSH config file
-	if err := os.WriteFile(configPath, []byte(sshConfig), 0600); err != nil {
-		return fmt.Errorf("failed to write SSH config: %w", err)
+	var lastErr error
+	for _, candidate := range []struct {
+		dir  string
+		home string
+	}{
+		{dir: "/home/app/.ssh"},
+		{dir: "/tmp/.ssh", home: "/tmp"},
+	} {
+		configPath := candidate.dir + "/config"
+		if err := os.MkdirAll(candidate.dir, 0700); err != nil {
+			lastErr = err
+			log.Printf("DEBUG Failed to create SSH directory %s: %v", candidate.dir, err)
+			continue
+		}
+		if err := os.WriteFile(configPath, []byte(sshConfig), 0600); err != nil {
+			lastErr = err
+			log.Printf("DEBUG Failed to write SSH config at %s: %v", configPath, err)
+			continue
+		}
+		if candidate.home != "" {
+			v.env = append(v.env, "HOME="+candidate.home)
+			log.Printf("INFO Using %s as HOME for SSH config", candidate.home)
+		}
+		log.Printf("INFO Created SSH config at %s honouring host-key policy", configPath)
+		return nil
 	}
 
-	log.Printf("INFO Created SSH config at %s honouring host-key policy", configPath)
-	return nil
+	return fmt.Errorf("failed to create writable SSH config: %w", lastErr)
 }
 
 // Cleanup performs any necessary cleanup operations


### PR DESCRIPTION
Closes #248.

libvirt key-based `qemu+ssh` auth never authenticated — the SSH-invocation logic is hand-rolled in four places and only the password branch of each was wired up. See #248 for the full `file:line` breakdown. This closes every gap, de-duplicates the SSH auth logic, and makes remote `virsh` target the correct libvirtd for both root and non-root ssh users.

### What changed

- `setupConnection` writes the key (0600) and pins `keyfile=&sshauth=privkey` on the URI; `~/.ssh/config` → `PubkeyAuthentication yes`, written for all ssh URIs (key-path write failure is now a hard error).
- the direct ssh (`!`), `scp` (`copyDiskToRemote`) and stdin-stream (`runSSHStdin`) paths pass `-i <keyfile>` via a shared `sshKeyAuthOptions()` / `resolveSSHKeyFile()` instead of silently omitting it; the `!` handler no longer runs key-path commands locally in the pod.
- `define` / `pool-define` run remotely (`runRemoteVirshCommand`) so they read the host-local XML the provider wrote; `ImportDisk`'s `qemu-img info` uses the remote copy; removed the now-unused `getSSHTarget()`.
- `remoteVirshConnectURI` derives `qemu:///{system,session}` from the connection URI and pins it with `-c`, so remote `virsh` hits the same libvirtd whether the ssh user is root or non-root (also fixes the pre-existing password + non-root case).

### Tests

`sshkeyauth_test.go` — key write/perms, URI pinning (key vs password), the arg builder, `resolveSSHKeyFile`, the `PubkeyAuthentication` flip, and `remoteVirshConnectURI` across the root/non-root × system/session quadrants. `go build` / `go vet` / `make test` clean.

### Open questions (carried from #248)

1. **Key on disk** at `/tmp/virtrigaud-libvirt/ssh-privatekey` (0600, the `tmp` emptyDir) — acceptable, or prefer ssh-agent / cleanup-on-exit? (ADR-0004 was careful about `/tmp` emptyDir semantics.)
2. Confirm the **URI-derived `-c`** approach (root/non-root) rather than assuming root.
3. OK to **bundle the password + non-root `-c` fix** here, or split it out?

### Impact

Not a breaking change — repairs a 100%-broken key-auth path; no operator action on upgrade.

- [x] Tests pass (`make test`)
- [x] `go vet` / `gofmt` clean
- [ ] CRD sync (N/A — no API change)
- [x] CHANGELOG entry added
- [ ] Docs updated (N/A — no operator-facing surface change)
