### PR TITLE
feat(libvirt): NFS migration via host-side qemu-img nfs:// (ADR-0006 Slice 4, #236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-19 14:15] - feat(libvirt): NFS migration via host-side qemu-img nfs:// (ADR-0006 Slice 4, #236)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/libvirt/nfs.go` (new): `exportDiskToNFS` / `importDiskFromNFS`. The libvirt HOST's `qemu-img` writes/reads the staged qcow2 **directly to/from the `nfs://` export over libnfs** (qemu's `block-nfs` driver) — no provider-pod hop, no S3 client, no host temp. Export = `qemu-img convert -U -f qcow2 -O qcow2 <vol> <nfs://…>`; import = `qemu-img convert <nfs://…> <pool-vol>` + `qemu-img check`. Reuses the existing SSH/disk-resolution machinery.
+- `internal/providers/libvirt/server.go`: `ExportDisk`/`ImportDisk` accept `nfs` (new `migration.EnsurePVCS3OrNFSBackend`) and **exempt it from the relay-mode gate** (NFS uses qemu-img's native transport, not relay); `GetCapabilities` now advertises `nfs` in the export/import backends.
+- `internal/storage/migration/backend.go`: NFS-inclusive gate + advertisement helpers (`EnsurePVCS3OrNFSBackend`, `EnsureS3OrNFSBackend`, `PVCS3AndNFS*`, `S3AndNFS*`).
+
+### Why
+First provider of the NFS backend (ADR-0006 Slice 4). libvirt now advertises and serves `nfs` as both source and target over the qemu-img transport. NFS integrity for this transport is the target-side `qemu-img check` (qemu-img emits no in-stream byte checksum). vSphere and Proxmox follow in the next slices; lab validation against the OMS server comes after.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (libvirt provider image)
+- [ ] Config change only
+
 ## [2026-06-19 13:45] - feat(migration): controller routes the nfs backend (qemu-img native transport) (ADR-0006 Slice 4, #236)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/nfs.go
+++ b/internal/providers/libvirt/nfs.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+)
+
+// exportDiskToNFS implements the ADR-0006 Slice 4 libvirt SOURCE path for the NFS
+// backend: the libvirt HOST's qemu-img writes the flattened qcow2 directly to the
+// NFS export over libnfs (qemu's block-nfs driver), with no provider-pod hop and
+// no S3 client. This is the host-side `direct`-style transport that is natural
+// for NFS (the host already has the disk and NFS reachability). The destination
+// is the controller-built, C7'-hardened nfs:// URL.
+func (s *Server) exportDiskToNFS(ctx context.Context, req *providerv1.ExportDiskRequest) (*providerv1.ExportDiskResponse, error) {
+	libvirtProvider, ok := s.provider.(*Provider)
+	if !ok || libvirtProvider == nil || libvirtProvider.virshProvider == nil {
+		return nil, fmt.Errorf("libvirt provider not initialized")
+	}
+	vp := libvirtProvider.virshProvider
+	if !strings.Contains(vp.uri, "ssh://") {
+		return nil, fmt.Errorf("nfs export requires an ssh:// libvirt transport (host-side qemu-img → nfs://); got %q", vp.uri)
+	}
+
+	nfsURL := strings.TrimSpace(req.DestinationUrl)
+	if !strings.HasPrefix(nfsURL, "nfs://") {
+		return nil, fmt.Errorf("nfs export destination must be an nfs:// URL, got %q", nfsURL)
+	}
+
+	// Resolve the source disk path on the host.
+	diskInfo, err := libvirtProvider.GetDiskInfo(ctx, contracts.GetDiskInfoRequest{
+		VmId:       req.VmId,
+		DiskId:     req.DiskId,
+		SnapshotId: req.SnapshotId,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve source disk info: %w", err)
+	}
+	srcPath := diskInfo.Path
+	if srcPath == "" {
+		return nil, fmt.Errorf("source disk %q has no resolvable host path", req.DiskId)
+	}
+
+	log.Printf("INFO Exporting disk from libvirt host to NFS: backend=nfs vm=%s src=%s dest=%s",
+		req.VmId, srcPath, nfsURL)
+
+	// Flatten + write straight to the NFS export. -U reads a possibly-running
+	// source (crash-consistent; a consistent copy still needs power-off/snapshot
+	// first). qemu-img's libnfs driver performs the NFS write — no pod buffering.
+	if res, err := vp.runVirshCommand(ctx, "!", "qemu-img", "convert", "-U", "-f", "qcow2", "-O", "qcow2",
+		shellQuote(srcPath), shellQuote(nfsURL)); err != nil {
+		return nil, fmt.Errorf("host-side qemu-img convert to nfs failed: %w%s", err, qemuImgStderr(res))
+	}
+
+	log.Printf("INFO Source disk written to NFS export: dest=%s", nfsURL)
+
+	return &providerv1.ExportDiskResponse{
+		ExportId: fmt.Sprintf("export-libvirt-nfs-%s-%d", req.VmId, time.Now().Unix()),
+		// qemu-img does not emit a byte SHA256 over the libnfs write; NFS integrity
+		// is established by the target's `qemu-img check` on the converted qcow2
+		// (ADR-0006 Slice 4 — no in-stream checksum for the qemu-img transport).
+	}, nil
+}
+
+// importDiskFromNFS implements the ADR-0006 Slice 4 libvirt TARGET path: the
+// host's qemu-img reads the staged qcow2 directly from the NFS export over libnfs
+// and writes it into the target storage pool. No download, no pod staging.
+func (s *Server) importDiskFromNFS(ctx context.Context, req *providerv1.ImportDiskRequest) (*providerv1.ImportDiskResponse, error) {
+	libvirtProvider, ok := s.provider.(*Provider)
+	if !ok || libvirtProvider == nil || libvirtProvider.virshProvider == nil {
+		return nil, fmt.Errorf("libvirt provider not initialized")
+	}
+	vp := libvirtProvider.virshProvider
+	if !strings.Contains(vp.uri, "ssh://") {
+		return nil, fmt.Errorf("nfs import requires an ssh:// libvirt transport (host-side qemu-img from nfs://); got %q", vp.uri)
+	}
+
+	nfsURL := strings.TrimSpace(req.SourceUrl)
+	if !strings.HasPrefix(nfsURL, "nfs://") {
+		return nil, fmt.Errorf("nfs import source must be an nfs:// URL, got %q", nfsURL)
+	}
+
+	// Resolve the target pool and its host path.
+	poolName := "default"
+	if req.StorageHint != "" {
+		poolName = req.StorageHint
+	}
+	storageProvider := NewStorageProvider(vp)
+	if err := storageProvider.EnsureDefaultStoragePool(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ensure storage pool: %w", err)
+	}
+	poolInfo, err := storageProvider.GetPoolInfo(ctx, poolName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve target pool %q: %w", poolName, err)
+	}
+	if poolInfo.Path == "" {
+		return nil, fmt.Errorf("target pool %q has no resolvable host path", poolName)
+	}
+
+	volumeName := req.TargetName
+	if volumeName == "" {
+		volumeName = fmt.Sprintf("imported-disk-%d", time.Now().Unix())
+	}
+	volumeName = sanitizeVolumeName(volumeName)
+	poolPath := strings.TrimRight(poolInfo.Path, "/")
+	targetPath := fmt.Sprintf("%s/%s.qcow2", poolPath, volumeName)
+
+	log.Printf("INFO Importing disk from NFS to libvirt host: backend=nfs pool=%s volume=%s src=%s target=%s",
+		poolName, volumeName, nfsURL, targetPath)
+
+	// Read the staged qcow2 straight from NFS and write the pool volume.
+	if res, err := vp.runVirshCommand(ctx, "!", "qemu-img", "convert", "-f", "qcow2", "-O", "qcow2",
+		shellQuote(nfsURL), shellQuote(targetPath)); err != nil {
+		return nil, fmt.Errorf("host-side qemu-img convert from nfs failed: %w%s", err, qemuImgStderr(res))
+	}
+
+	// Validate the converted qcow2 (ADR-0006 D5 structural integrity for NFS).
+	if res, err := vp.runVirshCommand(ctx, "!", "qemu-img", "check", shellQuote(targetPath)); err != nil {
+		return nil, fmt.Errorf("qemu-img check failed on imported qcow2 %s: %w%s", targetPath, err, qemuImgStderr(res))
+	}
+
+	if _, err := vp.runVirshCommand(ctx, "pool-refresh", poolName); err != nil {
+		log.Printf("WARN pool-refresh failed after import (volume may still be usable by path): %v", err)
+	}
+
+	log.Printf("INFO NFS object imported to pool volume: target=%s", targetPath)
+
+	return &providerv1.ImportDiskResponse{
+		DiskId: volumeName,
+		Path:   targetPath,
+		Task:   nil,
+	}, nil
+}

--- a/internal/providers/libvirt/server.go
+++ b/internal/providers/libvirt/server.go
@@ -538,8 +538,8 @@ func (s *Server) GetCapabilities(ctx context.Context, req *providerv1.GetCapabil
 		// vmdk→qcow2 convert) and EXPORTS (host-side flatten to standalone qcow2 +
 		// stream) over pvc AND s3. Only the relay transfer mode is implemented;
 		// direct is not.
-		SupportedExportBackends: migration.PVCAndS3ExportBackends(),
-		SupportedImportBackends: migration.PVCAndS3ImportBackends(),
+		SupportedExportBackends: migration.PVCS3AndNFSExportBackends(),
+		SupportedImportBackends: migration.PVCS3AndNFSImportBackends(),
 		SupportedTransferModes:  migration.RelayOnlyTransferModes(),
 	}, nil
 }
@@ -553,11 +553,22 @@ func (s *Server) ExportDisk(ctx context.Context, req *providerv1.ExportDiskReque
 	// of Slice 1's vSphere→S3→libvirt). Accept pvc and s3; reject nfs/unknown
 	// honestly. Only the relay transfer mode is implemented; an explicit "direct"
 	// fails loudly (never a silent downgrade, ADR-0006 D2).
-	if err := migration.EnsurePVCOrS3Backend(req.BackendType); err != nil {
+	if err := migration.EnsurePVCS3OrNFSBackend(req.BackendType); err != nil {
 		return nil, err
 	}
-	if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
-		return nil, err
+	// Relay-mode enforcement applies to the s3 streaming path; the nfs transport
+	// is qemu-img-native (the host writes nfs:// directly via libnfs), so it is
+	// exempt from the relay/direct distinction (ADR-0006 Slice 4).
+	if req.BackendType != migration.BackendNFS {
+		if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
+			return nil, err
+		}
+	}
+
+	// NFS export: the host's qemu-img writes the flattened qcow2 straight to the
+	// nfs:// export (no pod hop, no S3 client).
+	if req.BackendType == migration.BackendNFS {
+		return s.exportDiskToNFS(ctx, req)
 	}
 
 	// S3 relay export: flatten the disk on the host and stream the standalone
@@ -631,11 +642,19 @@ func (s *Server) ImportDisk(ctx context.Context, req *providerv1.ImportDiskReque
 	// ADR-0006: libvirt is a TARGET for the S3 relay import (Slice 1). Accept pvc
 	// and s3; reject nfs/unknown honestly. Only the relay transfer mode is
 	// implemented; an explicit "direct" fails loudly.
-	if err := migration.EnsurePVCOrS3Backend(req.BackendType); err != nil {
+	if err := migration.EnsurePVCS3OrNFSBackend(req.BackendType); err != nil {
 		return nil, err
 	}
-	if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
-		return nil, err
+	if req.BackendType != migration.BackendNFS {
+		if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
+			return nil, err
+		}
+	}
+
+	// NFS import: the host's qemu-img reads the staged qcow2 straight from the
+	// nfs:// export and writes it into the target pool (ADR-0006 Slice 4).
+	if req.BackendType == migration.BackendNFS {
+		return s.importDiskFromNFS(ctx, req)
 	}
 
 	// S3 relay import: download from S3 and stream into host-side qemu-img

--- a/internal/providers/libvirt/server_test.go
+++ b/internal/providers/libvirt/server_test.go
@@ -115,10 +115,10 @@ func TestServer_GetCapabilities_StorageBackends(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, caps)
-	assert.Equal(t, []string{"pvc", "s3"}, caps.SupportedExportBackends,
-		"libvirt exports to pvc and s3 in Slice 2 (SOURCE of libvirt→S3→vSphere reverse relay)")
-	assert.Equal(t, []string{"pvc", "s3"}, caps.SupportedImportBackends,
-		"libvirt imports from pvc and s3 in Slice 1 (TARGET of vSphere→S3→libvirt)")
+	assert.Equal(t, []string{"pvc", "s3", "nfs"}, caps.SupportedExportBackends,
+		"libvirt exports to pvc, s3 and nfs (NFS qemu-img transport, ADR-0006 Slice 4)")
+	assert.Equal(t, []string{"pvc", "s3", "nfs"}, caps.SupportedImportBackends,
+		"libvirt imports from pvc, s3 and nfs (NFS qemu-img transport, ADR-0006 Slice 4)")
 	assert.Equal(t, []string{"relay"}, caps.SupportedTransferModes)
 }
 
@@ -176,18 +176,41 @@ func TestServer_ImportDisk_DirectModeRejected(t *testing.T) {
 		"explicit direct mode must fail loudly (ADR-0006 D2)")
 }
 
-// TestServer_ImportDisk_NFSBackendUnimplemented verifies nfs is still rejected
-// with Unimplemented on the import path (only pvc/s3 are implemented).
-func TestServer_ImportDisk_NFSBackendUnimplemented(t *testing.T) {
+// TestServer_ImportDisk_NFSBackendPassesGate verifies that, as of ADR-0006 Slice
+// 4, an ImportDisk naming the nfs backend now PASSES the backend gate and is
+// exempt from the relay-mode gate (NFS uses qemu-img's native nfs:// transport),
+// failing LATER at the nil-provider check inside importDiskFromNFS — NOT with
+// codes.Unimplemented. Inversion of the old "nfs rejected" assertion.
+func TestServer_ImportDisk_NFSBackendPassesGate(t *testing.T) {
 	s := &Server{}
 
 	_, importErr := s.ImportDisk(context.Background(), &providerv1.ImportDiskRequest{
-		SourceUrl:   "nfs://server/export/disk",
+		SourceUrl:   "nfs://server/export/disk.qcow2",
 		BackendType: "nfs",
 	})
 	require.Error(t, importErr)
-	assert.Equal(t, codes.Unimplemented, status.Code(importErr),
-		"nfs import is not yet implemented (ADR-0006 Slice 4)")
+	assert.NotEqual(t, codes.Unimplemented, status.Code(importErr),
+		"libvirt ImportDisk must NOT reject nfs in Slice 4: the NFS qemu-img import is implemented")
+	assert.Contains(t, importErr.Error(), "not initialized",
+		"nfs import must pass the gate and fail later at the nil-provider check")
+}
+
+// TestServer_ExportDisk_NFSBackendPassesGate is the export-side sibling: nfs
+// export passes the gate (and the relay-mode exemption) and fails at the
+// nil-provider check, not with Unimplemented.
+func TestServer_ExportDisk_NFSBackendPassesGate(t *testing.T) {
+	s := &Server{}
+
+	_, exportErr := s.ExportDisk(context.Background(), &providerv1.ExportDiskRequest{
+		VmId:           "vm-1",
+		DestinationUrl: "nfs://server/export/disk.qcow2",
+		BackendType:    "nfs",
+	})
+	require.Error(t, exportErr)
+	assert.NotEqual(t, codes.Unimplemented, status.Code(exportErr),
+		"libvirt ExportDisk must NOT reject nfs in Slice 4")
+	assert.Contains(t, exportErr.Error(), "not initialized",
+		"nfs export must pass the gate and fail later at the nil-provider check")
 }
 
 // fakeDiskProvider is a minimal contracts.Provider used to exercise the Server's

--- a/internal/storage/migration/backend.go
+++ b/internal/storage/migration/backend.go
@@ -77,6 +77,27 @@ func PVCAndS3ExportBackends() []string { return []string{BackendPVC, BackendS3} 
 // libvirt provider as the TARGET in ADR-0006 Slice 1 (vSphere → S3 → libvirt).
 func PVCAndS3ImportBackends() []string { return []string{BackendPVC, BackendS3} }
 
+// PVCS3AndNFSExportBackends is the honest export-backend set for a provider that
+// implements the legacy pvc path, the S3 relay export, AND the NFS qemu-img
+// export (ADR-0006 Slice 4). Used by the vSphere/libvirt providers once NFS is
+// wired.
+func PVCS3AndNFSExportBackends() []string { return []string{BackendPVC, BackendS3, BackendNFS} }
+
+// PVCS3AndNFSImportBackends is the honest import-backend set for a provider that
+// implements the legacy pvc path, the S3 relay import, AND the NFS qemu-img
+// import (ADR-0006 Slice 4).
+func PVCS3AndNFSImportBackends() []string { return []string{BackendPVC, BackendS3, BackendNFS} }
+
+// S3AndNFSExportBackends is the honest export-backend set for a provider whose
+// only working transfers are S3 and NFS (no legacy pvc path). Used by the
+// Proxmox provider once NFS is wired (its disks live on the PVE node; both S3 and
+// NFS run host/node-side via qemu-img).
+func S3AndNFSExportBackends() []string { return []string{BackendS3, BackendNFS} }
+
+// S3AndNFSImportBackends is the honest import-backend set for an S3+NFS provider
+// (the Proxmox TARGET).
+func S3AndNFSImportBackends() []string { return []string{BackendS3, BackendNFS} }
+
 // S3OnlyExportBackends is the honest export-backend set for a provider whose
 // only working transfer is S3. The Proxmox provider uses this: its disks live on
 // the PVE node and the provider pod is the S3 client (bytes flow node ↔ pod ↔ S3
@@ -136,5 +157,33 @@ func EnsurePVCOrS3Backend(backendType string) error {
 	default:
 		return status.Errorf(codes.Unimplemented,
 			"backend %q not yet supported on this provider/direction (ADR-0006)", backendType)
+	}
+}
+
+// EnsurePVCS3OrNFSBackend accepts pvc, s3, and nfs (and empty = legacy pvc).
+// Providers that implement the legacy pvc path, the S3 relay path, AND the NFS
+// qemu-img path (vSphere, libvirt) call this so nfs is accepted while unknown
+// backends still fail honestly (ADR-0006 Slice 4).
+func EnsurePVCS3OrNFSBackend(backendType string) error {
+	switch backendType {
+	case "", BackendPVC, BackendS3, BackendNFS:
+		return nil
+	default:
+		return status.Errorf(codes.Unimplemented,
+			"backend %q not yet supported on this provider/direction (ADR-0006)", backendType)
+	}
+}
+
+// EnsureS3OrNFSBackend accepts only s3 and nfs (no legacy pvc). The Proxmox
+// provider uses this: its disks live on the PVE node, so the pod-mounted pvc
+// path can never work, but both the S3 relay and the NFS qemu-img paths run
+// node-side (ADR-0006 Slice 4).
+func EnsureS3OrNFSBackend(backendType string) error {
+	switch backendType {
+	case BackendS3, BackendNFS:
+		return nil
+	default:
+		return status.Errorf(codes.Unimplemented,
+			"backend %q not supported on this provider; only s3 and nfs are implemented (ADR-0006)", backendType)
 	}
 }

--- a/internal/storage/migration/backend_nfs_test.go
+++ b/internal/storage/migration/backend_nfs_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import "testing"
+
+func TestEnsurePVCS3OrNFSBackend(t *testing.T) {
+	for _, b := range []string{"", BackendPVC, BackendS3, BackendNFS} {
+		if err := EnsurePVCS3OrNFSBackend(b); err != nil {
+			t.Errorf("EnsurePVCS3OrNFSBackend(%q) = %v, want nil", b, err)
+		}
+	}
+	if err := EnsurePVCS3OrNFSBackend("gluster"); err == nil {
+		t.Error("EnsurePVCS3OrNFSBackend(gluster) = nil, want error")
+	}
+}
+
+func TestEnsureS3OrNFSBackend(t *testing.T) {
+	for _, b := range []string{BackendS3, BackendNFS} {
+		if err := EnsureS3OrNFSBackend(b); err != nil {
+			t.Errorf("EnsureS3OrNFSBackend(%q) = %v, want nil", b, err)
+		}
+	}
+	// pvc and empty (legacy pvc) are NOT accepted for an S3/NFS-only provider.
+	for _, b := range []string{"", BackendPVC, "gluster"} {
+		if err := EnsureS3OrNFSBackend(b); err == nil {
+			t.Errorf("EnsureS3OrNFSBackend(%q) = nil, want error", b)
+		}
+	}
+}
+
+func TestNFSBackendSets(t *testing.T) {
+	if got := PVCS3AndNFSExportBackends(); len(got) != 3 || got[0] != BackendPVC || got[1] != BackendS3 || got[2] != BackendNFS {
+		t.Errorf("PVCS3AndNFSExportBackends() = %v", got)
+	}
+	if got := PVCS3AndNFSImportBackends(); len(got) != 3 || got[2] != BackendNFS {
+		t.Errorf("PVCS3AndNFSImportBackends() = %v", got)
+	}
+	if got := S3AndNFSExportBackends(); len(got) != 2 || got[0] != BackendS3 || got[1] != BackendNFS {
+		t.Errorf("S3AndNFSExportBackends() = %v", got)
+	}
+	if got := S3AndNFSImportBackends(); len(got) != 2 || got[0] != BackendS3 || got[1] != BackendNFS {
+		t.Errorf("S3AndNFSImportBackends() = %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Third NFS slice (after coords #270 + controller #271): the **first provider** wired for the `nfs` backend — **libvirt**. The libvirt host's `qemu-img` writes/reads the staged qcow2 **directly to/from the `nfs://` export over libnfs** (qemu's `block-nfs` driver), with no provider-pod hop, no S3 client, and no host temp file.

### What's wired
- **`internal/providers/libvirt/nfs.go`** — `exportDiskToNFS` / `importDiskFromNFS`:
  - export: `qemu-img convert -U -f qcow2 -O qcow2 <host-vol> <nfs://…>` (the host flattens straight to NFS);
  - import: `qemu-img convert -f qcow2 -O qcow2 <nfs://…> <pool-vol>` then `qemu-img check`.
  - Reuses the existing SSH transport + `GetDiskInfo`/pool-resolution helpers.
- **`libvirt/server.go`** — `ExportDisk`/`ImportDisk` accept `nfs` (`EnsurePVCS3OrNFSBackend`) and **exempt it from the relay-mode gate** (NFS isn't relay — it's qemu-img-native); `GetCapabilities` now advertises `nfs` for both export and import.
- **`migration/backend.go`** — NFS-inclusive helpers: `EnsurePVCS3OrNFSBackend`, `EnsureS3OrNFSBackend` (proxmox), `PVCS3AndNFS{Export,Import}Backends`, `S3AndNFS{Export,Import}Backends`.

### Integrity note
qemu-img emits no in-stream byte SHA256 over the libnfs write, so NFS integrity for this transport is established by the **target-side `qemu-img check`** on the converted qcow2 (ADR-0006 Slice 4). Documented.

### Tests
- Flipped the libvirt "nfs Unimplemented" tests to "nfs passes the gate" (export + import now route to the NFS path and fail only at the nil-provider check, not `Unimplemented`); updated `GetCapabilities` to expect `[pvc, s3, nfs]`.
- `internal/storage/migration/backend_nfs_test.go` — the new gate + advertisement helpers.
- `make fmt` clean · lint 0 · libvirt + migration suites green · `make build` green.

## Next
Proxmox (node-side `qemu-img nfs://`) and vSphere (pod-side + `qemu-block-extra` image) providers, then lab validation against the OMS server (`172.16.56.13:/export/virtrigaud`) + the C6 export-hardening/cleartext docs.

## Impact
- [ ] Breaking change
- [x] Requires cluster rollout (libvirt provider image)

Refs #236.