### PR TITLE
fix(proxmox): Clone overrides, graceful-shutdown timeout, node discovery (#261 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-19 08:45] - fix(proxmox): Clone overrides, graceful-shutdown timeout, node discovery (#261 P1)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/proxmox/server.go` (P1-2): `Clone` now applies the requested VMClass sizing and placement instead of dropping them. A PVE clone inherits the source's cores/memory, so the `ClassJson` override is applied in a post-clone reconfigure (shared `applyVMClassSizing` helper, also used by the template-create path), and `PlacementJson` is honored — the target node (`Host`) is threaded into the clone and the post-clone sizing, and the target storage (`Datastore`) into the clone.
+- `internal/providers/proxmox/server.go` + `pveapi/client.go` (P1-4): a `SHUTDOWN_GRACEFUL` power op now forwards `graceful_timeout_seconds` to the PVE shutdown endpoint and sets `forceStop=1` so it escalates to a hard stop when the deadline elapses, instead of ignoring the timeout. (New `PowerOperationWithParams`; the pveapi request builder already form-encodes params.)
+- `internal/providers/proxmox/pveapi/client.go` + `server.go` (P1-4): node discovery. `FindNode` and `ListVMs` no longer assume a node literally named `pve` — when no `NodeSelector` is configured they discover the cluster's nodes via `GET /nodes` (new cached `ListNodes`). A wrong node name otherwise 500s every API call on a cluster whose node isn't named `pve`.
+
+### Why
+Continues the Proxmox parity epic (#261) after the P0 delete fix (#262) and the P1 sizing fix (#263): closes the remaining P1 feature gaps where Clone silently ignored overrides, graceful shutdown ignored the caller's timeout, and node addressing was hardcoded.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (proxmox provider image)
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-19 08:05] - fix(proxmox): honor VMClass CPU/memory; enforce relay-only transfer (#261 P1)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/proxmox/parity_p1b_test.go
+++ b/internal/providers/proxmox/parity_p1b_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/proxmox/pvefake"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestProxmoxProvider_CloneAppliesVMClassSizing is the #261 P1-2 fix: the Clone
+// RPC applies the VMClass CPU/memory override on top of the source instead of
+// silently inheriting it. The seeded source (vmid 100) is 2 CPU / 2048 MiB.
+func TestProxmoxProvider_CloneAppliesVMClassSizing(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	cloneResp, err := provider.Clone(ctx, &providerv1.CloneRequest{
+		SourceVmId: "100",
+		TargetName: "clone-sized",
+		ClassJson:  `{"CPU": 4, "MemoryMiB": 8192}`,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, cloneResp.TargetVmId)
+
+	cores, memMiB := vmConfigSize(t, provider, cloneResp.TargetVmId)
+	assert.Equal(t, 4, cores, "Clone must apply the VMClass CPU override")
+	assert.Equal(t, 8192, memMiB, "Clone must apply the VMClass MemoryMiB override")
+}
+
+// TestProxmoxProvider_PowerGracefulForwardsTimeout verifies the #261 P1-4 fix: a
+// graceful shutdown forwards the caller's timeout and asks PVE to escalate to a
+// hard stop (forceStop=1) when it elapses.
+func TestProxmoxProvider_PowerGracefulForwardsTimeout(t *testing.T) {
+	srv, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+
+	_, err = provider.Power(context.Background(), &providerv1.PowerRequest{
+		Id:                     "100",
+		Op:                     providerv1.PowerOp_POWER_OP_SHUTDOWN_GRACEFUL,
+		GracefulTimeoutSeconds: 30,
+	})
+	require.NoError(t, err)
+
+	last := srv.LastPowerOp()
+	require.NotNil(t, last)
+	assert.Equal(t, "shutdown", last.Operation)
+	assert.Equal(t, "30", last.Timeout, "graceful shutdown must forward the timeout")
+	assert.Equal(t, "1", last.ForceStop, "graceful shutdown must escalate to a hard stop")
+}
+
+// TestProxmoxProvider_PowerGracefulNoTimeout verifies that without a timeout the
+// shutdown is issued with no timeout/forceStop params (PVE's default behavior).
+func TestProxmoxProvider_PowerGracefulNoTimeout(t *testing.T) {
+	srv, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+
+	_, err = provider.Power(context.Background(), &providerv1.PowerRequest{
+		Id: "100",
+		Op: providerv1.PowerOp_POWER_OP_SHUTDOWN_GRACEFUL,
+	})
+	require.NoError(t, err)
+
+	last := srv.LastPowerOp()
+	require.NotNil(t, last)
+	assert.Equal(t, "shutdown", last.Operation)
+	assert.Empty(t, last.Timeout, "no timeout requested ⇒ none forwarded")
+	assert.Empty(t, last.ForceStop)
+}
+
+// TestProxmoxProvider_NodeDiscovery is the #261 P1-4 fix: with no NodeSelector
+// configured the client discovers nodes from the cluster API instead of assuming
+// "pve". The fake reports two nodes (incl. "pve2"), which the legacy hardcode
+// could never produce.
+func TestProxmoxProvider_NodeDiscovery(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint) // no NodeSelector configured
+	ctx := context.Background()
+
+	nodes, err := provider.client.ListNodes(ctx)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"pve", "pve2"}, nodes, "must discover the cluster's nodes via /nodes")
+
+	node, err := provider.client.FindNode(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "pve", node, "FindNode returns the first discovered node, not a hardcoded default")
+}

--- a/internal/providers/proxmox/pveapi/client.go
+++ b/internal/providers/proxmox/pveapi/client.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -56,6 +57,12 @@ type Client struct {
 	config     *Config
 	httpClient *http.Client
 	baseURL    *url.URL
+
+	// cachedNodes memoizes the cluster's node names (discovered via /nodes) for
+	// the client's lifetime; the node set rarely changes and a provider restart
+	// re-discovers it.
+	nodesMu     sync.Mutex
+	cachedNodes []string
 }
 
 // NewClient creates a new PVE API client
@@ -497,9 +504,19 @@ func (c *Client) DeleteVM(ctx context.Context, node string, vmid int, purge bool
 
 // PowerOperation performs a power operation on a VM
 func (c *Client) PowerOperation(ctx context.Context, node string, vmid int, operation string) (string, error) {
+	return c.PowerOperationWithParams(ctx, node, vmid, operation, nil)
+}
+
+// PowerOperationWithParams performs a power operation, passing extra POST
+// parameters to PVE (e.g. timeout/forceStop for a graceful shutdown).
+func (c *Client) PowerOperationWithParams(ctx context.Context, node string, vmid int, operation string, params url.Values) (string, error) {
 	path := fmt.Sprintf("/api2/json/nodes/%s/qemu/%d/status/%s", node, vmid, operation)
 
-	resp, err := c.request(ctx, "POST", path, nil)
+	var body interface{}
+	if len(params) > 0 {
+		body = params
+	}
+	resp, err := c.request(ctx, "POST", path, body)
 	if err != nil {
 		return "", fmt.Errorf("failed to perform power operation: %w", err)
 	}
@@ -728,14 +745,61 @@ func (c *Client) buildIPConfigString(ipConfig IPConfig) string {
 
 // FindNode selects an appropriate node for VM placement
 func (c *Client) FindNode(ctx context.Context) (string, error) {
-	// If node selector is configured, use the first available
+	// If a node selector is configured, use the first entry.
 	if len(c.config.NodeSelector) > 0 {
-		// TODO: Check node availability
 		return c.config.NodeSelector[0], nil
 	}
 
-	// TODO: Implement node discovery and selection logic
-	return "pve", nil // Default node name
+	// Otherwise discover the node from the cluster instead of assuming "pve" — a
+	// PVE node can be named anything, and a wrong node name makes every
+	// /nodes/<node>/... call 500 (#261 P1-4).
+	nodes, err := c.ListNodes(ctx)
+	if err != nil {
+		return "", fmt.Errorf("no NodeSelector configured and node discovery failed: %w", err)
+	}
+	return nodes[0], nil
+}
+
+// ListNodes returns the names of the nodes in the PVE cluster (GET /nodes). The
+// result is cached for the client's lifetime since the node set rarely changes.
+func (c *Client) ListNodes(ctx context.Context) ([]string, error) {
+	c.nodesMu.Lock()
+	defer c.nodesMu.Unlock()
+	if len(c.cachedNodes) > 0 {
+		return c.cachedNodes, nil
+	}
+
+	resp, err := c.request(ctx, "GET", "/api2/json/nodes", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // defer close is not critical
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list nodes failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var out struct {
+		Data []struct {
+			Node string `json:"node"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("failed to decode nodes response: %w", err)
+	}
+
+	nodes := make([]string, 0, len(out.Data))
+	for _, n := range out.Data {
+		if n.Node != "" {
+			nodes = append(nodes, n.Node)
+		}
+	}
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("PVE returned no nodes")
+	}
+	c.cachedNodes = nodes
+	return nodes, nil
 }
 
 // ReconfigureConfig represents VM reconfiguration parameters

--- a/internal/providers/proxmox/pvefake/server.go
+++ b/internal/providers/proxmox/pvefake/server.go
@@ -39,6 +39,7 @@ type Server struct {
 	tasks        map[string]*Task
 	snapshots    map[string][]*Snapshot
 	lastDownload *DownloadRequest
+	lastPowerOp  *PowerOpRequest
 	mu           sync.RWMutex
 	logger       *slog.Logger
 	config       *Config
@@ -61,6 +62,22 @@ func (s *Server) LastDownloadRequest() *DownloadRequest {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.lastDownload
+}
+
+// PowerOpRequest records the most recent power operation and its parameters so
+// tests can assert e.g. graceful-shutdown timeout/forceStop propagation.
+type PowerOpRequest struct {
+	Operation string
+	Timeout   string
+	ForceStop string
+}
+
+// LastPowerOp returns the most recent power operation seen by the fake server,
+// or nil if none has occurred. Safe for concurrent use.
+func (s *Server) LastPowerOp() *PowerOpRequest {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lastPowerOp
 }
 
 // Config holds fake server configuration
@@ -171,6 +188,9 @@ func NewServer() *Server {
 func (s *Server) setupRoutes() {
 	api := s.router.PathPrefix("/api2/json").Subrouter()
 
+	// Cluster nodes (discovery)
+	api.HandleFunc("/nodes", s.handleListNodes).Methods("GET")
+
 	// VM operations
 	api.HandleFunc("/nodes/{node}/qemu", s.handleCreateVM).Methods("POST")
 	api.HandleFunc("/nodes/{node}/qemu", s.handleListVMs).Methods("GET")
@@ -185,6 +205,7 @@ func (s *Server) setupRoutes() {
 	api.HandleFunc("/nodes/{node}/qemu/{vmid}/status/start", s.handlePowerOp("start")).Methods("POST")
 	api.HandleFunc("/nodes/{node}/qemu/{vmid}/status/stop", s.handlePowerOp("stop")).Methods("POST")
 	api.HandleFunc("/nodes/{node}/qemu/{vmid}/status/reboot", s.handlePowerOp("reboot")).Methods("POST")
+	api.HandleFunc("/nodes/{node}/qemu/{vmid}/status/shutdown", s.handlePowerOp("shutdown")).Methods("POST")
 
 	// Storage operations
 	api.HandleFunc("/nodes/{node}/storage/{storage}/download-url", s.handleDownloadURL).Methods("POST")
@@ -326,6 +347,16 @@ func (s *Server) handleCreateVM(w http.ResponseWriter, r *http.Request) {
 // handleListVMs handles listing VMs on a node (GET /nodes/{node}/qemu). It
 // returns all seeded/created VMs, including templates, so ImagePrepare's
 // verify-by-name and idempotency probes can find them.
+// handleListNodes returns the cluster's nodes. It reports two nodes (one not
+// named "pve") so a test can prove the provider discovers the node from the API
+// rather than assuming the legacy "pve" default.
+func (s *Server) handleListNodes(w http.ResponseWriter, _ *http.Request) {
+	s.writeResponse(w, []map[string]interface{}{
+		{"node": "pve", "status": "online"},
+		{"node": "pve2", "status": "online"},
+	})
+}
+
 func (s *Server) handleListVMs(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	node := vars["node"]
@@ -507,6 +538,14 @@ func (s *Server) handlePowerOp(operation string) http.HandlerFunc {
 
 		s.mu.Lock()
 		defer s.mu.Unlock()
+
+		// Record the operation + params so tests can assert e.g. graceful-shutdown
+		// timeout/forceStop propagation.
+		s.lastPowerOp = &PowerOpRequest{
+			Operation: operation,
+			Timeout:   r.FormValue("timeout"),
+			ForceStop: r.FormValue("forceStop"),
+		}
 
 		vm, exists := s.vms[vmid]
 		if !exists {

--- a/internal/providers/proxmox/server.go
+++ b/internal/providers/proxmox/server.go
@@ -269,28 +269,8 @@ func (p *Provider) Create(ctx context.Context, req *providerv1.CreateRequest) (*
 		// runs for EVERY clone, independent of cloud-init — the cloud-init
 		// reconfigure below is gated and would otherwise skip a plain VM. (The
 		// diskless create path applies sizing via configToValues at create time.)
-		sizeValues := url.Values{}
-		if vmConfig.CPUs > 0 {
-			// VMClass CPU is the total vCPU count, but PVE computes vCPUs as
-			// sockets × cores. A template may carry sockets>1, which would multiply
-			// the requested count, so pin sockets=1 (the diskless create path
-			// already yields a single socket) and put the whole count in cores.
-			sizeValues.Set("cores", strconv.Itoa(vmConfig.CPUs))
-			sizeValues.Set("sockets", "1")
-		}
-		if vmConfig.Memory > 0 {
-			sizeValues.Set("memory", strconv.FormatInt(vmConfig.Memory, 10))
-		}
-		if len(sizeValues) > 0 {
-			sizeTask, serr := p.client.ReconfigureVMRaw(ctx, node, vmConfig.VMID, sizeValues)
-			if serr != nil {
-				return nil, errors.NewInternal("failed to apply VMClass sizing to cloned VM", serr)
-			}
-			if sizeTask != "" {
-				if werr := p.client.WaitForTask(ctx, node, sizeTask); werr != nil {
-					return nil, errors.NewInternal("VMClass sizing reconfigure task failed", werr)
-				}
-			}
+		if err := p.applyVMClassSizing(ctx, node, vmConfig.VMID, vmConfig.CPUs, vmConfig.Memory); err != nil {
+			return nil, errors.NewInternal("failed to apply VMClass sizing to cloned VM", err)
 		}
 
 		// After cloning, we need to reconfigure the VM with cloud-init settings
@@ -464,7 +444,18 @@ func (p *Provider) Power(ctx context.Context, req *providerv1.PowerRequest) (*pr
 		return nil, errors.NewInvalidSpec("unsupported power operation: %v", req.Op)
 	}
 
-	taskID, err := p.client.PowerOperation(ctx, node, vmid, operation)
+	var taskID string
+	if req.Op == providerv1.PowerOp_POWER_OP_SHUTDOWN_GRACEFUL && req.GracefulTimeoutSeconds > 0 {
+		// Honor the caller's graceful-shutdown deadline and escalate to a hard
+		// stop when it elapses (PVE `forceStop`), instead of ignoring the timeout
+		// and waiting on the guest indefinitely (#261 P1-4).
+		params := url.Values{}
+		params.Set("timeout", strconv.Itoa(int(req.GracefulTimeoutSeconds)))
+		params.Set("forceStop", "1")
+		taskID, err = p.client.PowerOperationWithParams(ctx, node, vmid, operation, params)
+	} else {
+		taskID, err = p.client.PowerOperation(ctx, node, vmid, operation)
+	}
 	if err != nil {
 		return nil, errors.NewInternal("failed to perform power operation", err)
 	}
@@ -837,6 +828,50 @@ func (p *Provider) SnapshotRevert(ctx context.Context, req *providerv1.SnapshotR
 }
 
 // Clone clones a virtual machine
+// parseClassSizing extracts the CPU count and memory (MiB) from a marshaled
+// contracts.VMClass (keys "CPU"/"MemoryMiB"; no json tags). Returns zeros when
+// the JSON is empty or unparseable.
+func parseClassSizing(classJSON string) (cpus int, memoryMiB int64) {
+	if classJSON == "" {
+		return 0, 0
+	}
+	var class struct {
+		CPU       int32 `json:"CPU"`
+		MemoryMiB int32 `json:"MemoryMiB"`
+	}
+	if err := json.Unmarshal([]byte(classJSON), &class); err != nil {
+		return 0, 0
+	}
+	return int(class.CPU), int64(class.MemoryMiB)
+}
+
+// applyVMClassSizing reconfigures a VM to the VMClass CPU/memory. It is used
+// after a clone (which inherits the source/template hardware): the VMClass CPU
+// is the total vCPU count, so sockets is pinned to 1 and cores carries the whole
+// count (PVE computes vCPUs as sockets × cores), and MemoryMiB maps straight to
+// the PVE `memory` field. A zero count or memory is left untouched.
+func (p *Provider) applyVMClassSizing(ctx context.Context, node string, vmid, cpus int, memoryMiB int64) error {
+	vals := url.Values{}
+	if cpus > 0 {
+		vals.Set("cores", strconv.Itoa(cpus))
+		vals.Set("sockets", "1")
+	}
+	if memoryMiB > 0 {
+		vals.Set("memory", strconv.FormatInt(memoryMiB, 10))
+	}
+	if len(vals) == 0 {
+		return nil
+	}
+	task, err := p.client.ReconfigureVMRaw(ctx, node, vmid, vals)
+	if err != nil {
+		return err
+	}
+	if task != "" {
+		return p.client.WaitForTask(ctx, node, task)
+	}
+	return nil
+}
+
 func (p *Provider) Clone(ctx context.Context, req *providerv1.CloneRequest) (*providerv1.CloneResponse, error) {
 	if p.client == nil {
 		return nil, errors.NewUnavailable("PVE client not configured", nil)
@@ -851,30 +886,57 @@ func (p *Provider) Clone(ctx context.Context, req *providerv1.CloneRequest) (*pr
 	targetVMID := int(time.Now().Unix()%999999) + 100000 // Ensure 6-digit VMID
 
 	config := &pveapi.VMConfig{
-		VMID: targetVMID,
-		Name: req.TargetName,
+		VMID:   targetVMID,
+		Name:   req.TargetName,
+		Custom: map[string]string{},
 	}
-
 	if req.Linked {
-		config.Custom = map[string]string{"full": "0"}
+		config.Custom["full"] = "0"
 	} else {
-		config.Custom = map[string]string{"full": "1"}
+		config.Custom["full"] = "1"
 	}
 
-	taskID, err := p.client.CloneVM(ctx, sourceNode, sourceVMID, config)
+	// Honor placement overrides (#261 P1-2): the target node and storage. The
+	// clone request is issued to the source node; PVE's `target` parameter places
+	// the result on another node, so the post-clone sizing must use that node.
+	targetNode := sourceNode
+	if req.PlacementJson != "" {
+		var placement struct {
+			Host      string `json:"Host"`
+			Datastore string `json:"Datastore"`
+		}
+		if err := json.Unmarshal([]byte(req.PlacementJson), &placement); err == nil {
+			if placement.Host != "" {
+				config.Custom["target"] = placement.Host
+				targetNode = placement.Host
+			}
+			if placement.Datastore != "" {
+				config.Storage = placement.Datastore
+			}
+		}
+	}
+
+	cloneTask, err := p.client.CloneVM(ctx, sourceNode, sourceVMID, config)
 	if err != nil {
 		return nil, errors.NewInternal("failed to clone VM", err)
 	}
+	if cloneTask != "" {
+		if werr := p.client.WaitForTask(ctx, sourceNode, cloneTask); werr != nil {
+			return nil, errors.NewInternal("clone task failed", werr)
+		}
+	}
 
-	result := &providerv1.CloneResponse{
+	// Apply the VMClass sizing override (#261 P1-2): a clone inherits the source's
+	// cores/memory, so the requested class size must be set explicitly or the
+	// override is silently ignored.
+	cpus, memMiB := parseClassSizing(req.ClassJson)
+	if err := p.applyVMClassSizing(ctx, targetNode, targetVMID, cpus, memMiB); err != nil {
+		return nil, errors.NewInternal("failed to apply VMClass sizing to cloned VM", err)
+	}
+
+	return &providerv1.CloneResponse{
 		TargetVmId: fmt.Sprintf("%d", targetVMID),
-	}
-
-	if taskID != "" {
-		result.Task = &providerv1.TaskRef{Id: taskID}
-	}
-
-	return result, nil
+	}, nil
 }
 
 // ImagePrepare is implemented in image.go (structured source parsing, target_name
@@ -1797,12 +1859,15 @@ func (p *Provider) ListVMs(ctx context.Context, req *providerv1.ListVMsRequest) 
 		return nil, fmt.Errorf("Proxmox client not configured")
 	}
 
-	// Get nodes from config (or discover)
+	// Use the configured node selector, or discover the cluster's nodes via the
+	// API when none is set (#261 P1-4) instead of failing.
 	nodes := p.client.Config().NodeSelector
 	if len(nodes) == 0 {
-		// Default to discovering nodes - for now, use a placeholder
-		// In a real implementation, you'd discover nodes via API
-		return nil, fmt.Errorf("node selector not configured")
+		discovered, err := p.client.ListNodes(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("no node selector configured and node discovery failed: %w", err)
+		}
+		nodes = discovered
 	}
 
 	var allVMs []*providerv1.VMInfo


### PR DESCRIPTION
## Summary

P1 (features) slice of the Proxmox feature-parity epic (#261), following the merged P0 delete fix (#262) and P1 sizing/relay fix (#263).

- **P1-2 — Clone ignored its overrides.** `Clone` consumed only source/target/linked and dropped `ClassJson`/`PlacementJson`. It now applies the **VMClass sizing** (a PVE clone inherits the source's cores/memory, so the class size is set in a post-clone reconfigure via a shared `applyVMClassSizing` helper — also used by the template-create path) and **placement** (`Host` → clone target node + post-clone sizing node; `Datastore` → clone storage).
- **P1-4 — graceful shutdown ignored the timeout, and node addressing was hardcoded.** A `SHUTDOWN_GRACEFUL` op now forwards `graceful_timeout_seconds` to PVE's shutdown endpoint and sets `forceStop=1` to escalate to a hard stop on timeout (new `PowerOperationWithParams`). And `FindNode`/`ListVMs` no longer assume a node named `pve` — with no `NodeSelector` they discover the cluster's nodes via `GET /nodes` (new cached `ListNodes`); a wrong node name otherwise 500s every API call on a cluster whose node isn't `pve`.

## Tests
`internal/providers/proxmox/parity_p1b_test.go`: Clone applies the VMClass sizing override; graceful shutdown forwards `timeout`+`forceStop` (and sends neither when no timeout is set); node discovery returns the cluster's nodes and `FindNode` uses the discovered node. Fake PVE gained a `/nodes` endpoint, power-param capture, and a `shutdown` route. `make fmt`/`lint`/`build` clean; full provider suite green.

## Lab validation (real hardware, `pve.lab.k8`)
Rolled the provider and confirmed the refactor + node-discovery path are regression-free: a VM from `adopted-2cpu-4096mb` still comes up `cores=2 sockets=1 → 2 vCPU, 4096 MiB`, and CR deletion still stops+purges it (PVE VM gone). Graceful-timeout forwarding and clone-override behavior are unit-tested (they're awkward to exercise as a live single-node scenario).

Part of #261. Next: PR-4 (P2 polish — `GetDiskInfo` real values, `/cluster/nextid` VMIDs, debug-log cleanup).
