### PR TITLE
fix(proxmox): honor VMClass CPU/memory; enforce relay-only transfer (#261 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-19 08:05] - fix(proxmox): honor VMClass CPU/memory; enforce relay-only transfer (#261 P1)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/proxmox/server.go` (P1-1): `Create` and `Reconfigure` now read the VMClass CPU/memory from the correct keys. `ClassJson` is a marshaled `contracts.VMClass` (no JSON tags), so the keys are `CPU`/`MemoryMiB` — the old code read `cpus`/`memory` (and, in `Reconfigure`, the outer key `class` instead of `Class`), which never matched, so cores/memory stayed unset and **every Proxmox VM came up at the PVE default of 1 core / 512 MB regardless of its VMClass**. The fix is applied on both create paths: the diskless create (via `configToValues`) and the template clone (a PVE clone inherits the template's hardware, so `cores`/`memory` are now also set in the post-clone reconfigure). Mirrors the vSphere/libvirt parse of the same contract.
+- `internal/providers/proxmox/server.go` (P1-3): `ExportDisk`/`ImportDisk` now call `migration.EnsureRelayMode(req.TransferMode)`, so a `direct` transfer request fails with `InvalidArgument` instead of silently running as `relay` — Proxmox advertises relay-only (ADR-0006 D2). Matches libvirt's enforcement.
+
+### Why
+The first P0 fix (#262) addressed the delete-orphan incident; this P1 slice fixes the next-worst Proxmox parity gap surfaced by the audit (#261): silently undersized VMs (confirmed on real hardware — migrated VMs showed `cores=None, memory=None` in PVE) and a silently-downgraded transfer mode.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (proxmox provider image)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-19 07:20] - fix(proxmox): delete no longer orphans VMs; finalizer retained on delete failure (#261 P0)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/proxmox/parity_p1_test.go
+++ b/internal/providers/proxmox/parity_p1_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/proxmox/pvefake"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// vmConfigSize reads back the cores/memory(MiB) a VM actually has on the fake PVE.
+func vmConfigSize(t *testing.T, p *Provider, id string) (cores int, memMiB int) {
+	t.Helper()
+	vmid, node, err := p.parseVMReference(id)
+	require.NoError(t, err)
+	cfg, err := p.client.GetVMConfig(context.Background(), node, vmid)
+	require.NoError(t, err)
+	if c, ok := cfg["cores"].(float64); ok {
+		cores = int(c)
+	}
+	if m, ok := cfg["memory"].(float64); ok {
+		memMiB = int(m)
+	}
+	return cores, memMiB
+}
+
+// TestProxmoxProvider_CreateHonorsVMClassSizing is the #261 P1-1 fix: Create
+// parses the VMClass CPU/MemoryMiB (the marshaled contracts.VMClass keys) rather
+// than the non-existent "cpus"/"memory" keys, so the VM is sized to the class
+// instead of falling back to the PVE default of 1 core / 512 MB.
+func TestProxmoxProvider_CreateHonorsVMClassSizing(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	createResp, err := provider.Create(ctx, &providerv1.CreateRequest{
+		Name:      "sized-create",
+		ClassJson: `{"CPU": 4, "MemoryMiB": 8192}`,
+	})
+	require.NoError(t, err)
+	if createResp.Task != nil {
+		require.NoError(t, waitForTask(ctx, provider, createResp.Task.Id))
+	}
+
+	cores, memMiB := vmConfigSize(t, provider, createResp.Id)
+	assert.Equal(t, 4, cores, "Create must apply VMClass CPU")
+	assert.Equal(t, 8192, memMiB, "Create must apply VMClass MemoryMiB")
+}
+
+// TestProxmoxProvider_CloneHonorsVMClassSizing covers the template-clone path
+// (distinct from the diskless create): a PVE clone inherits the template's
+// cores/memory, so the provider must reconfigure the clone to the VMClass size —
+// and that must happen for a plain VM, not only when cloud-init is present. The
+// fake's seeded template (vmid 100) is 2 CPU / 2048 MiB; the class asks for 4 /
+// 8192, so inheriting the template would leave 2 / 2048.
+func TestProxmoxProvider_CloneHonorsVMClassSizing(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	createResp, err := provider.Create(ctx, &providerv1.CreateRequest{
+		Name:      "sized-clone",
+		ClassJson: `{"CPU": 4, "MemoryMiB": 8192}`,
+		ImageJson: `{"TemplateName": "100"}`, // clone the seeded VM (2 CPU / 2048 MiB)
+	})
+	require.NoError(t, err)
+	if createResp.Task != nil {
+		require.NoError(t, waitForTask(ctx, provider, createResp.Task.Id))
+	}
+
+	cores, memMiB := vmConfigSize(t, provider, createResp.Id)
+	assert.Equal(t, 4, cores, "clone must apply the VMClass CPU, not inherit the template's")
+	assert.Equal(t, 8192, memMiB, "clone must apply the VMClass MemoryMiB, not inherit the template's")
+}
+
+// TestProxmoxProvider_ReconfigureHonorsVMClassSizing verifies the Reconfigure
+// half of P1-1: the nested class is under "Class" with "CPU"/"MemoryMiB".
+func TestProxmoxProvider_ReconfigureHonorsVMClassSizing(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	createResp, err := provider.Create(ctx, &providerv1.CreateRequest{
+		Name:      "sized-reconfig",
+		ClassJson: `{"CPU": 1, "MemoryMiB": 1024}`,
+	})
+	require.NoError(t, err)
+	if createResp.Task != nil {
+		require.NoError(t, waitForTask(ctx, provider, createResp.Task.Id))
+	}
+
+	// DesiredJson is a marshaled contracts.CreateRequest → {"Class":{"CPU":..,"MemoryMiB":..}}.
+	_, err = provider.Reconfigure(ctx, &providerv1.ReconfigureRequest{
+		Id:          createResp.Id,
+		DesiredJson: `{"Name":"sized-reconfig","Class":{"CPU":4,"MemoryMiB":8192}}`,
+	})
+	require.NoError(t, err)
+
+	cores, memMiB := vmConfigSize(t, provider, createResp.Id)
+	assert.Equal(t, 4, cores, "Reconfigure must apply the new CPU")
+	assert.Equal(t, 8192, memMiB, "Reconfigure must apply the new MemoryMiB")
+}
+
+// TestExportDisk_DirectModeRejected verifies #261 P1-3: Proxmox advertises
+// relay-only transfer, so a `direct` request must fail loudly instead of silently
+// running as relay.
+func TestExportDisk_DirectModeRejected(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+
+	_, err = provider.ExportDisk(context.Background(), &providerv1.ExportDiskRequest{
+		VmId:         "100",
+		BackendType:  "s3",
+		TransferMode: "direct",
+	})
+	assert.Equal(t, codes.InvalidArgument, s3GRPCCode(t, err),
+		"ExportDisk must reject the unimplemented direct transfer mode")
+}
+
+// TestImportDisk_DirectModeRejected mirrors the export rejection for import.
+func TestImportDisk_DirectModeRejected(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+
+	_, err = provider.ImportDisk(context.Background(), &providerv1.ImportDiskRequest{
+		BackendType:  "s3",
+		TransferMode: "direct",
+	})
+	assert.Equal(t, codes.InvalidArgument, s3GRPCCode(t, err),
+		"ImportDisk must reject the unimplemented direct transfer mode")
+}

--- a/internal/providers/proxmox/server.go
+++ b/internal/providers/proxmox/server.go
@@ -263,6 +263,36 @@ func (p *Provider) Create(ctx context.Context, req *providerv1.CreateRequest) (*
 			}
 		}
 
+		// Apply the VMClass sizing on top of the cloned template. A PVE clone
+		// inherits the template's cores/memory, so they MUST be set explicitly or
+		// the VM comes up at the template's size, not the class's (#261 P1-1). This
+		// runs for EVERY clone, independent of cloud-init — the cloud-init
+		// reconfigure below is gated and would otherwise skip a plain VM. (The
+		// diskless create path applies sizing via configToValues at create time.)
+		sizeValues := url.Values{}
+		if vmConfig.CPUs > 0 {
+			// VMClass CPU is the total vCPU count, but PVE computes vCPUs as
+			// sockets × cores. A template may carry sockets>1, which would multiply
+			// the requested count, so pin sockets=1 (the diskless create path
+			// already yields a single socket) and put the whole count in cores.
+			sizeValues.Set("cores", strconv.Itoa(vmConfig.CPUs))
+			sizeValues.Set("sockets", "1")
+		}
+		if vmConfig.Memory > 0 {
+			sizeValues.Set("memory", strconv.FormatInt(vmConfig.Memory, 10))
+		}
+		if len(sizeValues) > 0 {
+			sizeTask, serr := p.client.ReconfigureVMRaw(ctx, node, vmConfig.VMID, sizeValues)
+			if serr != nil {
+				return nil, errors.NewInternal("failed to apply VMClass sizing to cloned VM", serr)
+			}
+			if sizeTask != "" {
+				if werr := p.client.WaitForTask(ctx, node, sizeTask); werr != nil {
+					return nil, errors.NewInternal("VMClass sizing reconfigure task failed", werr)
+				}
+			}
+		}
+
 		// After cloning, we need to reconfigure the VM with cloud-init settings
 		if len(req.UserData) > 0 || vmConfig.SSHKeys != "" {
 			p.logger.Info("Reconfiguring cloned VM with cloud-init", "vmid", vmConfig.VMID)
@@ -275,7 +305,8 @@ func (p *Provider) Create(ctx context.Context, req *providerv1.CreateRequest) (*
 			}
 			p.logger.Info("Detected primary boot disk", "vmid", vmConfig.VMID, "disk", primaryDisk)
 
-			// Build reconfiguration values for cloud-init
+			// Build reconfiguration values for cloud-init. Sizing (cores/memory) is
+			// already applied above for every clone, so it is not repeated here.
 			reconfigValues := url.Values{}
 			if vmConfig.IDE2 != "" {
 				reconfigValues.Set("ide2", vmConfig.IDE2)
@@ -472,9 +503,12 @@ func (p *Provider) Reconfigure(ctx context.Context, req *providerv1.ReconfigureR
 	// Extract reconfiguration parameters
 	config := &pveapi.ReconfigureConfig{}
 
-	// Handle CPU changes
-	if classData, ok := desired["class"].(map[string]interface{}); ok {
-		if cpus, ok := classData["cpus"].(float64); ok {
+	// Handle CPU/memory changes. DesiredJson is a marshaled contracts.CreateRequest,
+	// so the nested VMClass is under the (tag-less) key "Class" with fields "CPU"
+	// and "MemoryMiB" — NOT "class"/"cpus"/"memory" (reading those silently
+	// dropped every reconfigure of CPU/memory; #261 P1-1).
+	if classData, ok := desired["Class"].(map[string]interface{}); ok {
+		if cpus, ok := classData["CPU"].(float64); ok && cpus > 0 {
 			cpuCount := int(cpus)
 			config.CPUs = &cpuCount
 
@@ -491,20 +525,19 @@ func (p *Provider) Reconfigure(ctx context.Context, req *providerv1.ReconfigureR
 			}
 		}
 
-		// Handle memory changes
-		if memory, ok := classData["memory"].(string); ok {
-			if memBytes, err := parseMemory(memory); err == nil {
-				memMB := memBytes / (1024 * 1024)
-				config.Memory = &memMB
+		// Handle memory changes. MemoryMiB is already in MiB, which is what PVE's
+		// `memory` config field expects.
+		if mem, ok := classData["MemoryMiB"].(float64); ok && mem > 0 {
+			memMB := int64(mem)
+			config.Memory = &memMB
 
-				// Check if VM is running - memory changes may require power cycle for some guest OSes
-				vm, err := p.client.GetVM(ctx, node, vmid)
-				if err == nil && vm.Status == "running" {
-					// PVE supports online memory changes with balloon driver
-					if currentMem, exists := currentConfig["memory"]; exists {
-						if currentMemMB, ok := currentMem.(float64); ok && int64(currentMemMB) != memMB {
-							p.logger.Info("Memory change will be applied online (requires balloon driver)", "vmid", vmid, "old", int64(currentMemMB), "new", memMB)
-						}
+			// Check if VM is running - memory changes may require power cycle for some guest OSes
+			vm, err := p.client.GetVM(ctx, node, vmid)
+			if err == nil && vm.Status == "running" {
+				// PVE supports online memory changes with balloon driver
+				if currentMem, exists := currentConfig["memory"]; exists {
+					if currentMemMB, ok := currentMem.(float64); ok && int64(currentMemMB) != memMB {
+						p.logger.Info("Memory change will be applied online (requires balloon driver)", "vmid", vmid, "old", int64(currentMemMB), "new", memMB)
 					}
 				}
 			}
@@ -864,17 +897,23 @@ func (p *Provider) parseCreateRequest(req *providerv1.CreateRequest) (*pveapi.VM
 		Name: req.Name,
 	}
 
-	// Parse VMClass for CPU/memory
+	// Parse VMClass for CPU/memory. ClassJson is a marshaled contracts.VMClass,
+	// whose Go fields have NO json tags, so the keys are "CPU" and "MemoryMiB"
+	// (NOT "cpus"/"memory" — reading those left every Proxmox VM at the PVE
+	// default of 1 core / 512 MB regardless of the VMClass; #261 P1-1). This
+	// mirrors the vSphere/libvirt parse of the same contract. MemoryMiB is already
+	// in MiB, which is exactly what the PVE `memory` config field expects.
 	if req.ClassJson != "" {
-		var class map[string]interface{}
+		var class struct {
+			CPU       int32 `json:"CPU"`
+			MemoryMiB int32 `json:"MemoryMiB"`
+		}
 		if err := json.Unmarshal([]byte(req.ClassJson), &class); err == nil {
-			if cpus, ok := class["cpus"].(float64); ok {
-				config.CPUs = int(cpus)
+			if class.CPU > 0 {
+				config.CPUs = int(class.CPU)
 			}
-			if memory, ok := class["memory"].(string); ok {
-				if memBytes, err := parseMemory(memory); err == nil {
-					config.Memory = memBytes / (1024 * 1024) // Convert to MB
-				}
+			if class.MemoryMiB > 0 {
+				config.Memory = int64(class.MemoryMiB)
 			}
 		}
 	}
@@ -1340,6 +1379,12 @@ func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskReq
 	if err := migration.EnsurePVCOrS3Backend(req.BackendType); err != nil {
 		return nil, err
 	}
+	// Proxmox advertises relay-only transfer (RelayOnlyTransferModes); reject a
+	// `direct` request loudly instead of silently running it as relay (#261 P1-3,
+	// ADR-0006 D2). Mirrors the libvirt provider.
+	if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
+		return nil, err
+	}
 
 	// ADR-0006 Proxmox SOURCE path: stream the node disk to S3 over SSH.
 	if req.BackendType == migration.BackendS3 {
@@ -1549,6 +1594,12 @@ func (p *Provider) ImportDisk(ctx context.Context, req *providerv1.ImportDiskReq
 	// ADR-0006: accept the legacy pvc path and the S3 relay path; reject nfs and
 	// unknown backends honestly instead of silently falling through to pvc.
 	if err := migration.EnsurePVCOrS3Backend(req.BackendType); err != nil {
+		return nil, err
+	}
+	// Proxmox advertises relay-only transfer (RelayOnlyTransferModes); reject a
+	// `direct` request loudly instead of silently running it as relay (#261 P1-3,
+	// ADR-0006 D2). Mirrors the libvirt provider.
+	if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

P1 (correctness) slice of the Proxmox feature-parity epic (#261), following the merged P0 delete fix (#262).

- **P1-1 — Proxmox VMs ignored their VMClass CPU/memory.** `Create` and `Reconfigure` read the sizing from the wrong JSON keys: `ClassJson` is a marshaled `contracts.VMClass` (no json tags), so the keys are `CPU`/`MemoryMiB`, but the code read `cpus`/`memory` (and, in `Reconfigure`, the outer key `class` instead of `Class`). Nothing matched, so cores/memory stayed unset and **every Proxmox VM came up at the PVE default of 1 core / 512 MB regardless of its VMClass**. Fixed on both create paths — the diskless create (via `configToValues`) and the template clone (a PVE clone inherits the template's hardware, so the sizing is now applied in a dedicated post-clone reconfigure). Mirrors the vSphere/libvirt parse of the same contract.
- **P1-3 — `direct` transfer mode was silently downgraded to relay.** `ExportDisk`/`ImportDisk` now call `migration.EnsureRelayMode(req.TransferMode)`, so a `direct` request fails with `InvalidArgument` (Proxmox advertises relay-only; ADR-0006 D2). Matches libvirt.

## Tests
`internal/providers/proxmox/parity_p1_test.go`: Create / clone / Reconfigure all apply the VMClass sizing; `direct` mode is rejected on export and import. `make fmt`/`lint`/`build` clean.

## Lab validation (real hardware, `pve.lab.k8`)
Created a VM from the `adopted-2cpu-4096mb` class and confirmed the PVE config is `cores=2 sockets=1 → 2 vCPU total, memory=4096 MiB` (pre-fix it was `cores=1 sockets=2 memory=2048`).

Two issues that **only the live run surfaced** (the unit test on the fake passed before these) are fixed and now covered:
1. The post-clone reconfigure was gated behind `if cloud-init present`, so a plain VM skipped sizing entirely — moved sizing to a dedicated always-run reconfigure (+ added a clone-path unit test).
2. A clone inherits the template's `sockets`, so `cores=2` × `sockets=2` gave 4 vCPUs — pinned `sockets=1` to match the diskless path (VMClass CPU = total vCPUs).

Part of #261. Next: PR-3 (Clone overrides; Power timeout; node discovery), then PR-4 (P2 polish).
