### PR TITLE
fix(vsphere): Reconfigure honors VMClass CPU/memory (wrong JSON keys) (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-19 11:30] - fix(vsphere): Reconfigure honors VMClass CPU/memory (wrong JSON keys) (#266)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/providers/vsphere/server.go`: `Reconfigure` parsed `req.DesiredJson` (a marshaled `contracts.CreateRequest`) with the wrong keys — `class`/`cpus`/`memory` and `disks`/`size`. `VMClass`/`DiskSpec` carry **no** json tags, so the real keys are `Class.CPU`, `Class.MemoryMiB`, and `Disks[].SizeGiB`. Every key missed, so a VMClass CPU/memory change **silently no-opped while the RPC returned success** — and because the controller then treats the empty response as "completed synchronously" and updates status, the VM **reported the new size while the hardware stayed at the old one**, and drift detection never re-fired. Now parses the correct typed keys (mirroring the Create path and the libvirt/Proxmox providers), so `SupportsReconfigureOnline: true` is honest. Surfaced by the #261 cross-provider parity audit — the same wrong-key class that #261 P1-1 fixed for Proxmox.
+- `internal/providers/proxmox/server.go`: fixed the identical wrong-key bug in the Proxmox `Reconfigure` **disk-resize** branch (`desired["disks"]["size"]` → `Disks[].SizeGiB`). CPU/memory were already fixed in #261 P1-1; the disk branch was latent dead code (the controller only triggers Reconfigure on CPU/mem drift today, but it would silently drop a disk resize once that is wired).
+- Removed the now-unused `parseMemory` helpers from both providers — their only callers were the wrong-key paths; CPU/memory/size now arrive as numbers in the typed contract.
+
+### Why
+The Proxmox parity epic (#261) surfaced, via the cross-provider lens, that vSphere `Reconfigure` had the same wrong-JSON-key bug Proxmox just fixed — and worse, it corrupts status (reports a size the hardware never got). P0: a silently-wrong VM size in a regulated posture.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (vSphere + Proxmox provider images)
+- [ ] Config change only
+
+Closes #266.
+
 ## [2026-06-19 10:30] - docs(proxmox): align migration docs/examples with shipped parity; ExportCompression caveat (#261 P2-4)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/proxmox/reconfigure_disk_test.go
+++ b/internal/providers/proxmox/reconfigure_disk_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/proxmox/pvefake"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestProxmoxProvider_ReconfigureResizesDisk covers the #266 disk-key fix: the
+// marshaled contracts.CreateRequest nests disks under "Disks" with a numeric
+// "SizeGiB", NOT "disks"/"size". The old wrong keys never matched, so the
+// disk-resize branch was unreachable dead code (the same class of bug as the
+// CPU/memory key bug). The fake seeds scsi0 at size=32G.
+func TestProxmoxProvider_ReconfigureResizesDisk(t *testing.T) {
+	_, endpoint, err := pvefake.StartFakeServer()
+	require.NoError(t, err)
+	provider := createTestProvider(endpoint)
+	ctx := context.Background()
+
+	createResp, err := provider.Create(ctx, &providerv1.CreateRequest{
+		Name:      "disk-resize",
+		ClassJson: `{"CPU": 1, "MemoryMiB": 1024}`,
+	})
+	require.NoError(t, err)
+	if createResp.Task != nil {
+		require.NoError(t, waitForTask(ctx, provider, createResp.Task.Id))
+	}
+
+	// Grow 32G → 64G: must reach the resize path and return a task. The wrong-key
+	// code returned no task at all (the branch was never entered).
+	resp, err := provider.Reconfigure(ctx, &providerv1.ReconfigureRequest{
+		Id:          createResp.Id,
+		DesiredJson: `{"Disks":[{"SizeGiB":64,"Type":"","Name":"root"}]}`,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Task, "a disk grow must trigger a resize task")
+
+	// Shrink 32G → 8G: the resize path is reached and the shrink guard rejects it.
+	// With the old wrong keys this would silently succeed (a no-op), masking the bug.
+	_, err = provider.Reconfigure(ctx, &providerv1.ReconfigureRequest{
+		Id:          createResp.Id,
+		DesiredJson: `{"Disks":[{"SizeGiB":8,"Type":"","Name":"root"}]}`,
+	})
+	assert.Error(t, err, "a disk shrink must be rejected, proving the resize branch is reached")
+}

--- a/internal/providers/proxmox/server.go
+++ b/internal/providers/proxmox/server.go
@@ -535,48 +535,49 @@ func (p *Provider) Reconfigure(ctx context.Context, req *providerv1.ReconfigureR
 		}
 	}
 
-	// Handle disk changes
-	if disksData, ok := desired["disks"].([]interface{}); ok {
+	// Handle disk changes. The marshaled contracts.CreateRequest nests disks under
+	// the tag-less key "Disks", each a DiskSpec with a numeric "SizeGiB" (GiB) and a
+	// "Name" — NOT "disks"/"size"/"name". Reading the wrong keys silently dropped
+	// every disk resize (same #261 wrong-key class as the CPU/memory fix above).
+	if disksData, ok := desired["Disks"].([]interface{}); ok {
 		for _, diskData := range disksData {
 			if disk, ok := diskData.(map[string]interface{}); ok {
-				if diskName, ok := disk["name"].(string); ok {
-					if sizeStr, ok := disk["size"].(string); ok {
-						if sizeBytes, err := parseMemory(sizeStr); err == nil {
-							sizeGB := sizeBytes / (1024 * 1024 * 1024)
+				if diskName, ok := disk["Name"].(string); ok {
+					if sizeVal, ok := disk["SizeGiB"].(float64); ok && sizeVal > 0 {
+						sizeGB := int64(sizeVal)
 
-							// Find corresponding disk in current config
-							diskKey := "scsi0" // Default to scsi0, could be smarter
-							if diskName == "root" {
-								diskKey = "scsi0"
-							}
+						// Find corresponding disk in current config
+						diskKey := "scsi0" // Default to scsi0, could be smarter
+						if diskName == "root" {
+							diskKey = "scsi0"
+						}
 
-							// Check current disk size to prevent shrinking
-							if currentDisk, exists := currentConfig[diskKey]; exists {
-								if currentDiskStr, ok := currentDisk.(string); ok {
-									// Parse current disk size from config string (e.g., "local:vm-100-disk-0,size=32G")
-									if strings.Contains(currentDiskStr, "size=") {
-										parts := strings.Split(currentDiskStr, ",")
-										for _, part := range parts {
-											if strings.HasPrefix(part, "size=") {
-												sizeStr := strings.TrimPrefix(part, "size=")
-												sizeStr = strings.TrimSuffix(sizeStr, "G")
-												if currentSize, err := strconv.ParseInt(sizeStr, 10, 64); err == nil {
-													if sizeGB < currentSize {
-														return nil, errors.NewInvalidSpec("disk shrinking not allowed: current=%dG, requested=%dG", currentSize, sizeGB)
+						// Check current disk size to prevent shrinking
+						if currentDisk, exists := currentConfig[diskKey]; exists {
+							if currentDiskStr, ok := currentDisk.(string); ok {
+								// Parse current disk size from config string (e.g., "local:vm-100-disk-0,size=32G")
+								if strings.Contains(currentDiskStr, "size=") {
+									parts := strings.Split(currentDiskStr, ",")
+									for _, part := range parts {
+										if strings.HasPrefix(part, "size=") {
+											sizeStr := strings.TrimPrefix(part, "size=")
+											sizeStr = strings.TrimSuffix(sizeStr, "G")
+											if currentSize, err := strconv.ParseInt(sizeStr, 10, 64); err == nil {
+												if sizeGB < currentSize {
+													return nil, errors.NewInvalidSpec("disk shrinking not allowed: current=%dG, requested=%dG", currentSize, sizeGB)
+												}
+												if sizeGB > currentSize {
+													// Use ResizeDisk for disk expansion
+													taskID, err := p.client.ResizeDisk(ctx, node, vmid, diskKey, sizeGB)
+													if err != nil {
+														return nil, errors.NewInternal("failed to resize disk", err)
 													}
-													if sizeGB > currentSize {
-														// Use ResizeDisk for disk expansion
-														taskID, err := p.client.ResizeDisk(ctx, node, vmid, diskKey, sizeGB)
-														if err != nil {
-															return nil, errors.NewInternal("failed to resize disk", err)
-														}
 
-														result := &providerv1.TaskResponse{}
-														if taskID != "" {
-															result.Task = &providerv1.TaskRef{Id: taskID}
-														}
-														return result, nil
+													result := &providerv1.TaskResponse{}
+													if taskID != "" {
+														result.Task = &providerv1.TaskRef{Id: taskID}
 													}
+													return result, nil
 												}
 											}
 										}
@@ -1248,34 +1249,6 @@ func (p *Provider) parseVMReference(ref string) (int, string, error) {
 	}
 
 	return 0, "", fmt.Errorf("invalid VM reference format: %s", ref)
-}
-
-// parseMemory converts memory string (e.g., "2Gi", "1024Mi") to bytes
-func parseMemory(memory string) (int64, error) {
-	memory = strings.TrimSpace(memory)
-	if strings.HasSuffix(memory, "Gi") {
-		val, err := strconv.ParseFloat(strings.TrimSuffix(memory, "Gi"), 64)
-		if err != nil {
-			return 0, err
-		}
-		return int64(val * 1024 * 1024 * 1024), nil
-	}
-	if strings.HasSuffix(memory, "Mi") {
-		val, err := strconv.ParseFloat(strings.TrimSuffix(memory, "Mi"), 64)
-		if err != nil {
-			return 0, err
-		}
-		return int64(val * 1024 * 1024), nil
-	}
-	if strings.HasSuffix(memory, "Ki") {
-		val, err := strconv.ParseFloat(strings.TrimSuffix(memory, "Ki"), 64)
-		if err != nil {
-			return 0, err
-		}
-		return int64(val * 1024), nil
-	}
-	// Assume bytes
-	return strconv.ParseInt(memory, 10, 64)
 }
 
 // buildNetworkString constructs network configuration string for Proxmox

--- a/internal/providers/vsphere/reconfigure_test.go
+++ b/internal/providers/vsphere/reconfigure_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/vim25/mo"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// TestReconfigure_AppliesVMClassCPUMemory is the #266 fix: Reconfigure parses the
+// marshaled contracts.CreateRequest keys (Class.CPU / Class.MemoryMiB), not the
+// non-existent lowercase cpus/memory. The old code read the wrong keys, so a
+// VMClass resize silently no-opped while the RPC reported success — leaving the
+// hardware unchanged. This drives a real ReconfigVM_Task against the govmomi
+// simulator and asserts the VM's NumCPU/MemoryMB actually change. Marshaling a
+// real contracts.CreateRequest (not a hand-built map) is essential: a map with
+// lowercase keys would mask the bug.
+func TestReconfigure_AppliesVMClassCPUMemory(t *testing.T) {
+	cfg, cleanup := newSimConfig(t)
+	defer cleanup()
+
+	client, finder, err := createVSphereClient(cfg)
+	require.NoError(t, err)
+	defer func() { _ = client.Logout(context.Background()) }()
+
+	p := &Provider{client: client, finder: finder, config: cfg, logger: slog.Default()}
+	ctx := context.Background()
+
+	dc, err := finder.DefaultDatacenter(ctx)
+	require.NoError(t, err)
+	finder.SetDatacenter(dc)
+
+	vms, err := finder.VirtualMachineList(ctx, "*")
+	require.NoError(t, err)
+	require.NotEmpty(t, vms, "simulator should seed at least one VM")
+	vm := vms[0]
+	moid := vm.Reference().Value
+
+	// Power off first so the reconfigure is unconditionally allowed (no hot-add
+	// assumptions) and the test is deterministic.
+	if task, perr := vm.PowerOff(ctx); perr == nil {
+		_, _ = task.WaitForResult(ctx, nil)
+	}
+
+	// Confirm the starting size differs from what we'll request, so a passing
+	// assertion can only mean the reconfigure took effect.
+	var before mo.VirtualMachine
+	require.NoError(t, vm.Properties(ctx, vm.Reference(),
+		[]string{"config.hardware.numCPU", "config.hardware.memoryMB"}, &before))
+	require.NotEqual(t, int32(4), before.Config.Hardware.NumCPU)
+	require.NotEqual(t, int32(8192), before.Config.Hardware.MemoryMB)
+
+	// DesiredJson is a marshaled contracts.CreateRequest — exactly what the manager
+	// sends. VMClass has no json tags, so the keys are Class.CPU / Class.MemoryMiB.
+	desired, err := json.Marshal(contracts.CreateRequest{
+		Class: contracts.VMClass{CPU: 4, MemoryMiB: 8192},
+	})
+	require.NoError(t, err)
+
+	_, err = p.Reconfigure(ctx, &providerv1.ReconfigureRequest{
+		Id:          moid,
+		DesiredJson: string(desired),
+	})
+	require.NoError(t, err)
+
+	var after mo.VirtualMachine
+	require.NoError(t, vm.Properties(ctx, vm.Reference(),
+		[]string{"config.hardware.numCPU", "config.hardware.memoryMB"}, &after))
+	assert.Equal(t, int32(4), after.Config.Hardware.NumCPU, "Reconfigure must apply VMClass CPU")
+	assert.Equal(t, int32(8192), after.Config.Hardware.MemoryMB, "Reconfigure must apply VMClass MemoryMiB")
+}

--- a/internal/providers/vsphere/server.go
+++ b/internal/providers/vsphere/server.go
@@ -863,10 +863,13 @@ func (p *Provider) fallbackToPowerOff(ctx context.Context, vm *object.VirtualMac
 // req.Id. The JSON payload is expected to contain a subset of the following top-level
 // keys:
 //
-//   - "class": object with "cpus" (number) and/or "memory" (string, e.g. "4Gi") fields
+//   - "Class": object with "CPU" (number) and/or "MemoryMiB" (number, MiB) fields
 //     for CPU and memory adjustments.
-//   - "disks": array where the first element may contain a "size" (string, e.g. "100Gi")
+//   - "Disks": array where the first element may carry a "SizeGiB" (number, GiB)
 //     field to expand the primary disk.
+//
+// These are the Go field names of the marshaled contracts.CreateRequest — VMClass
+// and DiskSpec carry NO json tags — NOT lowercase cpus/memory/size.
 //
 // Current values are retrieved from vCenter before building the change-spec so that
 // only actual differences trigger a ReconfigVM_Task. If no changes are detected the
@@ -907,8 +910,22 @@ func (p *Provider) Reconfigure(ctx context.Context, req *providerv1.ReconfigureR
 		return nil, fmt.Errorf("failed to get VM properties: %w", err)
 	}
 
-	// Parse the desired configuration from JSON
-	var desired map[string]interface{}
+	// Parse the desired configuration. DesiredJson is a marshaled
+	// contracts.CreateRequest; VMClass and DiskSpec carry NO json tags, so the keys
+	// are the Go field names — Class.CPU, Class.MemoryMiB (numeric MiB), and
+	// Disks[].SizeGiB (numeric GiB). Reading lowercase cpus/memory/size (the prior
+	// bug) never matched, so every CPU/memory change was silently dropped while the
+	// RPC reported success — the VM stayed at its creation-time size and status
+	// falsely reported the new size. Mirror the typed parse the Create path uses.
+	var desired struct {
+		Class struct {
+			CPU       int32 `json:"CPU"`
+			MemoryMiB int32 `json:"MemoryMiB"`
+		} `json:"Class"`
+		Disks []struct {
+			SizeGiB int32 `json:"SizeGiB"`
+		} `json:"Disks"`
+	}
 	if err := json.Unmarshal([]byte(req.DesiredJson), &desired); err != nil {
 		return nil, fmt.Errorf("failed to parse desired configuration: %w", err)
 	}
@@ -917,73 +934,51 @@ func (p *Provider) Reconfigure(ctx context.Context, req *providerv1.ReconfigureR
 	configSpec := &types.VirtualMachineConfigSpec{}
 	hasChanges := false
 
-	// Handle CPU changes
-	if classData, ok := desired["class"].(map[string]interface{}); ok {
-		if cpus, ok := classData["cpus"].(float64); ok {
-			newCPUs := int32(cpus)
-			if newCPUs != vmMo.Config.Hardware.NumCPU {
-				p.logger.Info("CPU change requested", "vm_id", req.Id, "old", vmMo.Config.Hardware.NumCPU, "new", newCPUs)
-				configSpec.NumCPUs = newCPUs
-				hasChanges = true
-			}
-		}
+	// CPU
+	if desired.Class.CPU > 0 && desired.Class.CPU != vmMo.Config.Hardware.NumCPU {
+		p.logger.Info("CPU change requested", "vm_id", req.Id, "old", vmMo.Config.Hardware.NumCPU, "new", desired.Class.CPU)
+		configSpec.NumCPUs = desired.Class.CPU
+		hasChanges = true
+	}
 
-		// Handle memory changes (memory is in MiB in the request)
-		if memory, ok := classData["memory"].(string); ok {
-			memMiB, err := p.parseMemory(memory)
-			if err == nil {
-				newMemoryMB := memMiB
-				currentMemoryMB := int64(vmMo.Config.Hardware.MemoryMB)
-				if newMemoryMB != currentMemoryMB {
-					p.logger.Info("Memory change requested", "vm_id", req.Id, "old_mb", currentMemoryMB, "new_mb", newMemoryMB)
-					configSpec.MemoryMB = newMemoryMB
-					hasChanges = true
-				}
-			} else {
-				p.logger.Warn("Failed to parse memory value", "memory", memory, "error", err)
-			}
+	// Memory (MemoryMiB is already MiB; vSphere MemoryMB is the same numeric value)
+	if desired.Class.MemoryMiB > 0 {
+		newMemoryMB := int64(desired.Class.MemoryMiB)
+		currentMemoryMB := int64(vmMo.Config.Hardware.MemoryMB)
+		if newMemoryMB != currentMemoryMB {
+			p.logger.Info("Memory change requested", "vm_id", req.Id, "old_mb", currentMemoryMB, "new_mb", newMemoryMB)
+			configSpec.MemoryMB = newMemoryMB
+			hasChanges = true
 		}
 	}
 
-	// Handle disk changes
-	if disksData, ok := desired["disks"].([]interface{}); ok && len(disksData) > 0 {
-		// Get the first disk (primary disk) for resizing
-		if diskData, ok := disksData[0].(map[string]interface{}); ok {
-			if sizeStr, ok := diskData["size"].(string); ok {
-				sizeGiB, err := p.parseMemory(sizeStr)
-				if err == nil {
-					// Convert MiB to GiB (if parseMemory returns MiB)
-					sizeGB := sizeGiB / 1024
-					if sizeGB > 0 {
-						// Find the primary disk
-						var primaryDisk *types.VirtualDisk
-						for _, device := range vmMo.Config.Hardware.Device {
-							if disk, ok := device.(*types.VirtualDisk); ok {
-								primaryDisk = disk
-								break
-							}
-						}
+	// Disk resize (grow-only): the primary disk's SizeGiB from the desired spec.
+	if len(desired.Disks) > 0 && desired.Disks[0].SizeGiB > 0 {
+		sizeGB := int64(desired.Disks[0].SizeGiB)
+		// Find the primary disk
+		var primaryDisk *types.VirtualDisk
+		for _, device := range vmMo.Config.Hardware.Device {
+			if disk, ok := device.(*types.VirtualDisk); ok {
+				primaryDisk = disk
+				break
+			}
+		}
+		if primaryDisk != nil {
+			currentSizeGB := primaryDisk.CapacityInKB / (1024 * 1024)
+			if sizeGB > currentSizeGB {
+				p.logger.Info("Disk resize requested", "vm_id", req.Id, "old_gb", currentSizeGB, "new_gb", sizeGB)
 
-						if primaryDisk != nil {
-							currentSizeGB := primaryDisk.CapacityInKB / (1024 * 1024)
-							if sizeGB > currentSizeGB {
-								p.logger.Info("Disk resize requested", "vm_id", req.Id, "old_gb", currentSizeGB, "new_gb", sizeGB)
+				// Create a new disk with updated size
+				newDisk := *primaryDisk
+				newDisk.CapacityInKB = sizeGB * 1024 * 1024 // Convert GiB to KB
 
-								// Create a new disk with updated size
-								newDisk := *primaryDisk
-								newDisk.CapacityInKB = sizeGB * 1024 * 1024 // Convert GB to KB
-
-								deviceSpec := &types.VirtualDeviceConfigSpec{
-									Operation: types.VirtualDeviceConfigSpecOperationEdit,
-									Device:    &newDisk,
-								}
-
-								configSpec.DeviceChange = append(configSpec.DeviceChange, deviceSpec)
-								hasChanges = true
-							}
-						}
-					}
+				deviceSpec := &types.VirtualDeviceConfigSpec{
+					Operation: types.VirtualDeviceConfigSpecOperationEdit,
+					Device:    &newDisk,
 				}
+
+				configSpec.DeviceChange = append(configSpec.DeviceChange, deviceSpec)
+				hasChanges = true
 			}
 		}
 	}
@@ -1011,50 +1006,6 @@ func (p *Provider) Reconfigure(ctx context.Context, req *providerv1.ReconfigureR
 
 	// Return empty task response since we completed synchronously
 	return &providerv1.TaskResponse{}, nil
-}
-
-// parseMemory converts a Kubernetes-style quantity string to mebibytes (MiB).
-// Supported suffixes and their conversions:
-//
-//   - "Gi" — gibibytes, multiplied by 1024 to yield MiB.
-//   - "Mi" — mebibytes, returned as-is.
-//   - "Ki" — kibibytes, divided by 1024 to yield MiB (fractional KiB is truncated).
-//   - no suffix — assumed to already be MiB; parsed as a decimal integer.
-//
-// An error is returned for unrecognised suffixes or non-numeric values.
-func (p *Provider) parseMemory(memStr string) (int64, error) {
-	memStr = strings.TrimSpace(memStr)
-
-	if strings.HasSuffix(memStr, "Gi") {
-		val, err := strconv.ParseFloat(strings.TrimSuffix(memStr, "Gi"), 64)
-		if err != nil {
-			return 0, err
-		}
-		return int64(val * 1024), nil // Convert GiB to MiB
-	}
-
-	if strings.HasSuffix(memStr, "Mi") {
-		val, err := strconv.ParseInt(strings.TrimSuffix(memStr, "Mi"), 10, 64)
-		if err != nil {
-			return 0, err
-		}
-		return val, nil
-	}
-
-	if strings.HasSuffix(memStr, "Ki") {
-		val, err := strconv.ParseFloat(strings.TrimSuffix(memStr, "Ki"), 64)
-		if err != nil {
-			return 0, err
-		}
-		return int64(val / 1024), nil // Convert KiB to MiB
-	}
-
-	// Try parsing as raw number (assume MiB)
-	val, err := strconv.ParseInt(memStr, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid memory format: %s", memStr)
-	}
-	return val, nil
 }
 
 // HardwareUpgrade implements the ProviderServer interface. It upgrades the virtual


### PR DESCRIPTION
## Summary

Fixes **#266** — a P0 surfaced by the Proxmox parity audit (#261). vSphere `Reconfigure` parsed `req.DesiredJson` (a marshaled `contracts.CreateRequest`) with the **wrong JSON keys**: `class`/`cpus`/`memory` and `disks`/`size`. But `VMClass`/`DiskSpec` carry **no json tags**, so the real keys are `Class.CPU`, `Class.MemoryMiB`, and `Disks[].SizeGiB`.

Every key missed → a VMClass CPU/memory change **silently no-opped while the RPC returned success**. Worse, the controller then treats the empty (taskless) response as "completed synchronously" and updates status — so the VM **reports the new size while the hardware stays at the old one**, and drift detection never re-fires. It advertised `SupportsReconfigureOnline: true`, so this was a dishonest capability. This is the **same wrong-key class** that #261 P1-1 fixed for Proxmox (the Proxmox fix comment even claimed to "mirror the vSphere parse" — which was never actually correct).

### Fixed
- **`internal/providers/vsphere/server.go`** — `Reconfigure` now parses the correct typed keys (`Class.CPU`, `Class.MemoryMiB` numeric MiB, `Disks[].SizeGiB`), mirroring the Create path and the libvirt/Proxmox providers. Corrected the misleading doc comment.
- **`internal/providers/proxmox/server.go`** — fixed the **identical** wrong-key bug in Proxmox's `Reconfigure` *disk-resize* branch (`desired["disks"]["size"]` → `Disks[].SizeGiB`). CPU/memory were already fixed in #261 P1-1; the disk branch was latent dead code (the controller only triggers Reconfigure on CPU/mem drift today, but it would silently drop a disk resize once that's wired).
- Removed the now-dead `parseMemory` helpers from both providers (their only callers were the wrong-key paths).

### Tests
- `internal/providers/vsphere/reconfigure_test.go` — drives a real `ReconfigVM_Task` against the **govmomi simulator**: marshals a real `contracts.CreateRequest{Class:{CPU:4, MemoryMiB:8192}}`, calls `Reconfigure`, and asserts the VM's `NumCPU`/`MemoryMB` actually change from the seeded `1`/`32`. A map-with-lowercase-keys test would have masked the bug — this uses the real contract type. **Would fail on the old code** (no change applied).
- `internal/providers/proxmox/reconfigure_disk_test.go` — a 32G→64G grow now reaches the resize path and returns a task; a 32G→8G shrink is rejected by the shrink guard. Both prove the keys are read (the old wrong keys silently skipped the branch).
- `make fmt` clean · `golangci-lint` 0 issues (removed the dead helpers it flagged) · full vSphere + Proxmox suites green · `make build` green.

## Validation note
The fix is validated by the **govmomi-simulator test**, which exercises the real `ReconfigVM_Task` code path end-to-end (in-memory vCenter). A live-vCenter check was intentionally not run: it would mean mutating CPU/memory on a shared lab VM, disproportionate when the simulator drives the identical govmomi path.

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (vSphere + Proxmox provider images)
- [ ] Config change only

Closes #266.

> Note: if #267 (the docs closeout) merges first, this PR's top CHANGELOG entry may need a trivial rebase (both add at the top) — keep both entries.