### PR TITLE
feat(chart): render observability templates — ServiceMonitor, PrometheusRule, Grafana dashboard (closes #228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-17 14:55] - chart: render the observability templates (ServiceMonitor, PrometheusRule, Grafana dashboard)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `charts/virtrigaud/templates/servicemonitor.yaml`: a Prometheus-Operator `ServiceMonitor` selecting the manager Service's `metrics` port (`/metrics`), gated on `observability.prometheus.{enabled,serviceMonitor.enabled}` **and** the `monitoring.coreos.com/v1` CRD being present (so an install without the operator skips it cleanly rather than failing the apply). `interval`/`scrapeTimeout`/extra labels come from values.
+- `charts/virtrigaud/templates/prometheusrule.yaml`: a `PrometheusRule` with four starter alerts that reference only metrics the manager actually exports — `VirtRigaudManagerDown` (`absent(virtrigaud_build_info)`), `VirtRigaudProviderCircuitBreakerOpen` (`virtrigaud_circuit_breaker_state == 2`), `VirtRigaudHighReconcileErrorRate` (error-outcome reconcile ratio > 20%), `VirtRigaudProviderRPCErrors` (non-OK RPC ratio > 10%). Same value + CRD gate.
+- `charts/virtrigaud/templates/grafana-dashboard-configmap.yaml` + `charts/virtrigaud/dashboards/virtrigaud-dashboard.json`: a Grafana dashboard ConfigMap (9 panels) labelled `grafana_dashboard: "1"` for the Grafana sidecar to auto-import, gated on `observability.grafana.{enabled,dashboards.enabled}`.
+
+### Why
+The `observability` values block (and its `serviceMonitorLabels`/`prometheusRuleLabels`/`grafanaDashboardLabels` helpers) already existed, but **no template rendered any of it** — setting `observability.prometheus.serviceMonitor.enabled=true` produced nothing, so operators wiring kube-prometheus-stack had to hand-roll a ServiceMonitor. Closes #228.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] Config change only
+- [ ] Documentation only
+
 ## [2026-06-17 10:05] - Keep the libvirt SSH private key off node disk (memory-backed volume)
 **Author:** @wrkode (William Rizzo)
 

--- a/charts/virtrigaud/dashboards/virtrigaud-dashboard.json
+++ b/charts/virtrigaud/dashboards/virtrigaud-dashboard.json
@@ -1,0 +1,50 @@
+{
+  "title": "VirtRigaud — Operator Overview",
+  "uid": "virtrigaud-overview",
+  "tags": ["virtrigaud"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {"list": [
+    {"name": "datasource", "type": "datasource", "query": "prometheus", "current": {}, "hide": 0, "label": "Datasource"}
+  ]},
+  "panels": [
+    {"type": "stat", "title": "Build", "gridPos": {"h": 4, "w": 8, "x": 0, "y": 0},
+     "datasource": {"type": "prometheus", "uid": "${datasource}"},
+     "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "/^version$/"}, "textMode": "name", "colorMode": "none"},
+     "targets": [{"expr": "virtrigaud_build_info", "legendFormat": "{{version}} ({{go_version}})", "instant": true}]},
+    {"type": "stat", "title": "Circuit breaker state (per provider)", "gridPos": {"h": 4, "w": 8, "x": 8, "y": 0},
+     "datasource": {"type": "prometheus", "uid": "${datasource}"},
+     "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background"},
+     "fieldConfig": {"defaults": {"mappings": [
+       {"type": "value", "options": {"0": {"text": "closed", "color": "green"}, "1": {"text": "half-open", "color": "yellow"}, "2": {"text": "open", "color": "red"}}}]}},
+     "targets": [{"expr": "virtrigaud_circuit_breaker_state", "legendFormat": "{{provider}}", "instant": true}]},
+    {"type": "stat", "title": "Provider tasks in-flight", "gridPos": {"h": 4, "w": 8, "x": 16, "y": 0},
+     "datasource": {"type": "prometheus", "uid": "${datasource}"},
+     "targets": [{"expr": "sum(virtrigaud_provider_tasks_inflight) by (provider)", "legendFormat": "{{provider}}", "instant": true}]},
+
+    {"type": "timeseries", "title": "Reconcile rate by kind & outcome", "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+     "datasource": {"type": "prometheus", "uid": "${datasource}"},
+     "targets": [{"expr": "sum(rate(virtrigaud_manager_reconcile_total[5m])) by (kind, outcome)", "legendFormat": "{{kind}} / {{outcome}}"}]},
+    {"type": "timeseries", "title": "Reconcile p95 latency by kind (s)", "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+     "datasource": {"type": "prometheus", "uid": "${datasource}"},
+     "fieldConfig": {"defaults": {"unit": "s"}},
+     "targets": [{"expr": "histogram_quantile(0.95, sum(rate(virtrigaud_manager_reconcile_duration_seconds_bucket[5m])) by (le, kind))", "legendFormat": "{{kind}}"}]},
+
+    {"type": "timeseries", "title": "Provider RPC rate by method & code", "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+     "datasource": {"type": "prometheus", "uid": "${datasource}"},
+     "targets": [{"expr": "sum(rate(virtrigaud_provider_rpc_requests_total[5m])) by (method, code)", "legendFormat": "{{method}} / {{code}}"}]},
+    {"type": "timeseries", "title": "Provider RPC p95 latency by method (s)", "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+     "datasource": {"type": "prometheus", "uid": "${datasource}"},
+     "fieldConfig": {"defaults": {"unit": "s"}},
+     "targets": [{"expr": "histogram_quantile(0.95, sum(rate(virtrigaud_provider_rpc_latency_seconds_bucket[5m])) by (le, method))", "legendFormat": "{{method}}"}]},
+
+    {"type": "timeseries", "title": "VM operations rate by op & outcome", "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+     "datasource": {"type": "prometheus", "uid": "${datasource}"},
+     "targets": [{"expr": "sum(rate(virtrigaud_vm_operations_total[5m])) by (operation, outcome)", "legendFormat": "{{operation}} / {{outcome}}"}]},
+    {"type": "timeseries", "title": "Errors rate by reason & component", "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+     "datasource": {"type": "prometheus", "uid": "${datasource}"},
+     "targets": [{"expr": "sum(rate(virtrigaud_errors_total[5m])) by (reason, component)", "legendFormat": "{{reason}} / {{component}}"}]}
+  ]
+}

--- a/charts/virtrigaud/templates/grafana-dashboard-configmap.yaml
+++ b/charts/virtrigaud/templates/grafana-dashboard-configmap.yaml
@@ -1,0 +1,25 @@
+{{- /*
+Grafana dashboard ConfigMap. The Grafana sidecar (kube-prometheus-stack's
+grafana.sidecar.dashboards) discovers ConfigMaps carrying the
+`grafana_dashboard: "1"` label (from observability.grafana.dashboards.labels)
+and auto-imports the JSON. No Prometheus-Operator CRD needed — it is a plain
+ConfigMap. The dashboard JSON lives in the chart at dashboards/.
+*/ -}}
+{{- if and .Values.observability.grafana.enabled .Values.observability.grafana.dashboards.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "virtrigaud.fullname" . }}-grafana-dashboards
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "virtrigaud.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana-dashboard
+    {{- with (include "virtrigaud.grafanaDashboardLabels" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+data:
+{{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+  {{ base $path }}: |
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/virtrigaud/templates/prometheusrule.yaml
+++ b/charts/virtrigaud/templates/prometheusrule.yaml
@@ -1,0 +1,68 @@
+{{- /*
+PrometheusRule with a small set of starter alerts for the manager (Prometheus
+Operator). Expressions use only metrics the manager actually exports. Gated on
+the values flags AND on the monitoring.coreos.com/v1 CRD being present, like the
+ServiceMonitor. Prometheus's own `{{ $labels.x }}` templating is wrapped in Helm
+raw-string literals so Helm does not try to evaluate it.
+*/ -}}
+{{- if and .Values.observability.prometheus.enabled .Values.observability.prometheus.prometheusRule.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "virtrigaud.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "virtrigaud.labels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
+    {{- with (include "virtrigaud.prometheusRuleLabels" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: virtrigaud.rules
+      rules:
+        - alert: VirtRigaudManagerDown
+          expr: absent(virtrigaud_build_info)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: {{ `VirtRigaud manager is not reporting metrics` | quote }}
+            description: {{ `No virtrigaud_build_info sample for 5m — the manager is down or its /metrics endpoint is unreachable.` | quote }}
+
+        - alert: VirtRigaudProviderCircuitBreakerOpen
+          # circuit_breaker_state: 0=closed, 1=half-open, 2=open
+          expr: virtrigaud_circuit_breaker_state == 2
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: {{ `Provider circuit breaker open ({{ $labels.provider }})` | quote }}
+            description: {{ `The circuit breaker for provider {{ $labels.provider }} ({{ $labels.provider_type }}) has been open for 5m — calls to this provider are failing fast.` | quote }}
+
+        - alert: VirtRigaudHighReconcileErrorRate
+          expr: |-
+            sum by (kind) (rate(virtrigaud_manager_reconcile_total{outcome="error"}[5m]))
+              /
+            sum by (kind) (rate(virtrigaud_manager_reconcile_total[5m]))
+              > 0.2
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: {{ `High reconcile error rate for {{ $labels.kind }}` | quote }}
+            description: {{ `More than 20% of {{ $labels.kind }} reconciles have errored over the last 15m.` | quote }}
+
+        - alert: VirtRigaudProviderRPCErrors
+          expr: |-
+            sum by (provider_type, method) (rate(virtrigaud_provider_rpc_requests_total{code!="OK"}[5m]))
+              /
+            sum by (provider_type, method) (rate(virtrigaud_provider_rpc_requests_total[5m]))
+              > 0.1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: {{ `Elevated provider RPC error rate ({{ $labels.provider_type }} {{ $labels.method }})` | quote }}
+            description: {{ `More than 10% of {{ $labels.method }} RPCs to {{ $labels.provider_type }} providers returned a non-OK status over the last 10m.` | quote }}
+{{- end }}

--- a/charts/virtrigaud/templates/servicemonitor.yaml
+++ b/charts/virtrigaud/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- /*
+ServiceMonitor for the manager's /metrics endpoint (Prometheus Operator).
+
+Gated on the values flags AND on the monitoring.coreos.com/v1 CRD being present
+in the cluster, so a chart install on a cluster without the Prometheus Operator
+skips this resource cleanly instead of failing with "no matches for kind
+ServiceMonitor". (For `helm template`, pass `--api-versions monitoring.coreos.com/v1`
+to render it.)
+*/ -}}
+{{- if and .Values.observability.prometheus.enabled .Values.observability.prometheus.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "virtrigaud.managerServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "virtrigaud.labels" . | nindent 4 }}
+    app.kubernetes.io/component: manager
+    {{- with (include "virtrigaud.serviceMonitorLabels" .) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "virtrigaud.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: manager
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.observability.prometheus.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.observability.prometheus.serviceMonitor.scrapeTimeout | default "10s" }}
+{{- end }}


### PR DESCRIPTION
## Render the chart's observability templates

Closes #228.

The chart's `observability` values block (and its `serviceMonitorLabels` / `prometheusRuleLabels` / `grafanaDashboardLabels` helpers) existed, but **no template rendered any of it** — setting `observability.prometheus.serviceMonitor.enabled=true` produced nothing, so operators wiring kube-prometheus-stack had to hand-roll a ServiceMonitor.

### Added (all default-off, gated on the existing values)
- **`templates/servicemonitor.yaml`** — Prometheus-Operator `ServiceMonitor` selecting the manager Service's `metrics` port (`/metrics`), with `interval`/`scrapeTimeout`/extra-labels from values. Gated on `observability.prometheus.{enabled,serviceMonitor.enabled}` **and** the `monitoring.coreos.com/v1` CRD being present, so an install without the operator skips it cleanly (no "no matches for kind ServiceMonitor").
- **`templates/prometheusrule.yaml`** — four starter alerts referencing only metrics the manager actually exports:
  - `VirtRigaudManagerDown` — `absent(virtrigaud_build_info)`
  - `VirtRigaudProviderCircuitBreakerOpen` — `virtrigaud_circuit_breaker_state == 2`
  - `VirtRigaudHighReconcileErrorRate` — error-outcome reconcile ratio > 20%
  - `VirtRigaudProviderRPCErrors` — non-OK RPC ratio > 10%
- **`templates/grafana-dashboard-configmap.yaml`** + **`dashboards/virtrigaud-dashboard.json`** — a 9-panel Grafana dashboard ConfigMap labelled `grafana_dashboard: "1"` for the Grafana sidecar to auto-import. Gated on `observability.grafana.{enabled,dashboards.enabled}`.

### Verification
- `helm lint` clean.
- `helm template` confirmed for: **all-off** (nothing renders), **flags-on + `--api-versions monitoring.coreos.com/v1`** (ServiceMonitor + PrometheusRule render), **flags-on without the CRD** (both suppressed), and the **embedded dashboard JSON round-trips** (valid, 9 panels, `grafana_dashboard=1` label present).
- Alert expressions and the dashboard use only real exported metric names/labels (circuit-breaker `state==2` = open per the `iota` encoding; reconcile `outcome="error"`; RPC `code!="OK"`).

### Impact
- [ ] Breaking change
- [ ] Requires cluster rollout
- [x] Config change only (opt-in via `observability.*` values; defaults unchanged)
- [ ] Documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
