### PR TITLE
docs(proxmox): align migration docs/examples with shipped parity; ExportCompression caveat (#261 P2-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-19 10:30] - docs(proxmox): align migration docs/examples with shipped parity; ExportCompression caveat (#261 P2-4)
+**Author:** @wrkode (William Rizzo)
+
+### Changed
+- `README.md`: rewrote the **VM Migration** section — the S3/relay path is the validated model across **all three providers in any direction** (vSphere ↔ libvirt ↔ Proxmox); the example now uses `storage.type: s3` and PVC is demoted to compat-only. The old text claimed "only vSphere → Libvirt tested" and "pvc only — s3/http/nfs not implemented", both false post-#236/#261.
+- `examples/migration/proxmox-to-libvirt.yaml`, `examples/migration/vsphere-to-proxmox.yaml`: rewrote from the stale, broken **PVC** shape to **S3/relay** (mirroring `vmmigration-proxmox-s3.yaml`). The Proxmox provider is S3-only, so the old `storage.type: pvc` examples failed capability validation against Proxmox.
+- `examples/migration/README.md`: marked both Proxmox directions **Tested (ADR-0006 Slice 3)** over S3; corrected the model description (all-direction S3, Proxmox S3-only); documented that the Proxmox Provider Secret needs both API-token and SSH creds.
+- `examples/vmmigration-basic.yaml`, `examples/vmmigration-advanced.yaml`: corrected headers — these are legacy PVC compat examples; S3 is the recommended/validated path; dropped the "only vSphere→libvirt tested / s3 not implemented" claims.
+
+### Added
+- `docs/adr/0006-storage-backend-agnostic-cross-hypervisor-migration.md`: a **parity-hardening (#261)** note in Slice 3 — relay-mode is now enforced at the RPC (`EnsureRelayMode`, `InvalidArgument` on `direct`), and **P2-4**: `ExportCompression` is qcow2-only (`compress: true` has no effect on raw/vmdk exports). The qcow2-only caveat is also surfaced in the rewritten example headers.
+
+### Why
+Closes the last open items on the Proxmox parity epic (#261): the P2-4 ExportCompression caveat was undocumented, and several in-repo migration docs/examples still described the pre-parity world (pvc-only, "untested" Proxmox), actively contradicting the shipped behavior.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [ ] Config change only
+- [x] Documentation only
+
 ## [2026-06-19 09:30] - fix(proxmox): collision-free VMIDs, real disk-info, drop key logging (#261 P2)
 **Author:** @wrkode (William Rizzo)
 

--- a/README.md
+++ b/README.md
@@ -283,11 +283,15 @@ Go 1.26+ is required for source builds.
 
 ## VM Migration
 
-VirtRigaud supports VM migration between providers using PVC-backed storage.
+VirtRigaud migrates VMs between providers by staging the disk through an
+S3-compatible object store (ADR-0006). The **provider pod is the S3 client**, so
+the bytes flow host → pod → S3 → pod → host and never traverse a CSI PVC; the
+source exports its native disk format and the target converts on import.
 
-**Currently tested**: vSphere → Libvirt/KVM only. Other directions (Libvirt → vSphere, any Proxmox path) are roadmap items and unverified.
-
-Migration requires a `ReadWriteMany` StorageClass (NFS, CephFS, or similar):
+**Validated**: all three providers in any direction — vSphere ↔ Libvirt/KVM ↔
+Proxmox VE (ADR-0006 Slices 1–3). The Proxmox provider participates as a full
+source and target and is **S3/relay-only** (it does not advertise PVC/NFS/`direct`
+backends).
 
 ```yaml
 apiVersion: infra.virtrigaud.io/v1beta1
@@ -304,12 +308,21 @@ spec:
     providerRef:
       name: target-provider
   storage:
-    type: pvc       # Only "pvc" is supported — s3/http/nfs are not implemented
-    pvc:
-      storageClassName: nfs-migration-storage
-      size: 100Gi
-      accessMode: ReadWriteMany
+    type: s3
+    transferMode: relay        # relay (implemented); auto → relay
+    s3:
+      bucket: virtrigaud
+      endpoint: http://minio.example:9000   # omit for AWS S3
+      region: us-east-1
+      usePathStyle: true                     # true for MinIO/Ceph/rustfs; false for AWS
+      credentialsSecretRef:
+        name: s3-migration-credentials       # keys: accessKeyID, secretAccessKey
 ```
+
+> A legacy `storage.type: pvc` model (ReadWriteMany StorageClass) remains for the
+> vSphere/libvirt directions but is compat-only — it does not work for Proxmox or
+> for host-resident libvirt disks. See [`examples/migration/`](examples/migration/)
+> for per-direction examples.
 
 For full migration documentation including provider restart behaviour, see the [Migration Guide](https://projectbeskar.github.io/virtrigaud/operations/vm-migration/).
 

--- a/docs/adr/0006-storage-backend-agnostic-cross-hypervisor-migration.md
+++ b/docs/adr/0006-storage-backend-agnostic-cross-hypervisor-migration.md
@@ -377,6 +377,27 @@ ported verbatim.
    `known_hosts` pinned to that IP, because in-cluster DNS does not resolve the
    PVE hostname.
 
+**Parity hardening (#261).** A follow-up audit — triggered by a delete-orphan
+incident — brought the Proxmox provider to capability parity with vSphere/libvirt
+(PRs #262/#263/#264/#265). Migration-relevant outcomes:
+
+- **Transfer mode is enforced at the RPC, not just advertised (D2).**
+  `ExportDisk`/`ImportDisk` call `migration.EnsureRelayMode(req.TransferMode)`, so
+  a `direct` request fails fast with `InvalidArgument` instead of silently
+  downgrading to `relay`. Proxmox advertises **S3/relay-only** backends and now
+  rejects anything else at the door (matching libvirt's enforcement).
+- **`ExportCompression` is qcow2-only.** `ExportDisk` honors `options.compress`
+  only when the export target format is qcow2 (`qemu-img convert -c`); raw and
+  vmdk outputs are written uncompressed even when `compress: true`. The capability
+  is advertised, but with this caveat — setting `compress: true` on a non-qcow2
+  export has no size effect.
+- **`GetDiskInfo` reports real metadata.** It reads the disk's true size/used/
+  format from the storage-content API (`/nodes/{node}/storage/{storage}/content`)
+  rather than guessing, improving migration sizing accuracy.
+- Out of band of migration, the same epic hardened Delete (stop-first + purge, no
+  orphaned VMs), VMClass sizing on Create/Reconfigure, and collision-free VMID
+  allocation via `/cluster/nextid`.
+
 ### Source quiescing and Creating-phase robustness (both directions)
 
 7. **`source.powerOffBeforeMigration` is now honored** (was a no-op). The

--- a/examples/migration/README.md
+++ b/examples/migration/README.md
@@ -8,11 +8,15 @@ VirtRigaud's validated cross-hypervisor migration is **storage-backend-agnostic*
 (ADR-0006): the disk is staged through an object store (S3-compatible) and the
 **provider pod is the S3 client**, so the bytes flow host → pod → S3 → pod → host
 and **never traverse a CSI PVC**. The source exports its native disk format and
-the target converts on import. This is the recommended path for the
-vSphere ↔ libvirt directions.
+the target converts on import. This is the validated path across **all three
+providers in any direction** — vSphere, libvirt, and Proxmox (ADR-0006 Slices
+1–3). The Proxmox provider is **S3/relay-only**: it does not advertise a PVC, NFS,
+or `direct` backend, so a `storage.type: pvc` migration with a Proxmox source or
+target fails capability validation.
 
-A PVC-backed model also exists and is the basis for the (untested) Proxmox
-roadmap examples below; it requires a ReadWriteMany StorageClass.
+A legacy PVC-backed model also exists for the vSphere/libvirt directions (a
+ReadWriteMany StorageClass), but it is compat-only and does not work for Proxmox
+or for host-resident libvirt disks the provider pod cannot reach.
 
 Key points before using these examples:
 
@@ -31,8 +35,8 @@ Key points before using these examples:
 |------|-----------|---------|--------|
 | [`../vmmigration-s3.yaml`](../vmmigration-s3.yaml) | vSphere → Libvirt/KVM | S3 | **Tested** (ADR-0006 Slice 1) |
 | [libvirt-to-vsphere.yaml](./libvirt-to-vsphere.yaml) | Libvirt/KVM → vSphere | S3 | **Tested** (ADR-0006 Slice 2) |
-| [vsphere-to-proxmox.yaml](./vsphere-to-proxmox.yaml) | vSphere → Proxmox VE | PVC | Untested (roadmap) |
-| [proxmox-to-libvirt.yaml](./proxmox-to-libvirt.yaml) | Proxmox VE → Libvirt/KVM | PVC | Untested (roadmap) |
+| [vsphere-to-proxmox.yaml](./vsphere-to-proxmox.yaml) | vSphere → Proxmox VE | S3 | **Tested** (ADR-0006 Slice 3) |
+| [proxmox-to-libvirt.yaml](./proxmox-to-libvirt.yaml) | Proxmox VE → Libvirt/KVM | S3 | **Tested** (ADR-0006 Slice 3) |
 
 ## Quick start (S3, vSphere ↔ libvirt)
 
@@ -72,8 +76,11 @@ Key points before using these examples:
    kubectl describe vmmigration your-migration-name
    ```
 
-For the PVC-backed roadmap examples (Proxmox), supply a ReadWriteMany
-StorageClass and use `storage.type: pvc` as shown in those files.
+The Proxmox directions (`vsphere-to-proxmox.yaml`, `proxmox-to-libvirt.yaml`) use
+the same S3/relay shape. Note that the Proxmox **Provider's** Secret must carry
+both an API token (`token_id`/`token_secret`) and SSH credentials (`ssh_user` +
+`ssh_password` and/or `ssh_privatekey`) plus a pinned `known_hosts`, because the
+Proxmox disk data plane runs `qemu-img`/`qm` on the PVE node over SSH.
 
 ## Reference
 

--- a/examples/migration/proxmox-to-libvirt.yaml
+++ b/examples/migration/proxmox-to-libvirt.yaml
@@ -1,16 +1,39 @@
-# Example: Migrate a VM from Proxmox VE to Libvirt/KVM
+# Example: Migrate a VM from Proxmox VE to Libvirt/KVM over S3 (ADR-0006 Slice 3).
 #
-# WARNING: This migration direction (Proxmox → Libvirt) is NOT currently tested.
-# Only vSphere → Libvirt/KVM is tested in v0.3.6. Use this example with caution.
+# Proxmox → Libvirt is validated end-to-end over the S3/relay path. The disk is
+# staged through an S3-compatible object store and the provider pod is the S3
+# client, so bytes flow PVE node → pod → S3 → pod → libvirt host and NEVER
+# traverse a CSI PVC. (PVC/NFS/`direct` backends are NOT advertised by the
+# Proxmox provider — it is S3/relay-only; applying a `storage.type: pvc`
+# migration against a Proxmox source fails capability validation.)
 #
-# This example previously showed HTTP storage, which is NOT supported.
-# storage.type is constrained to "pvc" only. Use a RWX StorageClass instead.
+# Data path: the Proxmox SOURCE runs `qemu-img convert -O qcow2` on the PVE node
+# over SSH and streams the result up to S3; the libvirt TARGET streams the object
+# down and imports it into its storage pool.
+#
+# The Proxmox provider is a HYBRID: an API-token control plane (REST) plus an SSH
+# data plane to the PVE node. The Proxmox Provider's Secret therefore carries BOTH
+# an API token (token_id/token_secret) AND SSH credentials (ssh_user + ssh_password
+# and/or ssh_privatekey) plus a pinned known_hosts. This VMMigration only
+# references the S3 credentials below.
 #
 # Prerequisites:
-# - Source VM "postgres-db" running on Proxmox
-# - Target Libvirt provider configured
-# - A ReadWriteMany StorageClass
-
+# - Source VM "postgres-db" managed by a Proxmox provider
+# - Target Libvirt/KVM provider configured
+# - An S3-compatible bucket reachable from both provider pods
+---
+# S3 credentials Secret (same namespace as the VMMigration). Required keys:
+# accessKeyID, secretAccessKey. Optional: sessionToken (STS / temporary creds).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-migration-credentials
+  namespace: databases
+type: Opaque
+stringData:
+  accessKeyID: "REPLACE_WITH_ACCESS_KEY_ID"
+  secretAccessKey: "REPLACE_WITH_SECRET_ACCESS_KEY"
+  # sessionToken: "REPLACE_WITH_SESSION_TOKEN"   # only for temporary/STS creds
 ---
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
@@ -25,38 +48,43 @@ spec:
   source:
     vmRef:
       name: postgres-db
-    createSnapshot: true
-    powerOffBeforeMigration: true   # Stop writes before migration
+    createSnapshot: false
+    powerOffBeforeMigration: true   # Stop writes for a consistent disk image
     deleteAfterMigration: false     # Keep source DB until validated
-
   target:
     name: postgres-db-kvm
-    namespace: databases
     providerRef:
       name: kvm-host1
       namespace: default
     classRef:
       name: database-8cpu-32gb
-
-  # PVC-backed storage — only supported storage type in v0.3.6.
+    powerOn: false
+  # S3-compatible object storage staging. Swap rustfs for AWS S3 / MinIO / Ceph
+  # RGW as needed; both provider pods must reach this endpoint.
   storage:
-    type: pvc
-    pvc:
-      storageClassName: nfs-migration-storage
-      size: 600Gi
-      accessMode: ReadWriteMany
-
+    type: s3
+    transferMode: relay             # relay (implemented) | auto→relay
+    s3:
+      bucket: virtrigaud
+      endpoint: http://rustfs.lab.k8:9000   # http:// ⇒ plaintext; omit for AWS
+      region: us-east-1
+      prefix: postgres-db/
+      usePathStyle: true            # true for rustfs/MinIO/Ceph RGW; false for AWS
+      credentialsSecretRef:
+        name: s3-migration-credentials
   options:
+    # The SOURCE exports its native format and the TARGET converts on import
+    # (ADR-0006 D4); diskFormat is advisory. NOTE: `compress` is honored only for
+    # qcow2 exports — raw/vmdk exports are not compressed even if set true.
     diskFormat: qcow2
     compress: false
-    verifyChecksums: true
+    verifyChecksums: true           # SHA256 of the transferred object (ADR-0006 D5)
     timeout: "6h"
     retryPolicy:
       maxRetries: 5
       retryDelay: "10m"
       backoffMultiplier: 2
     cleanupPolicy: OnSuccess
-
   metadata:
     purpose: "provider-change"
     environment: "prod"

--- a/examples/migration/vsphere-to-proxmox.yaml
+++ b/examples/migration/vsphere-to-proxmox.yaml
@@ -1,16 +1,39 @@
-# Example: Migrate a VM from VMware vSphere to Proxmox VE
+# Example: Migrate a VM from VMware vSphere to Proxmox VE over S3 (ADR-0006 Slice 3).
 #
-# WARNING: This migration direction (vSphere → Proxmox) is NOT currently tested.
-# Only vSphere → Libvirt/KVM is tested in v0.3.6. Use this example with caution.
+# vSphere → Proxmox is validated end-to-end over the S3/relay path. The disk is
+# staged through an S3-compatible object store and the provider pod is the S3
+# client, so bytes flow vCenter → pod → S3 → pod → PVE node and NEVER traverse a
+# CSI PVC. (The Proxmox provider is S3/relay-only — it does NOT advertise
+# PVC/NFS/`direct` backends; a `storage.type: pvc` migration with a Proxmox target
+# fails capability validation.)
 #
-# This example previously showed NFS URI storage, which is NOT supported.
-# storage.type is constrained to "pvc" only. Use an NFS-backed StorageClass instead.
+# Data path: the vSphere SOURCE exports its native vmdk and streams it up to S3;
+# the Proxmox TARGET streams the object down to the PVE node over SSH, runs
+# `qemu-img convert -O qcow2`, then `qm importdisk` into a freshly created shell VM.
+#
+# The Proxmox provider is a HYBRID: an API-token control plane (REST) plus an SSH
+# data plane to the PVE node. The Proxmox Provider's Secret carries BOTH an API
+# token (token_id/token_secret) AND SSH credentials (ssh_user + ssh_password
+# and/or ssh_privatekey) plus a pinned known_hosts. This VMMigration only
+# references the S3 credentials below.
 #
 # Prerequisites:
-# - Source VM "windows-server-2022" running on vSphere
-# - Target Proxmox provider configured
-# - A ReadWriteMany StorageClass (NFS, CephFS, etc.)
-
+# - Source VM "windows-server-2022" managed by a vSphere provider
+# - Target Proxmox provider configured (API token + SSH credentials)
+# - An S3-compatible bucket reachable from both provider pods
+---
+# S3 credentials Secret (same namespace as the VMMigration). Required keys:
+# accessKeyID, secretAccessKey. Optional: sessionToken (STS / temporary creds).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-migration-credentials
+  namespace: production
+type: Opaque
+stringData:
+  accessKeyID: "REPLACE_WITH_ACCESS_KEY_ID"
+  secretAccessKey: "REPLACE_WITH_SECRET_ACCESS_KEY"
+  # sessionToken: "REPLACE_WITH_SESSION_TOKEN"   # only for temporary/STS creds
 ---
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
@@ -28,39 +51,48 @@ spec:
   source:
     vmRef:
       name: windows-server-2022
-    createSnapshot: true
-    powerOffBeforeMigration: false
+    createSnapshot: false
+    # Power the source off before exporting. REQUIRED for a vSphere source: ESXi
+    # locks a running VM's disk, so the export clone fails with "...vmdk is locked".
+    powerOffBeforeMigration: true
     deleteAfterMigration: false     # Keep source until target is validated
-
   target:
     name: windows-server-2022-pve
-    namespace: production
     providerRef:
       name: proxmox-cluster
       namespace: default
     classRef:
       name: windows-4cpu-8gb
-
-  # PVC-backed storage — only supported storage type in v0.3.6.
-  # Using an NFS-backed StorageClass achieves the same result as a direct NFS mount.
+    powerOn: false
+    # A raw/qcow2 disk migration carries the disk, not the NIC — re-specify the
+    # target network so the migrated VM boots with an adapter (map to a PVE bridge).
+    networks:
+      - name: production-network
+  # S3-compatible object storage staging.
   storage:
-    type: pvc
-    pvc:
-      storageClassName: nfs-migration-storage
-      size: 100Gi
-      accessMode: ReadWriteMany
-
+    type: s3
+    transferMode: relay             # relay (implemented) | auto→relay
+    s3:
+      bucket: virtrigaud
+      endpoint: http://rustfs.lab.k8:9000   # http:// ⇒ plaintext; omit for AWS
+      region: us-east-1
+      prefix: windows-server-2022/
+      usePathStyle: true            # true for rustfs/MinIO/Ceph RGW; false for AWS
+      credentialsSecretRef:
+        name: s3-migration-credentials
   options:
+    # The SOURCE exports its native vmdk and the TARGET converts to qcow2 on import
+    # (ADR-0006 D4); diskFormat is advisory. NOTE: `compress` is honored only for
+    # qcow2 exports — raw/vmdk exports are not compressed even if set true.
     diskFormat: qcow2
     compress: false
-    verifyChecksums: true
+    verifyChecksums: true           # SHA256 of the transferred object (ADR-0006 D5)
     timeout: "4h"
     retryPolicy:
       maxRetries: 5
       retryDelay: "10m"
       backoffMultiplier: 2
     cleanupPolicy: OnSuccess
-
   metadata:
     purpose: "provider-change"
     environment: "prod"
@@ -70,4 +102,4 @@ spec:
 #   kubectl get vmmigration windows-vsphere-to-proxmox -w
 #
 # Validate target VM before removing source:
-#   Log into Proxmox web UI, start windows-server-2022-pve, verify Windows boots
+#   Log into the Proxmox web UI, start windows-server-2022-pve, verify Windows boots.

--- a/examples/vmmigration-advanced.yaml
+++ b/examples/vmmigration-advanced.yaml
@@ -1,9 +1,11 @@
 # Advanced VM Migration Example
 # Demonstrates available VMMigration configuration options for v0.3.6.
 #
-# IMPORTANT CONSTRAINTS:
-# - storage.type only accepts "pvc" (enum-constrained). s3/http/nfs are not implemented.
-# - Only vSphere → Libvirt/KVM migration is tested. Other paths are roadmap.
+# NOTES:
+# - This example uses the legacy PVC-backed storage path (compat-only). The
+#   recommended, validated path is S3/relay across all three providers in any
+#   direction — see vmmigration-s3.yaml and vmmigration-proxmox-s3.yaml. PVC does
+#   NOT work for Proxmox or for host-resident libvirt disks.
 # - Fields that don't exist on the CRD (options.type, options.storage.*,
 #   options.performance.*, source.providerRef) have been removed.
 

--- a/examples/vmmigration-basic.yaml
+++ b/examples/vmmigration-basic.yaml
@@ -1,8 +1,10 @@
 # Basic VM Migration Example
 # Migrates a VM from one provider to another with minimal configuration.
 #
-# storage.type is enum-constrained to "pvc" only (v0.3.6).
-# Only vSphere → Libvirt/KVM is currently tested.
+# NOTE: this example uses the legacy PVC-backed storage path (compat-only).
+# The recommended, validated path is S3/relay across all three providers in any
+# direction — see vmmigration-s3.yaml and vmmigration-proxmox-s3.yaml. PVC does
+# NOT work for Proxmox or for host-resident libvirt disks.
 
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration


### PR DESCRIPTION
## Summary

Closes the **Proxmox parity epic (#261)** — its last open items were the **P2-4** ExportCompression caveat (undocumented) and several in-repo migration docs/examples still describing the pre-parity world (pvc-only, "untested" Proxmox) that now actively contradict shipped behavior (#262/#263/#264/#265).

This is **docs/examples only** — no code change.

### Changed
- **`README.md`** VM Migration section: rewritten — S3/relay is the validated model across **all three providers in any direction**; example now uses `storage.type: s3`; PVC demoted to compat-only. (Old text claimed "only vSphere→Libvirt tested" and "pvc only — s3/http/nfs not implemented", both false.)
- **`examples/migration/proxmox-to-libvirt.yaml`** & **`vsphere-to-proxmox.yaml`**: rewritten from the broken **PVC** shape to **S3/relay** (mirroring `vmmigration-proxmox-s3.yaml`). The Proxmox provider advertises S3-only, so the old `storage.type: pvc` examples **fail capability validation** against Proxmox — applying them was broken.
- **`examples/migration/README.md`**: both Proxmox directions marked **Tested (ADR-0006 Slice 3)** over S3; model description corrected; Proxmox Provider Secret (API token + SSH) documented.
- **`examples/vmmigration-basic.yaml`** & **`-advanced.yaml`**: headers corrected — legacy PVC compat examples; S3 is the recommended/validated path.

### Added
- **`docs/adr/0006-…md`** Slice 3: a parity-hardening (#261) note — relay-mode is enforced at the RPC (`EnsureRelayMode` → `InvalidArgument` on `direct`), and **P2-4**: `ExportCompression` is **qcow2-only** (`compress: true` is a no-op for raw/vmdk exports). The caveat is also surfaced in the rewritten example headers.

## Validation
- All changed example YAMLs pass `kubectl apply --dry-run=client`; the two rewritten migration examples mirror the schema-valid, shipped `vmmigration-proxmox-s3.yaml` shape (`type: s3` / `transferMode: relay`).
- CHANGELOG entry added with attribution.

## Impact
- [ ] Breaking change
- [ ] Requires cluster rollout
- [x] Documentation only

Closes #261.

---
*Note: the bulk of provider/migration prose lives in the separate `virtrigaud-website` repo and also needs a parity refresh (Proxmox delete/sizing/nextid/node-discovery, the migration guide's PVC diagram, the providers-capabilities footnote). Tracked separately from this in-repo closeout.*