### PR TITLE
fix(security): migration storage host allowlist closes live S3-endpoint SSRF (ADR-0006 C3, #236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-19 12:30] - fix(security): migration storage host allowlist closes live S3-endpoint SSRF; gates NFS (ADR-0006 C3, #236)
+**Author:** @wrkode (William Rizzo)
+
+### Security
+- `internal/storage/migration/addrpolicy.go` (new) + `internal/controller/vmmigration_controller.go`: a `VMMigration`'s `storage.s3.endpoint` is tenant-controlled and was dialed by the provider pod **with no host validation** — a live SSRF. A migration could point the pod at `169.254.169.254` (cloud-metadata), loopback, or an internal service, and the S3 SDK would present the configured credentials there. The controller now enforces a `HostPolicy` at the `Validating` phase: it **always** rejects loopback / link-local (including the metadata address) / unspecified / multicast targets, and — when the new allowlist is configured — anything outside it. Hostnames are resolved and **every** resolved address is checked (a validate-time DNS-rebind guard). RFC1918/private ranges stay permitted by default so on-prem storage works; regulated deployments should set the allowlist. The same gate is the hard prerequisite (ADR-0006 Slice 4, condition C3) for the NFS `direct`-mode backend, where the hypervisor host would dial the address — so it lands first.
+
+### Added
+- `cmd/manager/main.go`: `--migration-storage-allowed-hosts` flag (comma-separated IP/CIDR) wiring the allowlist into the VMMigration reconciler. Empty = permissive except the always-denied set.
+- `api/infra.virtrigaud.io/v1beta1/vmmigration_types.go`: `MaxLength` bounds on `S3StorageConfig.Endpoint` and `NFSStorageConfig.{Server,Export,Path}` (apiserver-side payload cap; CRDs regenerated).
+
+### Why
+The NFS migration security review (ADR-0006 Slice 4, C3) found the shipped S3 path dials an unvalidated, tenant-controlled endpoint — exploitable today — and that the NFS backend would extend the same exposure to the hypervisor host. This closes the live S3 SSRF and provides the reusable host gate the NFS slices build on.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager)
+- [ ] Config change only
+
 ## [2026-06-19 11:30] - fix(vsphere): Reconfigure honors VMClass CPU/memory (wrong JSON keys) (#266)
 **Author:** @wrkode (William Rizzo)
 

--- a/api/infra.virtrigaud.io/v1beta1/vmmigration_types.go
+++ b/api/infra.virtrigaud.io/v1beta1/vmmigration_types.go
@@ -253,7 +253,10 @@ type S3StorageConfig struct {
 	// Bucket is the S3 bucket for the transfer object.
 	Bucket string `json:"bucket"`
 	// Endpoint overrides the S3 endpoint (empty = AWS default; set for MinIO/Ceph RGW).
+	// The host is gated by the controller's SSRF allowlist before it is dialed
+	// (ADR-0006 C3). MaxLength bounds an apiserver-side payload.
 	// +optional
+	// +kubebuilder:validation:MaxLength=263
 	Endpoint string `json:"endpoint,omitempty"`
 	// Region is the S3 region for the bucket (empty = provider/SDK default).
 	// +optional
@@ -275,12 +278,16 @@ type S3StorageConfig struct {
 // NFSStorageConfig defines NFS-based staging configuration used to stage a
 // migration's transferred disk. Surface-only in ADR-0006 Slice 0.
 type NFSStorageConfig struct {
-	// Server is the NFS server hostname or IP exporting the share.
+	// Server is the NFS server hostname or IP exporting the share. The host is
+	// gated by the controller's SSRF allowlist before it is dialed (ADR-0006 C3).
+	// +kubebuilder:validation:MaxLength=253
 	Server string `json:"server"`
 	// Export is the exported NFS path on the server (e.g. "/exports/migrations").
+	// +kubebuilder:validation:MaxLength=4096
 	Export string `json:"export"`
 	// Path is an optional sub-path within the export for this migration's data.
 	// +optional
+	// +kubebuilder:validation:MaxLength=4096
 	Path string `json:"path,omitempty"`
 	// ReadOnly mounts the export read-only. No `omitempty` (defaulted bool footgun, PR #235).
 	// +optional

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -43,6 +44,7 @@ import (
 	"github.com/projectbeskar/virtrigaud/internal/obs/metrics"
 	"github.com/projectbeskar/virtrigaud/internal/resilience"
 	"github.com/projectbeskar/virtrigaud/internal/runtime/remote"
+	storagemigration "github.com/projectbeskar/virtrigaud/internal/storage/migration"
 	"github.com/projectbeskar/virtrigaud/internal/version"
 )
 
@@ -94,6 +96,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var enforceProviderCapabilities bool
+	var migrationStorageAllowedHosts string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -133,6 +136,11 @@ func main() {
 			"self-reported capabilities (issue #176). Opt-in: ensure provider "+
 			"capability flags are accurate before enabling, as under-reported "+
 			"capabilities will block otherwise-supported operations.")
+	flag.StringVar(&migrationStorageAllowedHosts, "migration-storage-allowed-hosts", "",
+		"Comma-separated IP/CIDR allowlist for migration staging backends (the S3 "+
+			"endpoint host and NFS server). Empty = permissive except the always-denied "+
+			"loopback/link-local/metadata/multicast targets (ADR-0006 C3, SSRF gate). "+
+			"Set to lock migration egress to known storage networks.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -343,6 +351,12 @@ func main() {
 		mgr.GetEventRecorderFor("vmmigration-controller"),
 		enforceProviderCapabilities,
 	)
+	storageHostPolicy, hpErr := storagemigration.NewHostPolicy(strings.Split(migrationStorageAllowedHosts, ","))
+	if hpErr != nil {
+		setupLog.Error(hpErr, "invalid --migration-storage-allowed-hosts")
+		os.Exit(1)
+	}
+	vmmigrationReconciler.StorageHostPolicy = storageHostPolicy
 	if err = vmmigrationReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VMMigration")
 		os.Exit(1)

--- a/config/crd/bases/infra.virtrigaud.io_vmmigrations.yaml
+++ b/config/crd/bases/infra.virtrigaud.io_vmmigrations.yaml
@@ -247,10 +247,12 @@ spec:
                       export:
                         description: Export is the exported NFS path on the server
                           (e.g. "/exports/migrations").
+                        maxLength: 4096
                         type: string
                       path:
                         description: Path is an optional sub-path within the export
                           for this migration's data.
+                        maxLength: 4096
                         type: string
                       readOnly:
                         default: false
@@ -258,8 +260,10 @@ spec:
                           (defaulted bool footgun, PR #235).'
                         type: boolean
                       server:
-                        description: Server is the NFS server hostname or IP exporting
-                          the share.
+                        description: |-
+                          Server is the NFS server hostname or IP exporting the share. The host is
+                          gated by the controller's SSRF allowlist before it is dialed (ADR-0006 C3).
+                        maxLength: 253
                         type: string
                     required:
                     - export
@@ -325,8 +329,11 @@ spec:
                         - name
                         type: object
                       endpoint:
-                        description: Endpoint overrides the S3 endpoint (empty = AWS
-                          default; set for MinIO/Ceph RGW).
+                        description: |-
+                          Endpoint overrides the S3 endpoint (empty = AWS default; set for MinIO/Ceph RGW).
+                          The host is gated by the controller's SSRF allowlist before it is dialed
+                          (ADR-0006 C3). MaxLength bounds an apiserver-side payload.
+                        maxLength: 263
                         type: string
                       prefix:
                         description: Prefix is the key prefix for this migration's

--- a/internal/controller/vmmigration_controller.go
+++ b/internal/controller/vmmigration_controller.go
@@ -74,6 +74,12 @@ type VMMigrationReconciler struct {
 	// byte-for-byte unchanged. See gateDiskExport / gateDiskImport.
 	EnforceCapabilities bool
 
+	// StorageHostPolicy gates the network address of a migration staging backend
+	// (S3 endpoint / NFS server) against an SSRF allowlist at the Validating
+	// phase (ADR-0006 C3). When nil, a default policy is used that still denies
+	// the always-forbidden loopback/link-local/metadata/multicast targets.
+	StorageHostPolicy *storagemigration.HostPolicy
+
 	// longOpInFlight is an in-memory guard against re-issuing a long-running,
 	// non-idempotent migration RPC (ExportDisk / ImportDisk) when a reconcile
 	// re-enters before the prior status write has propagated to the informer
@@ -1862,6 +1868,20 @@ func (r *VMMigrationReconciler) isProviderReady(provider *infrav1beta1.Provider)
 }
 
 // validateStorageConfig validates the storage configuration
+// defaultStorageHostPolicy denies only the always-forbidden SSRF targets
+// (loopback/link-local/metadata/multicast); used when no operator allowlist was
+// wired into the reconciler, so the SSRF gate is active by default.
+var defaultStorageHostPolicy, _ = storagemigration.NewHostPolicy(nil)
+
+// storageHostPolicy returns the reconciler's configured host policy, or the
+// deny-dangerous-only default when none was wired.
+func (r *VMMigrationReconciler) storageHostPolicy() *storagemigration.HostPolicy {
+	if r.StorageHostPolicy != nil {
+		return r.StorageHostPolicy
+	}
+	return defaultStorageHostPolicy
+}
+
 func (r *VMMigrationReconciler) validateStorageConfig(ctx context.Context, storageConfig *infrav1beta1.MigrationStorage) error {
 	if storageConfig == nil {
 		return fmt.Errorf("storage configuration is required")
@@ -1883,6 +1903,13 @@ func (r *VMMigrationReconciler) validateStorageConfig(ctx context.Context, stora
 		}
 		if storageConfig.S3.CredentialsSecretRef.Name == "" {
 			return fmt.Errorf("s3.credentialsSecretRef is required for s3 storage type")
+		}
+		// SSRF gate (ADR-0006 C3): the endpoint is tenant-controlled and is dialed
+		// by the provider pod (which also presents the S3 credentials there), so
+		// reject metadata/loopback/link-local targets and anything outside the
+		// operator allowlist before the migration proceeds.
+		if err := r.storageHostPolicy().ValidateS3Endpoint(storageConfig.S3.Endpoint); err != nil {
+			return fmt.Errorf("s3 endpoint not permitted: %w", err)
 		}
 		return nil
 	default:

--- a/internal/controller/vmmigration_storage_ssrf_test.go
+++ b/internal/controller/vmmigration_storage_ssrf_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+)
+
+func s3StorageWithEndpoint(endpoint string) *infrav1beta1.MigrationStorage {
+	return &infrav1beta1.MigrationStorage{
+		Type: "s3",
+		S3: &infrav1beta1.S3StorageConfig{
+			Bucket:               "virtrigaud",
+			Endpoint:             endpoint,
+			CredentialsSecretRef: infrav1beta1.ObjectRef{Name: "s3-creds"},
+		},
+	}
+}
+
+// TestValidateStorageConfig_S3EndpointSSRF is the ADR-0006 C3 fix: validateStorageConfig
+// rejects an S3 endpoint that targets a metadata/loopback/link-local address
+// before the provider pod ever dials it (and presents the S3 credentials there).
+// A nil StorageHostPolicy uses the deny-dangerous default, so the gate is active
+// even without operator configuration.
+func TestValidateStorageConfig_S3EndpointSSRF(t *testing.T) {
+	r := &VMMigrationReconciler{} // nil StorageHostPolicy → deny-dangerous default
+	ctx := context.Background()
+
+	for _, ep := range []string{
+		"http://169.254.169.254:9000", // cloud metadata
+		"http://127.0.0.1:9000",       // loopback
+		"http://[::1]:9000",           // ipv6 loopback
+	} {
+		err := r.validateStorageConfig(ctx, s3StorageWithEndpoint(ep))
+		if err == nil {
+			t.Errorf("validateStorageConfig(endpoint=%q) = nil, want SSRF rejection", ep)
+			continue
+		}
+		if !strings.Contains(err.Error(), "not permitted") {
+			t.Errorf("endpoint=%q: error = %v, want 'not permitted'", ep, err)
+		}
+	}
+
+	// A private storage endpoint passes the gate.
+	if err := r.validateStorageConfig(ctx, s3StorageWithEndpoint("http://172.16.56.13:9000")); err != nil {
+		t.Errorf("private endpoint rejected: %v", err)
+	}
+}

--- a/internal/storage/migration/addrpolicy.go
+++ b/internal/storage/migration/addrpolicy.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// lookupIP resolves a hostname to its IP addresses. It is a package variable so
+// tests can stub DNS without touching the network.
+var lookupIP = net.LookupIP
+
+// HostPolicy decides whether a migration staging backend's network address — an
+// S3 endpoint host or an NFS server — may be dialed. A VMMigration's
+// `storage.s3.endpoint` / `storage.nfs.server` are tenant-controlled and are
+// dialed by the provider pod (S3 relay) or, for NFS `direct` mode, by the
+// hypervisor host. Without this gate a migration could coerce those processes
+// into connecting to internal services or the cloud-metadata endpoint (SSRF).
+// See ADR-0006 (Slice 4 security, condition C3).
+//
+// The policy ALWAYS denies the SSRF-dangerous, never-legitimate-as-storage
+// targets — loopback, link-local (including the 169.254.169.254 cloud-metadata
+// address and fe80::/10), the unspecified address, and multicast — regardless of
+// configuration, so the SSRF teeth are removed even without operator setup. When
+// an operator allowlist is configured, an address must ALSO fall within it.
+// RFC1918 / on-prem ranges are permitted by default (migration storage is
+// commonly on a private network); regulated deployments SHOULD configure an
+// allowlist to lock egress down further.
+type HostPolicy struct {
+	allow           []*net.IPNet
+	allowConfigured bool
+}
+
+// NewHostPolicy builds a HostPolicy from operator-supplied allowlist entries,
+// each an IP or CIDR. An empty/nil list yields a permissive-except-always-denied
+// policy. Hostnames are not accepted as allowlist entries — request hosts are
+// resolved to IPs and matched against these ranges.
+func NewHostPolicy(allow []string) (*HostPolicy, error) {
+	p := &HostPolicy{}
+	for _, raw := range allow {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		p.allowConfigured = true
+		if _, ipnet, err := net.ParseCIDR(entry); err == nil {
+			p.allow = append(p.allow, ipnet)
+			continue
+		}
+		if ip := net.ParseIP(entry); ip != nil {
+			p.allow = append(p.allow, singleHostNet(ip))
+			continue
+		}
+		return nil, fmt.Errorf("invalid storage-host allowlist entry %q (want an IP or CIDR)", entry)
+	}
+	return p, nil
+}
+
+// singleHostNet returns a /32 (IPv4) or /128 (IPv6) net for a single IP.
+func singleHostNet(ip net.IP) *net.IPNet {
+	bits := 32
+	if ip.To4() == nil {
+		bits = 128
+	}
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)}
+}
+
+// ValidateS3Endpoint validates the host of an S3 endpoint, which may be a URL
+// ("http://host:port"), a bare "host:port", or "host". An empty endpoint means
+// the AWS default (validated as s3.amazonaws.com). This is the S3 entry point
+// for the SSRF gate.
+func (p *HostPolicy) ValidateS3Endpoint(endpoint string) error {
+	host := hostFromS3Endpoint(endpoint)
+	if host == "" {
+		host = "s3.amazonaws.com"
+	}
+	return p.ValidateHost(host)
+}
+
+// ValidateHost resolves host — a hostname or IP literal, optionally with a port
+// or IPv6 brackets — and rejects it if any resolved address is always-denied,
+// or, when an allowlist is configured, falls outside it. All resolved addresses
+// must pass (a host that resolves to even one forbidden address is rejected).
+func (p *HostPolicy) ValidateHost(host string) error {
+	h := strings.TrimSpace(host)
+	if h == "" {
+		return fmt.Errorf("storage host is empty")
+	}
+	if hostOnly, _, err := net.SplitHostPort(h); err == nil {
+		h = hostOnly
+	}
+	h = strings.Trim(h, "[]")
+
+	ips, err := resolveHost(h)
+	if err != nil {
+		return fmt.Errorf("cannot resolve storage host %q: %w", h, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("storage host %q resolved to no addresses", h)
+	}
+	for _, ip := range ips {
+		if isAlwaysDenied(ip) {
+			return fmt.Errorf("storage host %q resolves to forbidden address %s (loopback/link-local/metadata/multicast are blocked)", h, ip)
+		}
+		if p.allowConfigured && !p.inAllowlist(ip) {
+			return fmt.Errorf("storage host %q (%s) is not in the configured storage-host allowlist", h, ip)
+		}
+	}
+	return nil
+}
+
+// inAllowlist reports whether ip falls within any configured allow CIDR.
+func (p *HostPolicy) inAllowlist(ip net.IP) bool {
+	for _, n := range p.allow {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAlwaysDenied reports whether ip is an SSRF-dangerous target that is never a
+// legitimate migration storage endpoint. IsLinkLocalUnicast covers the
+// 169.254.169.254 cloud-metadata address and fe80::/10.
+func isAlwaysDenied(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsMulticast()
+}
+
+// resolveHost returns the IPs for host, short-circuiting IP literals so no DNS
+// lookup is performed for them.
+func resolveHost(host string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{ip}, nil
+	}
+	return lookupIP(host)
+}
+
+// hostFromS3Endpoint extracts host[:port] from an S3 endpoint that may be a URL,
+// a bare "host:port", or "host". An empty endpoint returns "".
+func hostFromS3Endpoint(endpoint string) string {
+	e := strings.TrimSpace(endpoint)
+	if e == "" {
+		return ""
+	}
+	if strings.Contains(e, "://") {
+		if u, err := url.Parse(e); err == nil && u.Host != "" {
+			return u.Host
+		}
+	}
+	return e
+}

--- a/internal/storage/migration/addrpolicy_test.go
+++ b/internal/storage/migration/addrpolicy_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"net"
+	"testing"
+)
+
+// TestHostPolicy_AlwaysDenied verifies the SSRF-dangerous targets are rejected
+// even with no allowlist configured — most importantly the 169.254.169.254
+// cloud-metadata address (ADR-0006 C3).
+func TestHostPolicy_AlwaysDenied(t *testing.T) {
+	p, err := NewHostPolicy(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range []string{
+		"127.0.0.1", "127.0.0.53", // loopback
+		"169.254.169.254", "169.254.1.1", // link-local incl. cloud metadata
+		"::1",       // ipv6 loopback
+		"0.0.0.0",   // unspecified
+		"224.0.0.1", // multicast
+		"ff02::1",   // ipv6 multicast
+		"fe80::1",   // ipv6 link-local
+	} {
+		if err := p.ValidateHost(h); err == nil {
+			t.Errorf("ValidateHost(%q) = nil, want denied", h)
+		}
+	}
+}
+
+// TestHostPolicy_PermissiveDefault verifies that without an allowlist, ordinary
+// public and RFC1918 addresses are permitted (so on-prem/lab storage works).
+func TestHostPolicy_PermissiveDefault(t *testing.T) {
+	p, _ := NewHostPolicy(nil)
+	for _, h := range []string{"172.16.56.13", "10.0.0.5", "192.168.1.1", "8.8.8.8"} {
+		if err := p.ValidateHost(h); err != nil {
+			t.Errorf("ValidateHost(%q) = %v, want allowed (no allowlist)", h, err)
+		}
+	}
+}
+
+// TestHostPolicy_Allowlist verifies that a configured allowlist permits only its
+// members, and that the always-denied set still wins inside the allowlist.
+func TestHostPolicy_Allowlist(t *testing.T) {
+	p, err := NewHostPolicy([]string{"172.16.56.0/24", "10.1.2.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range []string{"172.16.56.13", "172.16.56.1", "10.1.2.3"} {
+		if err := p.ValidateHost(h); err != nil {
+			t.Errorf("ValidateHost(%q) = %v, want allowed", h, err)
+		}
+	}
+	for _, h := range []string{"10.0.0.5", "8.8.8.8", "172.16.57.1"} {
+		if err := p.ValidateHost(h); err == nil {
+			t.Errorf("ValidateHost(%q) = nil, want denied (outside allowlist)", h)
+		}
+	}
+	if err := p.ValidateHost("169.254.169.254"); err == nil {
+		t.Error("metadata IP allowed under allowlist; always-denied must win")
+	}
+}
+
+// TestNewHostPolicy_BadEntry verifies a non-IP/CIDR allowlist entry is rejected.
+func TestNewHostPolicy_BadEntry(t *testing.T) {
+	if _, err := NewHostPolicy([]string{"not-an-ip"}); err == nil {
+		t.Error("NewHostPolicy(bad) = nil err, want error")
+	}
+}
+
+// TestValidateS3Endpoint covers the URL / bare-host / scheme forms of an S3
+// endpoint against the SSRF gate.
+func TestValidateS3Endpoint(t *testing.T) {
+	p, _ := NewHostPolicy(nil)
+	if err := p.ValidateS3Endpoint("http://169.254.169.254:9000"); err == nil {
+		t.Error("metadata S3 endpoint allowed, want denied")
+	}
+	if err := p.ValidateS3Endpoint("http://127.0.0.1:9000"); err == nil {
+		t.Error("localhost S3 endpoint allowed, want denied")
+	}
+	if err := p.ValidateS3Endpoint("172.16.56.13:9000"); err != nil {
+		t.Errorf("private S3 endpoint denied: %v", err)
+	}
+	if err := p.ValidateS3Endpoint("https://172.16.56.13"); err != nil {
+		t.Errorf("private https S3 endpoint denied: %v", err)
+	}
+}
+
+// TestValidateHost_HostnameResolution verifies hostnames are resolved and ALL
+// resolved addresses are checked (a host resolving to even one forbidden address
+// is rejected — a DNS-rebind-style guard at validate time).
+func TestValidateHost_HostnameResolution(t *testing.T) {
+	orig := lookupIP
+	defer func() { lookupIP = orig }()
+	lookupIP = func(host string) ([]net.IP, error) {
+		switch host {
+		case "evil.lab":
+			return []net.IP{net.ParseIP("169.254.169.254")}, nil
+		case "good.lab":
+			return []net.IP{net.ParseIP("172.16.56.13")}, nil
+		case "mixed.lab":
+			return []net.IP{net.ParseIP("172.16.56.13"), net.ParseIP("127.0.0.1")}, nil
+		}
+		return nil, &net.DNSError{Err: "no such host", Name: host}
+	}
+	p, _ := NewHostPolicy(nil)
+	if err := p.ValidateHost("evil.lab"); err == nil {
+		t.Error("hostname resolving to metadata IP allowed, want denied")
+	}
+	if err := p.ValidateHost("good.lab"); err != nil {
+		t.Errorf("hostname resolving to private IP denied: %v", err)
+	}
+	if err := p.ValidateHost("mixed.lab"); err == nil {
+		t.Error("hostname resolving to a forbidden IP allowed, want denied")
+	}
+	if err := p.ValidateHost("nope.lab"); err == nil {
+		t.Error("unresolvable host allowed, want error")
+	}
+}


### PR DESCRIPTION
## Summary

**PR-0 of the NFS migration epic** (ADR-0006 Slice 4, #236), and a **standalone security fix**: it closes a **live SSRF in the shipped S3 migration path** and lands the host-allowlist gate the NFS backend requires.

### The live bug
A `VMMigration`'s `storage.s3.endpoint` is tenant-controlled and was dialed by the provider pod **with no host validation** (`parseS3Endpoint` checked only the URL scheme; `validateStorageConfig` ignored the endpoint; no validating webhook exists). So any principal who can create a `VMMigration` could point the provider pod at `http://169.254.169.254/…` (cloud-metadata), loopback, or an internal service — and the S3 SDK would **present the configured S3 credentials there**. Classic SSRF + credential exposure, exploitable on `main` today.

### The fix
- **`internal/storage/migration/addrpolicy.go` (new)** — a `HostPolicy` that **always** denies the never-legitimate SSRF targets (loopback, link-local incl. the metadata address, unspecified, multicast) and, when an operator allowlist is configured, requires the address to be inside it. Hostnames are resolved and **every** resolved address is checked (a validate-time DNS-rebind guard). RFC1918/private ranges stay permitted by default so on-prem/lab storage works.
- **Controller** enforces it in `validateStorageConfig` at the **`Validating`** phase (fail fast, never mid-export), for the S3 endpoint now and reused by NFS next.
- **`--migration-storage-allowed-hosts`** manager flag (comma-separated IP/CIDR) to lock egress down; empty = permissive-except-always-denied (so the SSRF teeth are removed with zero config).
- **CRD bounds**: `MaxLength` on `S3StorageConfig.Endpoint` and `NFSStorageConfig.{Server,Export,Path}` (apiserver payload cap; CRDs regenerated).

### Tests
- `internal/storage/migration/addrpolicy_test.go` — always-denied set (incl. `169.254.169.254`), permissive default, allowlist enforcement (and always-denied beating the allowlist), bad-entry rejection, S3-endpoint URL/bare/scheme forms, and stubbed hostname resolution incl. a mixed-resolution rebind case.
- `internal/controller/vmmigration_storage_ssrf_test.go` — `validateStorageConfig` rejects metadata/loopback/ipv6-loopback S3 endpoints (default deny-dangerous policy, no config needed) and admits a private endpoint.
- `make fmt` clean · `golangci-lint` 0 issues · full `controller` + `storage` suites green · `make build` green.

## Why this is the on-ramp (not just a fix)
The NFS security re-bless made this **condition C3 hard-blocking**: in NFS `direct` mode the *hypervisor host* (not just a pod) would dial the tenant-chosen `storage.nfs.server`, so the allowlist must exist before any NFS code. Building it first closes the live S3 exposure and gives the NFS slices a ready gate.

## Impact
- [ ] Breaking change (rejects only never-legitimate metadata/loopback/link-local endpoints)
- [x] Requires cluster rollout (manager)

Refs #236.