### PR TITLE
fix(proxmox): delete stops+purges; controller retains finalizer on failure (#261 P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-19 07:20] - fix(proxmox): delete no longer orphans VMs; finalizer retained on delete failure (#261 P0)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/controller/virtualmachine_controller.go` (P0-2, cross-cutting): `handleDeletion` no longer removes the VirtualMachine finalizer when the provider `Delete` fails. The old code logged the error and continued (`// Continue with cleanup even if deletion fails`), so a failed delete deleted the CR while leaving the hypervisor VM running — orphaning it on **any** provider (a real compliance problem for the regulated posture). It now keeps the finalizer and requeues on a real failure, treats a provider `NotFound` as already-deleted (idempotent), and honors a new `virtrigaud.io/force-delete: "true"` annotation as an operator escape hatch for a permanently-unreachable provider. Adds a `contracts.IsNotFound` helper and unit tests.
+- `internal/providers/proxmox/{server.go,pveapi/client.go}` (P0-1): the Proxmox `Delete` now stops a running VM first (Proxmox refuses to destroy a running VM — "VM <id> is running - destroy failed") and then destroys it with `purge=1&destroy-unreferenced-disks=1`, waiting for both tasks so a successful Delete means the VM is actually gone. Mirrors vSphere (power-off → Destroy) and libvirt (destroy → undefine). Also fixes the pveapi request builder to honor a query string instead of percent-encoding the `?` into the path. Fake PVE server now rejects destroying a running VM so the stop-first path is exercised by tests.
+- `internal/providers/proxmox/capabilities.go` (P0-3): drop the dishonest `pvc` disk export/import backend advertisement — the legacy pvc path `os.Open`s node-local image paths the provider pod can never reach, so only `s3` is advertised. Adds `migration.S3Only{Export,Import}Backends`.
+
+### Why
+A `kubectl delete virtualmachine` of Proxmox VMs removed the Kubernetes resources but left the VMs running on the hypervisor. Root cause was two bugs (a Proxmox `Delete` that can't destroy a running VM, and a controller that drops the finalizer even when the provider delete fails). This is the P0 slice of the Proxmox feature-parity epic (#261), which audits Proxmox against vSphere/libvirt.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager + proxmox provider images)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-18 20:40] - migration: wire powerOffBeforeMigration + Proxmox matrix validated (ADR-0006)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/controller/virtualmachine_controller.go
+++ b/internal/controller/virtualmachine_controller.go
@@ -61,6 +61,23 @@ const (
 	errReasonImagePrepare     = "image-prepare"
 )
 
+// forceDeleteAnnotation, when set to "true" on a VirtualMachine, lets the
+// finalizer be removed even if the provider Delete keeps failing. It is the
+// operator escape hatch for a permanently-unreachable provider; by default a
+// failed Delete retains the finalizer and retries so the hypervisor VM is never
+// silently orphaned.
+const forceDeleteAnnotation = "virtrigaud.io/force-delete"
+
+// vmDeleteRetryInterval is the requeue cadence while a provider Delete keeps
+// failing (finalizer retained until it succeeds or force-delete is set).
+const vmDeleteRetryInterval = 15 * time.Second
+
+// hasForceDeleteAnnotation reports whether the VM carries the force-delete
+// escape-hatch annotation set to "true".
+func hasForceDeleteAnnotation(vm *infravirtrigaudiov1beta1.VirtualMachine) bool {
+	return vm.Annotations[forceDeleteAnnotation] == "true"
+}
+
 // ProviderResolver resolves Provider resources to provider implementations.
 // Implemented by *remote.Resolver in production; can be mocked in tests.
 type ProviderResolver interface {
@@ -405,13 +422,31 @@ func (r *VirtualMachineReconciler) handleDeletion(ctx context.Context, vm *infra
 			} else {
 				logger.Info("Deleting VM from provider", "id", vm.Status.ID)
 				taskRef, err := providerInstance.Delete(ctx, vm.Status.ID)
-				if err != nil {
-					logger.Error(err, "Failed to delete VM from provider")
+				switch {
+				case err == nil:
+					if taskRef != "" {
+						logger.Info("VM deletion initiated", "taskRef", taskRef)
+						// TODO: Wait for task completion in future iterations
+					}
+				case contracts.IsNotFound(err):
+					// The hypervisor VM is already gone — nothing to orphan, so
+					// proceed to finalizer removal (idempotent delete).
+					logger.Info("VM already absent from provider; proceeding with cleanup", "id", vm.Status.ID)
+				case hasForceDeleteAnnotation(vm):
+					// Operator opted out of the safety gate: drop the finalizer even
+					// though the provider VM may be left behind. Logged loudly.
+					logger.Error(err, "Provider VM delete failed but force-delete annotation is set; removing finalizer (the provider VM may be orphaned)",
+						"id", vm.Status.ID, "annotation", forceDeleteAnnotation)
 					metrics.RecordError(errReasonProviderDelete, metrics.ComponentManager)
-					// Continue with cleanup even if deletion fails
-				} else if taskRef != "" {
-					logger.Info("VM deletion initiated", "taskRef", taskRef)
-					// TODO: Wait for task completion in future iterations
+				default:
+					// Real failure (e.g. PVE "VM is running - destroy failed"). Do
+					// NOT remove the finalizer — that would orphan the hypervisor VM.
+					// Retain it and requeue so the delete is retried; an operator can
+					// set the force-delete annotation to break out if needed.
+					logger.Error(err, "Failed to delete VM from provider; retaining finalizer and retrying",
+						"id", vm.Status.ID)
+					metrics.RecordError(errReasonProviderDelete, metrics.ComponentManager)
+					return ctrl.Result{RequeueAfter: vmDeleteRetryInterval}, nil
 				}
 			}
 		}

--- a/internal/controller/virtualmachine_controller_delete_test.go
+++ b/internal/controller/virtualmachine_controller_delete_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	stderrors "errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infravirtrigaudiov1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+)
+
+// deleteStubProvider embeds stubProvider and makes Delete return a configurable
+// error, recording how many times it was called.
+type deleteStubProvider struct {
+	stubProvider
+	err   error
+	calls atomic.Int32
+}
+
+func (p *deleteStubProvider) Delete(_ context.Context, _ string) (string, error) {
+	p.calls.Add(1)
+	return "", p.err
+}
+
+// deletionVM builds a VM that already carries the finalizer and a provider VM ID,
+// so handleDeletion attempts the provider-side delete.
+func deletionVM(name string) *infravirtrigaudiov1beta1.VirtualMachine {
+	vm := &infravirtrigaudiov1beta1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  "default",
+			Finalizers: []string{infravirtrigaudiov1beta1.VirtualMachineFinalizer},
+		},
+		Spec: infravirtrigaudiov1beta1.VirtualMachineSpec{
+			ProviderRef: infravirtrigaudiov1beta1.ObjectRef{Name: "test-provider"},
+		},
+	}
+	vm.Status.ID = "100"
+	return vm
+}
+
+func deletionProviderCR() *infravirtrigaudiov1beta1.Provider {
+	return &infravirtrigaudiov1beta1.Provider{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-provider", Namespace: "default"},
+	}
+}
+
+// markForDeletion deletes the VM through the fake client (which sets a
+// DeletionTimestamp because the finalizer is present) and returns the refreshed,
+// deletion-marked object.
+func markForDeletion(t *testing.T, r *VirtualMachineReconciler, vm *infravirtrigaudiov1beta1.VirtualMachine) *infravirtrigaudiov1beta1.VirtualMachine {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, r.Delete(ctx, vm))
+	var marked infravirtrigaudiov1beta1.VirtualMachine
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(vm), &marked))
+	require.False(t, marked.DeletionTimestamp.IsZero(), "VM should be marked for deletion")
+	return &marked
+}
+
+// TestHandleDeletion_RetainsFinalizerOnDeleteFailure is the core #261 P0-2 fix: a
+// failed provider Delete must NOT drop the finalizer (which would orphan the
+// hypervisor VM). It requeues and the VM stays present.
+func TestHandleDeletion_RetainsFinalizerOnDeleteFailure(t *testing.T) {
+	ctx := context.Background()
+	s := coverageTestScheme(t)
+	prov := &deleteStubProvider{err: stderrors.New("VM 100 is running - destroy failed")}
+	vm := deletionVM("vm-keep")
+	r := newTestReconciler(s, &stubResolver{provider: prov}, vm, deletionProviderCR())
+	marked := markForDeletion(t, r, vm)
+
+	res, err := r.handleDeletion(ctx, marked)
+	require.NoError(t, err)
+	assert.Greater(t, res.RequeueAfter, time.Duration(0), "must requeue to retry the delete")
+	require.EqualValues(t, 1, prov.calls.Load(), "must have attempted the provider delete")
+
+	var after infravirtrigaudiov1beta1.VirtualMachine
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(vm), &after), "VM must still exist (finalizer retained)")
+	assert.Contains(t, after.Finalizers, infravirtrigaudiov1beta1.VirtualMachineFinalizer,
+		"finalizer must be retained so the hypervisor VM is not orphaned")
+}
+
+// TestHandleDeletion_ProceedsWhenAlreadyGone verifies an already-absent VM
+// (provider returns NotFound) is treated as success: the finalizer is removed.
+func TestHandleDeletion_ProceedsWhenAlreadyGone(t *testing.T) {
+	ctx := context.Background()
+	s := coverageTestScheme(t)
+	prov := &deleteStubProvider{err: contracts.NewNotFoundError("delete: VM not found", nil)}
+	vm := deletionVM("vm-gone")
+	r := newTestReconciler(s, &stubResolver{provider: prov}, vm, deletionProviderCR())
+	marked := markForDeletion(t, r, vm)
+
+	_, err := r.handleDeletion(ctx, marked)
+	require.NoError(t, err)
+
+	var after infravirtrigaudiov1beta1.VirtualMachine
+	getErr := r.Get(ctx, client.ObjectKeyFromObject(vm), &after)
+	assert.True(t, apierrors.IsNotFound(getErr), "finalizer removed → VM gone when the provider VM is already absent")
+}
+
+// TestHandleDeletion_ForceDeleteAnnotationRemovesFinalizer verifies the escape
+// hatch: with the force-delete annotation, a persistently-failing Delete still
+// removes the finalizer (operator accepts a possibly-orphaned provider VM).
+func TestHandleDeletion_ForceDeleteAnnotationRemovesFinalizer(t *testing.T) {
+	ctx := context.Background()
+	s := coverageTestScheme(t)
+	prov := &deleteStubProvider{err: stderrors.New("provider permanently unreachable")}
+	vm := deletionVM("vm-force")
+	vm.Annotations = map[string]string{forceDeleteAnnotation: "true"}
+	r := newTestReconciler(s, &stubResolver{provider: prov}, vm, deletionProviderCR())
+	marked := markForDeletion(t, r, vm)
+
+	_, err := r.handleDeletion(ctx, marked)
+	require.NoError(t, err)
+
+	var after infravirtrigaudiov1beta1.VirtualMachine
+	getErr := r.Get(ctx, client.ObjectKeyFromObject(vm), &after)
+	assert.True(t, apierrors.IsNotFound(getErr), "force-delete annotation must remove the finalizer despite the failure")
+}

--- a/internal/providers/contracts/errors.go
+++ b/internal/providers/contracts/errors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package contracts
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -76,6 +77,15 @@ func (e *ProviderError) IsRetryable() bool {
 	return e.Retryable || e.Type == ErrorTypeRetryable ||
 		e.Type == ErrorTypeUnavailable || e.Type == ErrorTypeTimeout ||
 		e.Type == ErrorTypeRateLimit
+}
+
+// IsNotFound reports whether err is, or wraps, a provider NotFound error. The
+// transport client maps a gRPC codes.NotFound into a *ProviderError of this
+// type (see mapGRPCError), so controllers can treat an already-absent resource
+// as success rather than a failure.
+func IsNotFound(err error) bool {
+	var pe *ProviderError
+	return errors.As(err, &pe) && pe.Type == ErrorTypeNotFound
 }
 
 // NewNotFoundError creates a not found error

--- a/internal/providers/proxmox/capabilities.go
+++ b/internal/providers/proxmox/capabilities.go
@@ -42,12 +42,14 @@ func GetProviderCapabilities() *capabilities.Manager {
 		DiskExport("qcow2", "raw", "vmdk").
 		ExportCompression().
 		DiskImport("qcow2", "raw", "vmdk").
-		// ADR-0006: ExportDisk/ImportDisk implement BOTH the legacy pod-side
-		// (pvc, relay-shaped) staging path AND the S3 relay data path (bytes flow
-		// node ↔ provider-pod ↔ S3 over SSH; the pod is the S3 client). nfs and
-		// direct transfer remain unimplemented, so they are not advertised.
-		ExportBackends(migration.PVCAndS3ExportBackends()...).
-		ImportBackends(migration.PVCAndS3ImportBackends()...).
+		// ADR-0006: only the S3 relay data path is real for Proxmox — bytes flow
+		// node ↔ provider-pod ↔ S3 over SSH (the pod is the S3 client). The legacy
+		// pvc path (storage_helper.go) does os.Open on node-local image paths,
+		// which a remote provider pod can never reach, so pvc is NOT advertised
+		// (advertising it lets a migration select a backend that always fails).
+		// nfs and direct transfer remain unimplemented, so they are not advertised.
+		ExportBackends(migration.S3OnlyExportBackends()...).
+		ImportBackends(migration.S3OnlyImportBackends()...).
 		TransferModes(migration.RelayOnlyTransferModes()...).
 		DiskTypes("raw", "qcow2").
 		NetworkTypes("bridge", "vlan").

--- a/internal/providers/proxmox/provider_test.go
+++ b/internal/providers/proxmox/provider_test.go
@@ -216,6 +216,43 @@ func TestProxmoxProvider_Delete(t *testing.T) {
 	assert.False(t, describeResp.Exists)
 }
 
+// TestProxmoxProvider_DeleteRunningVMStopsFirst proves the #261 P0-1 fix: a
+// running VM is stopped before it is destroyed. The fake PVE server rejects a
+// destroy of a running VM (status 500 "is running - destroy failed", mirroring
+// real PVE), so a Delete that did not stop first would fail and orphan the VM.
+func TestProxmoxProvider_DeleteRunningVMStopsFirst(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	createResp, err := provider.Create(ctx, &providerv1.CreateRequest{
+		Name:      "del-running",
+		ClassJson: `{"cpus": 1, "memory": "1Gi"}`,
+	})
+	require.NoError(t, err)
+	if createResp.Task != nil {
+		require.NoError(t, waitForTask(ctx, provider, createResp.Task.Id))
+	}
+
+	// Power it on so the hypervisor reports it running.
+	_, err = provider.Power(ctx, &providerv1.PowerRequest{Id: createResp.Id, Op: providerv1.PowerOp_POWER_OP_ON})
+	require.NoError(t, err)
+	desc, err := provider.Describe(ctx, &providerv1.DescribeRequest{Id: createResp.Id})
+	require.NoError(t, err)
+	require.Equal(t, "On", desc.PowerState, "VM should be running before the delete")
+
+	// Delete must stop the VM first, then destroy it — without the stop the fake
+	// returns 500 and this errors.
+	_, err = provider.Delete(ctx, &providerv1.DeleteRequest{Id: createResp.Id})
+	require.NoError(t, err, "Delete must stop a running VM before destroying it")
+
+	// VM is gone.
+	desc, err = provider.Describe(ctx, &providerv1.DescribeRequest{Id: createResp.Id})
+	require.NoError(t, err)
+	assert.False(t, desc.Exists, "VM must be destroyed after Delete")
+}
+
 func TestProxmoxProvider_GetCapabilities(t *testing.T) {
 	// Start fake PVE server
 	_, endpoint, err := pvefake.StartFakeServer()
@@ -243,14 +280,15 @@ func TestProxmoxProvider_GetCapabilities(t *testing.T) {
 	// `-c` for qcow2 targets (#219), so compression is advertised.
 	assert.True(t, resp.SupportsExportCompression, "Proxmox ExportDisk compresses qcow2 targets when Compress=true (#219)")
 
-	// ADR-0006: Proxmox advertises BOTH the legacy pvc path and the S3 relay
-	// data path on export and import; nfs/direct remain unimplemented.
-	assert.Equal(t, []string{"pvc", "s3"}, resp.SupportedExportBackends,
-		"Proxmox advertises pvc + s3 export backends (ADR-0006)")
-	assert.Equal(t, []string{"pvc", "s3"}, resp.SupportedImportBackends,
-		"Proxmox advertises pvc + s3 import backends (ADR-0006)")
+	// ADR-0006: Proxmox advertises ONLY the S3 relay data path. The legacy pvc
+	// path does os.Open on node-local image paths the provider pod can't reach,
+	// so advertising pvc would be dishonest (#261 P0-3). nfs/direct unimplemented.
+	assert.Equal(t, []string{"s3"}, resp.SupportedExportBackends,
+		"Proxmox advertises s3-only export backend (pvc is not reachable off-node)")
+	assert.Equal(t, []string{"s3"}, resp.SupportedImportBackends,
+		"Proxmox advertises s3-only import backend (pvc is not reachable off-node)")
 	assert.Equal(t, []string{"relay"}, resp.SupportedTransferModes,
-		"both pvc and s3 paths are relay-shaped (bytes flow node ↔ pod ↔ backend)")
+		"the s3 path is relay-shaped (bytes flow node ↔ pod ↔ backend)")
 }
 
 func TestExportNeedsConversion(t *testing.T) {

--- a/internal/providers/proxmox/pveapi/client.go
+++ b/internal/providers/proxmox/pveapi/client.go
@@ -276,7 +276,15 @@ func (c *Client) request(ctx context.Context, method, path string, body interfac
 		}
 	}
 
-	reqURL := c.baseURL.ResolveReference(&url.URL{Path: path})
+	// Split an optional query string off the path: a url.URL with the query in
+	// its Path field would percent-encode the "?" (e.g. DELETE …/qemu/123?purge=1
+	// becomes …/qemu/123%3Fpurge=1), so set RawQuery explicitly.
+	ref := &url.URL{Path: path}
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		ref.Path = path[:i]
+		ref.RawQuery = path[i+1:]
+	}
+	reqURL := c.baseURL.ResolveReference(ref)
 	req, err := http.NewRequestWithContext(ctx, method, reqURL.String(), reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -448,9 +456,16 @@ func (c *Client) CloneVM(ctx context.Context, node string, vmid int, config *VMC
 	return "", fmt.Errorf("unexpected response format")
 }
 
-// DeleteVM deletes a VM
-func (c *Client) DeleteVM(ctx context.Context, node string, vmid int) (string, error) {
+// DeleteVM deletes a VM. When purge is true the destroy also removes the VM's
+// disk volumes and drops it from any backup/replication jobs
+// (purge=1&destroy-unreferenced-disks=1); a bare DELETE leaves the disks behind.
+// The VM must already be stopped — PVE returns 500 "VM is running - destroy
+// failed" otherwise (callers stop it first).
+func (c *Client) DeleteVM(ctx context.Context, node string, vmid int, purge bool) (string, error) {
 	path := fmt.Sprintf("/api2/json/nodes/%s/qemu/%d", node, vmid)
+	if purge {
+		path += "?purge=1&destroy-unreferenced-disks=1"
+	}
 
 	resp, err := c.request(ctx, "DELETE", path, nil)
 	if err != nil {

--- a/internal/providers/proxmox/pvefake/server.go
+++ b/internal/providers/proxmox/pvefake/server.go
@@ -386,8 +386,17 @@ func (s *Server) handleDeleteVM(w http.ResponseWriter, r *http.Request) {
 	defer s.mu.Unlock()
 
 	// Check if VM exists
-	if _, exists := s.vms[vmid]; !exists {
+	vm, exists := s.vms[vmid]
+	if !exists {
 		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	// PVE refuses to destroy a running VM — callers must stop it first. Mirroring
+	// that here makes the fake exercise the provider's stop-before-destroy path
+	// (#261 P0-1); a bare destroy of a running VM would orphan it.
+	if vm.Status == "running" {
+		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("VM %d is running - destroy failed", vmid))
 		return
 	}
 

--- a/internal/providers/proxmox/s3import.go
+++ b/internal/providers/proxmox/s3import.go
@@ -285,7 +285,9 @@ func (p *Provider) createFromImportedDisk(
 		if attachOK {
 			return
 		}
-		delTask, derr := p.client.DeleteVM(context.Background(), node, vmConfig.VMID)
+		// purge=true so the rollback also reclaims any disk already imported into
+		// the half-built shell (the shell is never started, so no stop is needed).
+		delTask, derr := p.client.DeleteVM(context.Background(), node, vmConfig.VMID, true)
 		if derr != nil {
 			p.logger.Warn("Failed to delete half-built VM shell after imported-disk failure (manual cleanup may be needed)",
 				"vmid", vmConfig.VMID, "error", derr)

--- a/internal/providers/proxmox/server.go
+++ b/internal/providers/proxmox/server.go
@@ -369,17 +369,43 @@ func (p *Provider) Delete(ctx context.Context, req *providerv1.DeleteRequest) (*
 		return nil, errors.NewInvalidSpec("invalid VM reference: %v", err)
 	}
 
-	taskID, err := p.client.DeleteVM(ctx, node, vmid)
+	// Proxmox refuses to destroy a running VM ("VM <id> is running - destroy
+	// failed"), so stop it first and wait for the stop to complete — mirroring
+	// vSphere (power-off → Destroy) and libvirt (destroyDomain → undefine). If PVE
+	// no longer knows the VM, GetVM/DeleteVM treat it as already deleted, so a
+	// missing VM is not an error.
+	vm, err := p.client.GetVM(ctx, node, vmid)
+	if err == nil && vm != nil {
+		switch vm.Status {
+		case "running", "paused", "suspended":
+			stopTask, stopErr := p.client.PowerOperation(ctx, node, vmid, "stop")
+			if stopErr != nil {
+				return nil, errors.NewInternal("failed to stop VM before delete", stopErr)
+			}
+			if stopTask != "" {
+				if werr := p.client.WaitForTask(ctx, node, stopTask); werr != nil {
+					return nil, errors.NewInternal("failed waiting for VM to stop before delete", werr)
+				}
+			}
+		}
+	}
+
+	// Destroy with purge=1 so the config, disk volumes, and any backup/replication
+	// references are reclaimed (a bare DELETE leaves disks behind). Wait for the
+	// destroy task so a successful Delete RPC means the VM is actually gone — the
+	// controller removes the finalizer on success, so returning success while the
+	// VM still exists would orphan it.
+	taskID, err := p.client.DeleteVM(ctx, node, vmid, true)
 	if err != nil {
 		return nil, errors.NewInternal("failed to delete VM", err)
 	}
-
-	result := &providerv1.TaskResponse{}
 	if taskID != "" {
-		result.Task = &providerv1.TaskRef{Id: taskID}
+		if werr := p.client.WaitForTask(ctx, node, taskID); werr != nil {
+			return nil, errors.NewInternal("failed waiting for VM destroy task", werr)
+		}
 	}
 
-	return result, nil
+	return &providerv1.TaskResponse{}, nil
 }
 
 // Power performs power operations on a virtual machine

--- a/internal/storage/migration/backend.go
+++ b/internal/storage/migration/backend.go
@@ -77,6 +77,17 @@ func PVCAndS3ExportBackends() []string { return []string{BackendPVC, BackendS3} 
 // libvirt provider as the TARGET in ADR-0006 Slice 1 (vSphere → S3 → libvirt).
 func PVCAndS3ImportBackends() []string { return []string{BackendPVC, BackendS3} }
 
+// S3OnlyExportBackends is the honest export-backend set for a provider whose
+// only working transfer is S3. The Proxmox provider uses this: its disks live on
+// the PVE node and the provider pod is the S3 client (bytes flow node ↔ pod ↔ S3
+// over SSH). The legacy pvc path does os.Open on node-local image paths, which a
+// remote pod can never reach, so advertising pvc would be dishonest.
+func S3OnlyExportBackends() []string { return []string{BackendS3} }
+
+// S3OnlyImportBackends is the honest import-backend set for an S3-only provider
+// (the Proxmox TARGET). See S3OnlyExportBackends for why pvc is excluded.
+func S3OnlyImportBackends() []string { return []string{BackendS3} }
+
 // RelayOnlyTransferModes is the honest transfer-mode set for a provider that
 // only implements the pod-side (relay) path. Both the legacy pvc path and the
 // ADR-0006 Slice 1 S3 path are relay-shaped (bytes flow host → provider-pod →


### PR DESCRIPTION
## Summary

P0 slice of the Proxmox feature-parity epic (#261), fixing the incident where `kubectl delete virtualmachine` removed the Kubernetes resources but left the VMs **running and orphaned on Proxmox**.

Root cause was two independent bugs (one Proxmox-specific, one cross-cutting):

- **P0-1 — Proxmox `Delete` can't destroy a running VM.** It issued a bare `DELETE …/qemu/{vmid}` with no stop-first and no `purge`. Proxmox rejects that with `500 "VM <id> is running - destroy failed"`. It now stops a running VM first, then destroys with `purge=1&destroy-unreferenced-disks=1`, waiting for both tasks so a successful `Delete` means the VM is actually gone — mirroring vSphere (power-off → Destroy) and libvirt (destroy → undefine). Also fixes the pveapi request builder, which percent-encoded a `?` query string into the path.
- **P0-2 — the controller dropped the finalizer even when `Delete` failed** (`// Continue with cleanup even if deletion fails`), orphaning the hypervisor VM on **any** provider. `handleDeletion` now retains the finalizer and requeues on a real failure, treats a provider `NotFound` as already-deleted (idempotent), and honors a `virtrigaud.io/force-delete: "true"` escape hatch for a permanently-unreachable provider.
- **P0-3 — honesty:** drop the `pvc` disk-migration backend advertisement from Proxmox (the pvc path `os.Open`s node-local image paths the provider pod can't reach); only `s3` is real.

## Tests

- `internal/providers/proxmox/provider_test.go`: the fake PVE server now **rejects destroying a running VM** (mirrors real PVE), and a new test proves `Delete` stops the VM first; capability test asserts s3-only backends.
- `internal/controller/virtualmachine_controller_delete_test.go`: a failed `Delete` retains the finalizer + requeues; `NotFound` proceeds; the force-delete annotation removes the finalizer despite a failure.
- `make fmt`/`lint`/`build` clean; affected packages green.

## Validation

Unit-tested (the fake PVE reproduces the exact running-VM-destroy rejection that caused the incident). Live lab validation of a real running-Proxmox-VM delete is a follow-up (dev manager + provider images).

Part of #261. Next slices: P1 (Create/Reconfigure CPU/mem; relay-mode enforcement), then P1 features and P2 polish.
