### PR TITLE
fix(libvirt): collapse validation N+1 to a single domain list (avoid 30s gRPC deadline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ The `observability` values block (and its `serviceMonitorLabels`/`prometheusRule
 - [x] Config change only
 - [ ] Documentation only
 
+## [2026-06-17 11:00] - libvirt: lighten connection validation to avoid gRPC deadline
+**Author:** @jing2uo (Komh)
+
+### Fixed
+- `internal/providers/libvirt/provider.go` + `internal/providers/libvirt/virsh.go`: `Provider.Validate` and `VirshProvider.testConnection` no longer call `listDomains`, which issued one `virsh domstate` per domain on top of the initial `virsh list`. Over the `qemu+ssh://` transport every virsh call is a separate SSH round-trip, so that N+1 grows linearly with the number of domains on the host. `Validate` runs under the manager's 30s gRPC deadline and is invoked on every VM reconcile (and by the runtime resolver as a health check before reusing a provider client), so on a host with only ~40 domains the cold-SSH N+1 (~37s measured) exceeded the deadline and returned `DeadlineExceeded` — leaving VMs stuck `NotReady` in a 5s requeue loop and forcing the resolver to evict and reconnect. Both paths now run a single `virsh list --all --name` and count non-empty lines; the per-domain state the old code fetched was only used for a log count, never consumed.
+
+### Why
+Validation/readiness only need a reachability check, not per-domain state. Collapsing the N+1 to one command makes the cost O(1) and independent of how many VMs run on the host. Measured on two hosts (CentOS 7 / libvirt 4.5.0 with 44 domains; Ubuntu 22.04 / libvirt 8.0.0 with 38 domains): the old path took ~36–37s of cold-SSH round-trips against a 30s deadline, while the single `virsh list` is one round-trip.
+
 ## [2026-06-17 10:05] - Keep the libvirt SSH private key off node disk (memory-backed volume)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/provider.go
+++ b/internal/providers/libvirt/provider.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -195,13 +196,22 @@ func (p *Provider) Validate(ctx context.Context) error {
 		return contracts.NewRetryableError("virsh provider not initialized", nil)
 	}
 
-	// Test the connection by listing domains
-	domains, err := p.virshProvider.listDomains(ctx)
+	// Validate must stay lightweight: controllers call it before most provider
+	// operations. Do not use listDomains here; it runs domstate for every domain
+	// and can exceed the manager-side gRPC deadline on busy libvirt hosts.
+	result, err := p.virshProvider.runVirshCommand(ctx, "list", "--all", "--name")
 	if err != nil {
 		return contracts.NewRetryableError("virsh connection validation failed", err)
 	}
 
-	log.Printf("INFO Connection validation successful - found %d domains", len(domains))
+	domainCount := 0
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		if strings.TrimSpace(line) != "" {
+			domainCount++
+		}
+	}
+
+	log.Printf("INFO Connection validation successful - found %d domains", domainCount)
 	return nil
 }
 

--- a/internal/providers/libvirt/virsh.go
+++ b/internal/providers/libvirt/virsh.go
@@ -340,13 +340,22 @@ func (v *VirshProvider) testConnection(ctx context.Context) error {
 
 	log.Printf("INFO Connection successful! Libvirt version: %s", strings.TrimSpace(result.Stdout))
 
-	// Test domain listing to verify full functionality
-	domains, err := v.listDomains(ctx)
+	// Test domain listing to verify full functionality. Keep this lightweight:
+	// startup readiness should not run one domstate command per domain on busy
+	// libvirt hosts.
+	listResult, err := v.runVirshCommand(ctx, "list", "--all", "--name")
 	if err != nil {
 		return fmt.Errorf("connection established but domain listing failed: %w", err)
 	}
 
-	log.Printf("INFO Successfully listed %d domains", len(domains))
+	domainCount := 0
+	for _, line := range strings.Split(listResult.Stdout, "\n") {
+		if strings.TrimSpace(line) != "" {
+			domainCount++
+		}
+	}
+
+	log.Printf("INFO Successfully listed %d domains", domainCount)
 	return nil
 }
 


### PR DESCRIPTION
## What

`Provider.Validate()` and `VirshProvider.testConnection()` called `listDomains()`, which runs `virsh list --all --name` **plus one `virsh domstate` per domain**. Over `qemu+ssh://`, each `virsh` call is a separate SSH round-trip, so this N+1 grows linearly with the number of domains on the host.

`Validate()` runs under the manager's 30s gRPC deadline and is called on every VM reconcile (and by the runtime resolver as a health check before reusing a cached provider client). On a host with only ~40 domains the cold-SSH N+1 (~37s measured) exceeds the deadline → `DeadlineExceeded` → VMs stuck `NotReady` in a 5s requeue loop while the resolver evicts and reconnects.

This replaces `listDomains()` in both paths with a single `virsh list --all --name` and counts non-empty lines. Validation/readiness only need a reachability check, not per-domain state — the `domstate` results were only used for a log count, never consumed. `listDomains()` itself is untouched for callers that need per-domain state.

## Testing

Measured against two hosts (different distros/libvirt versions). Full data in #255.

| Host | OS | libvirt | domains | old N+1 (cold SSH) | single `virsh list` |
|------|----|---------|---------|--------------------|---------------------|
| A | CentOS Linux 7 | 4.5.0 | 44 | **~37.4s** (> 30s deadline) | ~25ms host-local + 1 SSH hop |
| B | Ubuntu 22.04 | 8.0.0 | 38 | **~36.3s** (> 30s deadline) | ~29ms host-local + 1 SSH hop |

Host-locally the same N+1 takes only ~1s, confirming the cost is SSH transport per command, not libvirt. Cost is now O(1), independent of domain count. `go build` + `go vet` green.

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
