### PR TITLE
test(controller): regression coverage for migration-PVC mount lifecycle (closes #230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-17 15:30] - test: regression coverage for the migration-PVC mount lifecycle (#230)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/controller/provider_controller_migration_test.go`: `TestDiscoverMigration_MergesAllActive_AndDropsRemoved` reproduces both #230 bugs and asserts the discovery-rebuild model fixes them — (1) two concurrent migration PVCs both yield a volume+mount (no last-writer-wins clobber), and (2) once a PVC is removed, the next discovery drops its volume/mount (no stale leftover). Locks in the behavior delivered by #232/#184.
+
+### Why
+#230 was structurally addressed by the discovery-rebuild model but lacked an explicit regression test for the parallel-merge and stale-removal scenarios; this verifies and guards them. Closes #230.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-17 14:55] - chart: render the observability templates (ServiceMonitor, PrometheusRule, Grafana dashboard)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/controller/provider_controller_migration_test.go
+++ b/internal/controller/provider_controller_migration_test.go
@@ -102,6 +102,67 @@ func TestDiscoverMigrationVolumeMounts_SkipsDeletingPVCs(t *testing.T) {
 	assert.Equal(t, "/mnt/migration-storage/mig-normal", mounts[0].MountPath)
 }
 
+// TestDiscoverMigration_MergesAllActive_AndDropsRemoved reproduces the two #230
+// bugs and asserts the discovery-rebuild model fixes both:
+//
+//  1. Parallel migrations no longer clobber each other — with TWO active migration
+//     PVCs in the namespace, discovery returns a volume+mount for BOTH (the desired
+//     set is rebuilt from the full PVC list each reconcile, not from one migration's
+//     context, so it is not last-writer-wins).
+//  2. Stale mounts are removed — once a PVC is gone, the next discovery no longer
+//     returns its volume/mount, so a provider re-reconcile drops it.
+func TestDiscoverMigration_MergesAllActive_AndDropsRemoved(t *testing.T) {
+	ctx := context.Background()
+	scheme := migrationTestScheme(t)
+	ns := "default"
+
+	a := migrationPVC("mig-a", ns, false)
+	b := migrationPVC("mig-b", ns, false)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(a, b).Build()
+	r := &ProviderReconciler{Client: c, Scheme: scheme}
+
+	volNames := func() map[string]string {
+		out := map[string]string{}
+		for _, v := range r.discoverMigrationPVCs(ctx, ns) {
+			require.NotNil(t, v.PersistentVolumeClaim)
+			out[v.Name] = v.PersistentVolumeClaim.ClaimName
+		}
+		return out
+	}
+	mountNames := func() map[string]string {
+		out := map[string]string{}
+		for _, m := range r.discoverMigrationVolumeMounts(ctx, ns) {
+			out[m.Name] = m.MountPath
+		}
+		return out
+	}
+
+	// (1) Parallel merge: both active PVCs are present in the desired volume/mount set.
+	vols := volNames()
+	require.Len(t, vols, 2, "both concurrent migration PVCs must be mounted (no last-writer-wins)")
+	assert.Equal(t, "mig-a", vols["migration-mig-a"])
+	assert.Equal(t, "mig-b", vols["migration-mig-b"])
+
+	mounts := mountNames()
+	require.Len(t, mounts, 2)
+	assert.Equal(t, "/mnt/migration-storage/mig-a", mounts["migration-mig-a"])
+	assert.Equal(t, "/mnt/migration-storage/mig-b", mounts["migration-mig-b"])
+
+	// (2) Stale removal: delete mig-a entirely (no finalizer → actually removed). The
+	// next discovery rebuilds from the current PVC list and drops mig-a's volume/mount.
+	require.NoError(t, c.Delete(ctx, a))
+	vols = volNames()
+	require.Len(t, vols, 1, "removed PVC's volume must not survive the rebuild")
+	assert.Equal(t, "mig-b", vols["migration-mig-b"])
+	assert.NotContains(t, mountNames(), "migration-mig-a")
+
+	// Remove the last one too → the set is empty (no stale leftovers).
+	require.NoError(t, c.Delete(ctx, b))
+	assert.Empty(t, r.discoverMigrationPVCs(ctx, ns))
+	assert.Empty(t, r.discoverMigrationVolumeMounts(ctx, ns))
+}
+
 // TestProvidersForMigrationPVC verifies the watch map function enqueues every
 // Provider in the PVC's namespace for a migration PVC, and ignores non-migration
 // PVCs (issue #184).


### PR DESCRIPTION
## Regression coverage for the migration-PVC mount lifecycle (closes #230)

#230 reported two bugs in how provider deployments carry migration-PVC mounts:
1. **Parallel migrations clobber each other** — two concurrent VMMigrations on one provider, only the second's volume present (last-writer-wins).
2. **Stale mounts survive deletion** — after deleting migrations + PVCs, the provider deployment still carried the volume, wedging future pod restarts.

Both were structurally fixed by the **discovery-rebuild model** (#232: `discoverMigrationPVCs`/`discoverMigrationVolumeMounts` list **all** label-matched PVCs every reconcile and rebuild the desired volume set) plus **PVC deletion-protection** (#184). This adds the explicit regression test that was missing, so the fix is verified and guarded.

### Test
`TestDiscoverMigration_MergesAllActive_AndDropsRemoved` asserts, against the real discovery code:
- **Merge:** two active migration PVCs → a volume **and** mount for **both** (no clobber).
- **Stale removal:** delete one PVC → next discovery returns only the survivor; delete both → empty set.

```
--- PASS: TestDiscoverMigration_MergesAllActive_AndDropsRemoved (0.00s)
--- PASS: TestDiscoverMigrationPVCs_SkipsDeletingPVCs (0.00s)
--- PASS: TestDiscoverMigrationVolumeMounts_SkipsDeletingPVCs (0.00s)
ok  github.com/projectbeskar/virtrigaud/internal/controller
```

This is the verification I'd flagged as pending before closing #230. A full live re-run on the lab is confounded right now (the deployed release is still the v0.3.9 chart, whose RBAC predates the #231 PVC permissions), so the deterministic test against the merged code is the authoritative check. fmt / `golangci-lint` (0 issues) / full controller package all pass. Test-only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
