### PR TITLE
feat(migration): controller routes the nfs backend (qemu-img native transport) (ADR-0006 Slice 4, #236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-19 13:45] - feat(migration): controller routes the nfs backend (qemu-img native transport) (ADR-0006 Slice 4, #236)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/controller/vmmigration_controller.go`: the VMMigration controller now routes `storage.type: nfs` on its side:
+  - `gateMigrationStorageBackend` accepts `nfs` and exempts it from relay/direct transfer-mode gating — NFS uses qemu-img's native `nfs://` transport (host-side for libvirt/Proxmox, pod-side for vSphere), not the stream-through-the-pod relay model.
+  - `validateStorageConfig` validates `nfs.server`/`nfs.export` and runs the server through the **same SSRF host gate** as the S3 endpoint (ADR-0006 C3); NFS carries no credentials Secret.
+  - `storageOptionsJSON` (renamed from `s3StorageOptionsJSON`) ships the NFS coordinates (server/export/path/uid/gid) in `storage_options_json`.
+  - `generateStorageURL` builds the hardened `nfs://…/<stage>.qcow2` URL via `NFSURL` (C7'); the staged object is qcow2 and the import format is derived as qcow2.
+  - The Validating-phase pre-flight skips the PVC cross-namespace check for nfs (it stages over the network, like s3).
+
+### Why
+Wires the controller for the NFS backend. NFS migrations now pass the controller's routing/validation; they still require the providers to advertise `nfs` and run the `qemu-img nfs://` transport (the next, per-provider slice), so end-to-end NFS is not yet active.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager)
+- [ ] Config change only
+
 ## [2026-06-19 13:15] - feat(migration): NFS staging coordinates + hardened nfs:// URL builder (ADR-0006 Slice 4, #236)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/controller/vmmigration_controller.go
+++ b/internal/controller/vmmigration_controller.go
@@ -400,17 +400,21 @@ func (r *VMMigrationReconciler) handleValidatingPhase(ctx context.Context, migra
 			return r.transitionToFailed(ctx, migration, fmt.Sprintf("Invalid storage configuration: %v", err))
 		}
 
-		// The s3 backend (ADR-0006) stages bytes through external object storage,
-		// not a shared PVC, so it has NEITHER the cross-namespace constraint NOR a
-		// migration PVC to create. The provider pods are the S3 clients. Skip the
-		// PVC path entirely for s3.
-		if migrationBackendType(migration) == storagemigration.BackendS3 {
+		// The s3 and nfs backends (ADR-0006) stage bytes over the network, not a
+		// shared PVC, so they have NEITHER the cross-namespace constraint NOR a
+		// migration PVC to create. Skip the PVC path entirely for them.
+		switch migrationBackendType(migration) {
+		case storagemigration.BackendS3:
 			// Validate credentials resolve before any side effect (fail fast at
 			// Validating, never mid-export — ADR-0006 D6). Never log the values.
 			if _, err := r.loadS3Credentials(ctx, migration); err != nil {
 				return r.transitionToFailed(ctx, migration, fmt.Sprintf("Invalid s3 storage configuration: %v", err))
 			}
-		} else {
+		case storagemigration.BackendNFS:
+			// NFS stages over the network with no Kubernetes Secret and no PVC; the
+			// server + export were validated (incl. the SSRF host gate) in
+			// validateStorageConfig above. Nothing further to pre-flight here.
+		default:
 			// Fail fast on a cross-namespace topology (#229). The migration transfer
 			// PVC is mounted into both the source and target provider pods, and a
 			// Kubernetes pod can only mount a PVC from its own namespace. If either
@@ -816,7 +820,7 @@ func (r *VMMigrationReconciler) handleExportingPhase(ctx context.Context, migrat
 	// Resolve the s3 staging options and credentials (ADR-0006). For the pvc
 	// backend these are empty/no-op, preserving the legacy behavior. Credentials
 	// come from the referenced Secret and are NEVER logged or placed in Status.
-	storageOptionsJSON, err := s3StorageOptionsJSON(migration)
+	storageOpts, err := storageOptionsJSON(migration)
 	if err != nil {
 		return r.transitionToFailed(ctx, migration, fmt.Sprintf("Failed to build storage options: %v", err))
 	}
@@ -838,7 +842,7 @@ func (r *VMMigrationReconciler) handleExportingPhase(ctx context.Context, migrat
 		Credentials:        creds,
 		BackendType:        migrationBackendType(migration),
 		TransferMode:       resolveTransferMode(migration),
-		StorageOptionsJSON: storageOptionsJSON,
+		StorageOptionsJSON: storageOpts,
 	}
 
 	// Create extended context for export operation (disk exports can take a long time)
@@ -1061,7 +1065,7 @@ func (r *VMMigrationReconciler) handleImportingPhase(ctx context.Context, migrat
 	// Resolve the s3 staging options and credentials (ADR-0006). For the pvc
 	// backend these are empty/no-op. Credentials come from the referenced Secret
 	// and are NEVER logged or placed in Status.
-	storageOptionsJSON, err := s3StorageOptionsJSON(migration)
+	storageOpts, err := storageOptionsJSON(migration)
 	if err != nil {
 		return r.transitionToFailed(ctx, migration, fmt.Sprintf("Failed to build storage options: %v", err))
 	}
@@ -1077,7 +1081,8 @@ func (r *VMMigrationReconciler) handleImportingPhase(ctx context.Context, migrat
 	// qcow2 (reverse). For non-s3 backends the legacy/spec-derived format is
 	// threaded unchanged.
 	importFormat := diskFormat
-	if migrationBackendType(migration) == storagemigration.BackendS3 {
+	switch migrationBackendType(migration) {
+	case storagemigration.BackendS3:
 		sourceProvider, srcErr := r.getSourceProvider(ctx, migration)
 		if srcErr != nil {
 			return r.transitionToFailed(ctx, migration, fmt.Sprintf("Failed to get source provider: %v", srcErr))
@@ -1085,6 +1090,10 @@ func (r *VMMigrationReconciler) handleImportingPhase(ctx context.Context, migrat
 		importFormat = stagedImportFormat(sourceProvider)
 		logger.Info("Derived s3 staged import format from source provider",
 			"source_provider_type", sourceProvider.Spec.Type, "import_format", importFormat)
+	case storagemigration.BackendNFS:
+		// NFS via qemu-img always stages a qcow2 (the export runs
+		// `qemu-img convert -O qcow2`); the target converts from qcow2.
+		importFormat = "qcow2"
 	}
 
 	// Build import request. transfer_mode is resolved auto→relay (Slice 1).
@@ -1098,7 +1107,7 @@ func (r *VMMigrationReconciler) handleImportingPhase(ctx context.Context, migrat
 		Credentials:        creds,
 		BackendType:        migrationBackendType(migration),
 		TransferMode:       resolveTransferMode(migration),
-		StorageOptionsJSON: storageOptionsJSON,
+		StorageOptionsJSON: storageOpts,
 	}
 
 	// Set expected checksum if available
@@ -1912,8 +1921,23 @@ func (r *VMMigrationReconciler) validateStorageConfig(ctx context.Context, stora
 			return fmt.Errorf("s3 endpoint not permitted: %w", err)
 		}
 		return nil
+	case storagemigration.BackendNFS:
+		// NFS staging: require a server + absolute export. The server is dialed by
+		// the data plane (the hypervisor host for libvirt/Proxmox, the pod for
+		// vSphere), so it passes the same SSRF gate as the S3 endpoint (ADR-0006
+		// C3). NFS carries no credentials Secret.
+		if storageConfig.NFS == nil {
+			return fmt.Errorf("nfs configuration is required when using nfs storage type")
+		}
+		if storageConfig.NFS.Server == "" || storageConfig.NFS.Export == "" {
+			return fmt.Errorf("nfs.server and nfs.export are required for nfs storage type")
+		}
+		if err := r.storageHostPolicy().ValidateHost(storageConfig.NFS.Server); err != nil {
+			return fmt.Errorf("nfs server not permitted: %w", err)
+		}
+		return nil
 	default:
-		return fmt.Errorf("unsupported storage type: %s (supported: 'pvc', 's3')", storageConfig.Type)
+		return fmt.Errorf("unsupported storage type: %s (supported: 'pvc', 's3', 'nfs')", storageConfig.Type)
 	}
 
 	// Validate PVC configuration
@@ -2325,24 +2349,41 @@ func resolveTransferMode(migration *infrav1beta1.VMMigration) string {
 	return mode
 }
 
-// s3StorageOptionsJSON builds the non-secret storage_options_json carried to a
-// provider for the s3 backend (ADR-0006). Returns "" for non-s3 backends.
-func s3StorageOptionsJSON(migration *infrav1beta1.VMMigration) (string, error) {
-	if migrationBackendType(migration) != storagemigration.BackendS3 {
+// storageOptionsJSON builds the non-secret storage_options_json carried to a
+// provider (ADR-0006). It dispatches on the backend: s3 ships the bucket/endpoint
+// options, nfs ships the server/export coordinates and uid/gid; pvc and unknown
+// backends carry no options ("").
+func storageOptionsJSON(migration *infrav1beta1.VMMigration) (string, error) {
+	switch migrationBackendType(migration) {
+	case storagemigration.BackendS3:
+		s3 := migration.Spec.Storage.S3
+		if s3 == nil {
+			return "", fmt.Errorf("s3 storage configuration is required for s3 backend")
+		}
+		return storagemigration.MarshalStorageOptions(storagemigration.StorageOptions{
+			Backend:      storagemigration.BackendS3,
+			Bucket:       s3.Bucket,
+			Endpoint:     s3.Endpoint,
+			Region:       s3.Region,
+			Prefix:       s3.Prefix,
+			UsePathStyle: s3.UsePathStyle,
+		})
+	case storagemigration.BackendNFS:
+		nfs := migration.Spec.Storage.NFS
+		if nfs == nil || nfs.Server == "" || nfs.Export == "" {
+			return "", fmt.Errorf("nfs storage configuration (server, export) is required for nfs backend")
+		}
+		return storagemigration.MarshalStorageOptions(storagemigration.StorageOptions{
+			Backend: storagemigration.BackendNFS,
+			Server:  nfs.Server,
+			Export:  nfs.Export,
+			Path:    nfs.Path,
+			UID:     nfs.UID,
+			GID:     nfs.GID,
+		})
+	default:
 		return "", nil
 	}
-	s3 := migration.Spec.Storage.S3
-	if s3 == nil {
-		return "", fmt.Errorf("s3 storage configuration is required for s3 backend")
-	}
-	return storagemigration.MarshalStorageOptions(storagemigration.StorageOptions{
-		Backend:      storagemigration.BackendS3,
-		Bucket:       s3.Bucket,
-		Endpoint:     s3.Endpoint,
-		Region:       s3.Region,
-		Prefix:       s3.Prefix,
-		UsePathStyle: s3.UsePathStyle,
-	})
 }
 
 // loadS3Credentials reads the S3 access credentials from the Secret referenced by
@@ -2493,17 +2534,22 @@ func (r *VMMigrationReconciler) gateMigrationStorageBackend(
 	backend := migrationBackendType(migration)
 	mode := migrationTransferMode(migration)
 
-	// Only pvc and s3 have transfer logic. nfs has none yet (ADR-0006 Slice 4),
-	// so reject it up front regardless of what a provider might (later) advertise.
-	if backend != storagemigration.BackendPVC && backend != storagemigration.BackendS3 {
+	// pvc, s3 and nfs have transfer logic (ADR-0006 Slices 1–4). Anything else is
+	// rejected up front regardless of what a provider might (later) advertise.
+	if backend != storagemigration.BackendPVC &&
+		backend != storagemigration.BackendS3 &&
+		backend != storagemigration.BackendNFS {
 		return fmt.Sprintf(
-			"storage backend %q is not yet implemented; supported today: %q, %q (ADR-0006)",
-			backend, storagemigration.BackendPVC, storagemigration.BackendS3)
+			"storage backend %q is not yet implemented; supported today: %q, %q, %q (ADR-0006)",
+			backend, storagemigration.BackendPVC, storagemigration.BackendS3, storagemigration.BackendNFS)
 	}
 
-	// Only relay is implemented (ADR-0006 Slice 1). An explicit "direct" fails
-	// loudly here — never a silent downgrade — before any side effect.
-	if mode == storagemigration.TransferModeDirect {
+	// The relay/direct streaming model applies to the pvc/s3 backends. NFS uses
+	// qemu-img's native nfs:// transport (host-side for libvirt/Proxmox, pod-side
+	// for vSphere), so the transfer-mode distinction does not apply and any mode
+	// is accepted. For pvc/s3, only relay is implemented — an explicit "direct"
+	// fails loudly here, never a silent downgrade.
+	if backend != storagemigration.BackendNFS && mode == storagemigration.TransferModeDirect {
 		return fmt.Sprintf(
 			"transfer mode %q is not yet implemented; only %q (and %q) are supported today (ADR-0006 Slice 1)",
 			storagemigration.TransferModeDirect, storagemigration.TransferModeRelay, storagemigration.TransferModeAuto)
@@ -2524,8 +2570,9 @@ func (r *VMMigrationReconciler) gateMigrationStorageBackend(
 	}
 
 	// "auto" is resolved later against both providers' modes; only an explicit
-	// mode is gated here. Both providers must advertise the explicit mode.
-	if mode != storagemigration.TransferModeAuto {
+	// mode is gated here. Both providers must advertise the explicit mode. NFS is
+	// exempt — its transport is qemu-img-native, not relay/direct.
+	if backend != storagemigration.BackendNFS && mode != storagemigration.TransferModeAuto {
 		sourceModes := reportedTransferModes(sourceProvider)
 		if !containsString(sourceModes, mode) {
 			return fmt.Sprintf(
@@ -2648,6 +2695,23 @@ func (r *VMMigrationReconciler) generateStorageURL(ctx context.Context, migratio
 		}
 		// s3://bucket/<prefix>/<key>
 		return fmt.Sprintf("s3://%s/%s", storageConfig.S3.Bucket, key), nil
+
+	case storagemigration.BackendNFS:
+		// NFS stages a qcow2 written/read by qemu-img's native nfs:// transport
+		// (libnfs). NFSURL is the single sanitised construction site (ADR-0006
+		// C7'); the host was SSRF-validated at the Validating phase (C3).
+		nfs := storageConfig.NFS
+		if nfs == nil || nfs.Server == "" || nfs.Export == "" {
+			return "", fmt.Errorf("nfs storage configuration (server, export) is required")
+		}
+		key := fmt.Sprintf("vmmigrations/%s/%s/%s.qcow2", migration.Namespace, migration.Name, stage)
+		return storagemigration.NFSURL(storagemigration.StorageOptions{
+			Server: nfs.Server,
+			Export: nfs.Export,
+			Path:   nfs.Path,
+			UID:    nfs.UID,
+			GID:    nfs.GID,
+		}, key)
 
 	default:
 		return "", fmt.Errorf("unsupported storage type: %s", storageConfig.Type)

--- a/internal/controller/vmmigration_nfs_controller_test.go
+++ b/internal/controller/vmmigration_nfs_controller_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infrav1beta1 "github.com/projectbeskar/virtrigaud/api/infra.virtrigaud.io/v1beta1"
+	storagemigration "github.com/projectbeskar/virtrigaud/internal/storage/migration"
+)
+
+func nfsMigration(server, export, path string) *infrav1beta1.VMMigration {
+	return &infrav1beta1.VMMigration{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "mig", Name: "m1"},
+		Spec: infrav1beta1.VMMigrationSpec{
+			Storage: &infrav1beta1.MigrationStorage{
+				Type: storagemigration.BackendNFS,
+				NFS:  &infrav1beta1.NFSStorageConfig{Server: server, Export: export, Path: path},
+			},
+		},
+	}
+}
+
+// TestStorageOptionsJSON_NFS verifies the controller ships the NFS coordinates
+// (not S3 fields) in storage_options_json for an nfs migration.
+func TestStorageOptionsJSON_NFS(t *testing.T) {
+	raw, err := storageOptionsJSON(nfsMigration("omv.lab", "/export/virtrigaud", "sub"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts, err := storagemigration.ParseStorageOptions(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Backend != storagemigration.BackendNFS || opts.Server != "omv.lab" ||
+		opts.Export != "/export/virtrigaud" || opts.Path != "sub" {
+		t.Errorf("unexpected nfs storage options: %+v", opts)
+	}
+}
+
+// TestGenerateStorageURL_NFS verifies the controller builds the hardened nfs://
+// staging URL for an nfs migration.
+func TestGenerateStorageURL_NFS(t *testing.T) {
+	r := &VMMigrationReconciler{}
+	got, err := r.generateStorageURL(context.Background(), nfsMigration("172.16.56.13", "/export/virtrigaud", ""), "export")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "nfs://172.16.56.13/export/virtrigaud/vmmigrations/mig/m1/export.qcow2"; got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+// TestValidateStorageConfig_NFS verifies nfs validation: coords required, and the
+// server runs through the same SSRF host gate as the S3 endpoint (ADR-0006 C3).
+func TestValidateStorageConfig_NFS(t *testing.T) {
+	r := &VMMigrationReconciler{} // nil StorageHostPolicy → deny-dangerous default
+	ctx := context.Background()
+
+	if err := r.validateStorageConfig(ctx, nfsMigration("172.16.56.13", "/export/virtrigaud", "").Spec.Storage); err != nil {
+		t.Errorf("valid nfs config rejected: %v", err)
+	}
+	if err := r.validateStorageConfig(ctx, nfsMigration("172.16.56.13", "", "").Spec.Storage); err == nil {
+		t.Error("nfs config missing export accepted, want rejection")
+	}
+	err := r.validateStorageConfig(ctx, nfsMigration("169.254.169.254", "/export/virtrigaud", "").Spec.Storage)
+	if err == nil || !strings.Contains(err.Error(), "not permitted") {
+		t.Errorf("SSRF nfs server: err=%v, want 'not permitted'", err)
+	}
+}

--- a/internal/controller/vmmigration_s3_test.go
+++ b/internal/controller/vmmigration_s3_test.go
@@ -144,9 +144,9 @@ func TestLoadS3CredentialsFromSecret(t *testing.T) {
 // TestS3StorageOptionsJSON verifies the non-secret options JSON carries the
 // endpoint/bucket/region/prefix/path-style and never any credential material.
 func TestS3StorageOptionsJSON(t *testing.T) {
-	raw, err := s3StorageOptionsJSON(s3Migration("ns", "m", "auto"))
+	raw, err := storageOptionsJSON(s3Migration("ns", "m", "auto"))
 	if err != nil {
-		t.Fatalf("s3StorageOptionsJSON: %v", err)
+		t.Fatalf("storageOptionsJSON: %v", err)
 	}
 	opts, err := storagemigration.ParseStorageOptions(raw)
 	if err != nil {
@@ -167,7 +167,7 @@ func TestS3StorageOptionsJSON(t *testing.T) {
 	pvcMig := &infrav1beta1.VMMigration{Spec: infrav1beta1.VMMigrationSpec{
 		Storage: &infrav1beta1.MigrationStorage{Type: "pvc"},
 	}}
-	if raw, err := s3StorageOptionsJSON(pvcMig); err != nil || raw != "" {
-		t.Errorf("s3StorageOptionsJSON(pvc) = (%q,%v), want empty,nil", raw, err)
+	if raw, err := storageOptionsJSON(pvcMig); err != nil || raw != "" {
+		t.Errorf("storageOptionsJSON(pvc) = (%q,%v), want empty,nil", raw, err)
 	}
 }


### PR DESCRIPTION
## Summary

Second NFS slice (after the coords/URL builder #270): the **VMMigration controller now routes `storage.type: nfs`** end-to-end on its side. **NFS is still not active end-to-end** — the gate's provider-capability check requires the providers to advertise `nfs`, and the `qemu-img nfs://` transport lands in the next (per-provider) slice.

### What the controller now does for `nfs`
- **`gateMigrationStorageBackend`** accepts `nfs` and **exempts it from the relay/direct transfer-mode gating** — NFS uses qemu-img's native `nfs://` transport (host-side for libvirt/Proxmox, pod-side for vSphere), which isn't the stream-through-the-pod relay model. (S3/PVC keep their existing relay-only enforcement.)
- **`validateStorageConfig`** validates `nfs.server`/`nfs.export` and runs the server through the **same SSRF host gate** as the S3 endpoint (ADR-0006 C3). NFS carries no credentials Secret.
- **`storageOptionsJSON`** (renamed from `s3StorageOptionsJSON`) ships the NFS coordinates (`server`/`export`/`path`/`uid`/`gid`) in `storage_options_json`.
- **`generateStorageURL`** builds the hardened `nfs://…/<stage>.qcow2` URL via `NFSURL` (C7′). The staged object is qcow2 and the import format is derived as qcow2.
- The Validating-phase pre-flight **skips the PVC cross-namespace check** for nfs (it stages over the network, like s3).

### Design note (transfer mode)
NFS is modeled as its **own qemu-img-native transport**, not a relay/direct mode — the user sets `storage.type: nfs` + `server`/`export` and the provider does `qemu-img convert … nfs://…`. `transferMode` is informational for nfs. (Flagged earlier; proceeding per that call.)

### Tests
- `internal/controller/vmmigration_nfs_controller_test.go` — `storageOptionsJSON` ships nfs coords; `generateStorageURL` builds the expected `nfs://` URL; `validateStorageConfig` accepts a valid nfs config, rejects a missing export, and rejects an SSRF server (`169.254.169.254`) with "not permitted".
- Renamed the function ref in the existing S3 test. `make fmt` clean · lint 0 · full `controller`+`storage` suites green · `make build` green.

## Next slice
Per-provider `qemu-img nfs://` invocation (libvirt/Proxmox host-side, vSphere pod-side) + advertise `nfs` in capabilities + `qemu-block-extra` in the vSphere image → then lab validation against the OMS server + the export-hardening/cleartext docs (C6).

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (manager)

Refs #236.