### PR TITLE
fix(security): keep the libvirt SSH private key off node disk (memory-backed volume)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-17 10:05] - Keep the libvirt SSH private key off node disk (memory-backed volume)
+**Author:** @wrkode (William Rizzo)
+
+### Security
+- `internal/controller/provider_controller.go`: libvirt provider pods now get a dedicated **memory-backed (tmpfs) emptyDir** mounted at `/tmp/virtrigaud-libvirt` (the directory the libvirt provider materialises its SSH private key into, added in #249). Previously that path lived under the provider's main `/tmp`, a plain disk-backed `EmptyDir{}`, so a key written from the `credentialsSecretRef` Secret (itself tmpfs) would also persist at rest on the node's disk. The new volume is `Medium: Memory` with a small `4Mi` sizeLimit and is **scoped to libvirt providers** so the main `/tmp` stays disk-backed for multi-GB migration disk staging (a memory-backed `/tmp` would OOM vSphere's qcow2→vmdk conversion).
+
+### Why
+Hardening for the libvirt key-based SSH auth path: key material should never touch the node's disk. Surfaced during the security review of the libvirt key-auth fix (#249/#248). The mount path matches the libvirt provider's `sshPrivateKeyDir`.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (provider pods re-templated; libvirt provider pods gain one volume)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-17 08:57] - libvirt SSH private-key authentication works end-to-end
 **Author:** @jing2uo (Komh)
 

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -910,6 +910,19 @@ func (r *ProviderReconciler) buildProviderContainer(provider *infravirtrigaudiov
 		MountPath: "/tmp",
 	})
 
+	// Back the libvirt provider's SSH private-key directory with a memory-backed
+	// (tmpfs) volume so the key it materialises from the credentials Secret is
+	// never written to the node's disk-backed /tmp emptyDir. Nested under /tmp so
+	// the main /tmp stays disk-backed for multi-GB migration disk staging (a
+	// memory-backed /tmp would OOM disk conversion). Scoped to libvirt — only that
+	// provider writes an SSH key here.
+	if provider.Spec.Type == infravirtrigaudiov1beta1.ProviderTypeLibvirt {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      sshKeyVolumeName,
+			MountPath: sshKeyMountPath,
+		})
+	}
+
 	// Default security context
 	securityContext := &corev1.SecurityContext{
 		RunAsNonRoot:             util.BoolPtr(true),
@@ -1045,8 +1058,34 @@ func (r *ProviderReconciler) buildPodVolumes(provider *infravirtrigaudiov1beta1.
 		},
 	})
 
+	// Memory-backed companion for the libvirt SSH key mount: keeps the private key
+	// in RAM (tmpfs), never on node disk. Small sizeLimit — only key material lives
+	// here. Scoped to libvirt providers (see the matching volume mount).
+	if provider.Spec.Type == infravirtrigaudiov1beta1.ProviderTypeLibvirt {
+		sshKeySizeLimit := resource.MustParse("4Mi")
+		volumes = append(volumes, corev1.Volume{
+			Name: sshKeyVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium:    corev1.StorageMediumMemory,
+					SizeLimit: &sshKeySizeLimit,
+				},
+			},
+		})
+	}
+
 	return volumes
 }
+
+const (
+	// sshKeyVolumeName and sshKeyMountPath back the libvirt provider's on-disk SSH
+	// private key with a memory-backed (tmpfs) emptyDir, so the key materialised
+	// from the credentials Secret never lands at rest on the node's disk-backed
+	// /tmp. sshKeyMountPath MUST match sshPrivateKeyDir in the libvirt provider
+	// (internal/providers/libvirt/virsh.go).
+	sshKeyVolumeName = "libvirt-ssh-key"
+	sshKeyMountPath  = "/tmp/virtrigaud-libvirt"
+)
 
 const (
 	// migrationPVCLabelKey and migrationPVCLabelValue identify a migration scratch


### PR DESCRIPTION
## Keep the libvirt SSH private key off node disk

Security hardening surfaced while reviewing the libvirt key-based SSH auth fix (#249, closes #248).

### Problem
That fix has the libvirt provider materialise its SSH private key (from the `credentialsSecretRef` Secret) to `/tmp/virtrigaud-libvirt/ssh-privatekey` (correct perms: `0600` in a `0700` dir). But the provider's `/tmp` is a plain disk-backed `EmptyDir{}` ([provider_controller.go](internal/controller/provider_controller.go)), so the key — which otherwise lives only in the tmpfs-mounted Secret — also lands **at rest on the node's disk**. For VirtRigaud's documented banking-compliance posture, private-key material should never touch node disk.

### Fix
Mount a dedicated **memory-backed (tmpfs) `emptyDir`** at `/tmp/virtrigaud-libvirt` (`Medium: Memory`, `4Mi` sizeLimit), **scoped to libvirt provider pods**. The key now stays in RAM.

Deliberately a *nested, dedicated* volume rather than flipping the whole `/tmp` to memory: the main `/tmp` must stay disk-backed because the vSphere provider stages multi-GB disks there during migration (`qcow2 → streamOptimized vmdk`); a memory-backed `/tmp` would OOM that conversion against the 512Mi limit.

### Notes
- **Independent of #249** — the mount is harmless before that PR merges (nothing writes there) and protective after. Mergeable in either order. The mount path matches the libvirt provider's `sshPrivateKeyDir` constant.
- The key *file* is `0600`, so content is protected regardless; this closes the at-rest-on-disk gap.
- `go build` / `go vet` / `golangci-lint` / controller tests all pass.

### Impact
- [ ] Breaking change
- [x] Requires cluster rollout (libvirt provider pods gain one volume)
- [ ] Config change only
- [ ] Documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
