### PR TITLE
feat(proxmox): NFS migration via node-side qemu-img nfs:// (ADR-0006 Slice 4, #236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-21 09:30] - feat(proxmox): NFS migration via node-side qemu-img nfs:// (ADR-0006 Slice 4, #236)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/proxmox/nfs.go` (new): `exportDiskToNFS` / `importDiskFromNFS`. The PVE NODE's `qemu-img` writes/reads the staged qcow2 **directly to/from the `nfs://` export over libnfs** (qemu's `block-nfs` driver) — no provider-pod hop, no S3 client. Export resolves the on-node disk path (`pvesm path`) and flattens straight to `nfs://` (reusing the tested `buildExportFlattenCommand` argv builder); import converts `nfs://` → a node-local stage file (new `buildNFSImportConvertCommand`) + `qemu-img check`, which the Create path then feeds to `qm importdisk` (Proxmox cannot `importdisk` an `nfs://` URL directly).
+- `internal/providers/proxmox/capabilities.go`: `GetCapabilities` now advertises `nfs` alongside `s3` in the export/import backends (`migration.S3AndNFS*`).
+
+### Changed
+- `internal/providers/proxmox/server.go`: `ExportDisk`/`ImportDisk` now gate on `migration.EnsureS3OrNFSBackend` (was `EnsurePVCOrS3Backend`) — this **accepts `nfs`, keeps `s3`, and now rejects `pvc`**, aligning the gate with Proxmox's long-standing honest advertisement (its disks live on the node, so the pod-mounted pvc path can never work). `nfs` is **exempt from the relay-mode gate** (it runs node-side, not relay); the `s3` path keeps its relay-only enforcement.
+
+### Why
+Second provider of the NFS backend (ADR-0006 Slice 4). Proxmox now advertises and serves `nfs` as both source and target over the node-side qemu-img transport, mirroring the libvirt host-side model. With libvirt + Proxmox both serving `nfs`, the first end-to-end NFS migration paths are now wireable. NFS integrity for this transport is the node-side `qemu-img check` (qemu-img emits no in-stream byte checksum). vSphere (pod-side) follows next; lab validation against the OMS server comes after.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (proxmox provider image)
+- [ ] Config change only
+
 ## [2026-06-19 14:15] - feat(libvirt): NFS migration via host-side qemu-img nfs:// (ADR-0006 Slice 4, #236)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/proxmox/capabilities.go
+++ b/internal/providers/proxmox/capabilities.go
@@ -42,14 +42,18 @@ func GetProviderCapabilities() *capabilities.Manager {
 		DiskExport("qcow2", "raw", "vmdk").
 		ExportCompression().
 		DiskImport("qcow2", "raw", "vmdk").
-		// ADR-0006: only the S3 relay data path is real for Proxmox — bytes flow
-		// node ↔ provider-pod ↔ S3 over SSH (the pod is the S3 client). The legacy
-		// pvc path (storage_helper.go) does os.Open on node-local image paths,
-		// which a remote provider pod can never reach, so pvc is NOT advertised
-		// (advertising it lets a migration select a backend that always fails).
-		// nfs and direct transfer remain unimplemented, so they are not advertised.
-		ExportBackends(migration.S3OnlyExportBackends()...).
-		ImportBackends(migration.S3OnlyImportBackends()...).
+		// ADR-0006: two real data paths for Proxmox, both node-side. (1) The S3
+		// relay — bytes flow node ↔ provider-pod ↔ S3 over SSH (the pod is the S3
+		// client). (2) The NFS qemu-img path (Slice 4) — the node's qemu-img reads/
+		// writes nfs:// directly over libnfs, no pod hop. The legacy pvc path
+		// (storage_helper.go) does os.Open on node-local image paths, which a
+		// remote provider pod can never reach, so pvc is NOT advertised (advertising
+		// it lets a migration select a backend that always fails).
+		ExportBackends(migration.S3AndNFSExportBackends()...).
+		ImportBackends(migration.S3AndNFSImportBackends()...).
+		// NFS runs node-side ("direct"-shaped), but the controller treats nfs's
+		// transfer mode as informational and exempts it from the relay check, so
+		// advertising relay (for the S3 path) remains accurate.
 		TransferModes(migration.RelayOnlyTransferModes()...).
 		DiskTypes("raw", "qcow2").
 		NetworkTypes("bridge", "vlan").

--- a/internal/providers/proxmox/nfs.go
+++ b/internal/providers/proxmox/nfs.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+	"github.com/projectbeskar/virtrigaud/sdk/provider/errors"
+)
+
+// exportDiskToNFS implements the ADR-0006 Slice 4 Proxmox SOURCE path for the NFS
+// backend: the PVE NODE's qemu-img flattens the source disk and writes the
+// resulting qcow2 directly to the NFS export over libnfs (qemu's block-nfs
+// driver), with no provider-pod hop and no S3 client. This mirrors the libvirt
+// host-side NFS export — the node already has the disk and NFS reachability, so
+// the bytes never transit the pod (unlike the S3 relay). The destination is the
+// controller-built, C7'-hardened nfs:// URL.
+func (p *Provider) exportDiskToNFS(ctx context.Context, req *providerv1.ExportDiskRequest) (*providerv1.ExportDiskResponse, error) {
+	if p.client == nil {
+		return nil, errors.NewUnavailable("PVE client not configured", nil)
+	}
+	if p.ssh == nil {
+		return nil, errors.NewUnavailable("migration SSH data plane not configured (set PROVIDER_ENDPOINT and SSH credentials)", nil)
+	}
+
+	nfsURL := strings.TrimSpace(req.DestinationUrl)
+	if !strings.HasPrefix(nfsURL, "nfs://") {
+		return nil, errors.NewInvalidSpec("nfs export destination must be an nfs:// URL, got %q", nfsURL)
+	}
+
+	// Resolve the disk's PVE storage:volid via GetDiskInfo (returns it in Path).
+	diskInfo, err := p.GetDiskInfo(ctx, &providerv1.GetDiskInfoRequest{
+		VmId:       req.VmId,
+		DiskId:     req.DiskId,
+		SnapshotId: req.SnapshotId,
+	})
+	if err != nil {
+		return nil, errors.NewInternal("failed to get disk info for nfs export", err)
+	}
+	volid := strings.TrimSpace(diskInfo.Path)
+	if volid == "" {
+		return nil, errors.NewInvalidSpec("source disk %q has no resolvable storage volume", req.DiskId)
+	}
+	srcFormat := diskInfo.Format
+	if srcFormat == "" {
+		srcFormat = "qcow2"
+	}
+
+	// Resolve the real on-node filesystem path from the volid via `pvesm path`.
+	srcPath, err := p.resolveNodeDiskPath(ctx, volid)
+	if err != nil {
+		return nil, errors.NewInternal("failed to resolve on-node disk path", err)
+	}
+
+	// Never log credentials — only the backend, volid, paths.
+	p.logger.Info("Exporting disk from Proxmox node to NFS",
+		"backend", req.BackendType, "vm", req.VmId, "volid", volid, "src_path", srcPath,
+		"destination", nfsURL)
+
+	// Flatten + write straight to the NFS export via the node's qemu-img (libnfs).
+	// Reuse the tested S3-export flatten builder: it emits `qemu-img convert -U -f
+	// <srcFormat> -O qcow2 '<src>' '<dst>'` with both operands shell-quoted — the
+	// destination being an nfs:// URL instead of a node temp is immaterial to the
+	// builder, and we inherit its quoting guarantee for the security-sensitive URL.
+	// -U reads a possibly-running source (crash-consistent; a consistent copy still
+	// needs power-off/snapshot first). No hostTmp, no pod buffering — qemu-img's
+	// block-nfs driver performs the NFS write directly. Compression stays off: the
+	// target qcow2 lands on the NFS export for the peer to read, not a local cache.
+	convertCmd := buildExportFlattenCommand(srcFormat, srcPath, nfsURL, false)
+	if _, stderr, err := p.ssh.runSSH(ctx, convertCmd); err != nil {
+		return nil, errors.NewInternal(
+			fmt.Sprintf("node-side qemu-img convert to nfs failed (stderr: %s)", strings.TrimSpace(stderr)), err)
+	}
+
+	p.logger.Info("Source disk written to NFS export", "destination", nfsURL)
+
+	return &providerv1.ExportDiskResponse{
+		ExportId: fmt.Sprintf("export-proxmox-nfs-%s-%d", sanitizeProxmoxName(req.VmId), time.Now().Unix()),
+		// qemu-img does not emit a byte SHA256 over the libnfs write; NFS integrity
+		// is established by the target's `qemu-img check` on the converted qcow2
+		// (ADR-0006 Slice 4 — no in-stream checksum for the qemu-img transport).
+	}, nil
+}
+
+// importDiskFromNFS implements the ADR-0006 Slice 4 Proxmox TARGET path: the PVE
+// node's qemu-img reads the staged qcow2 directly from the NFS export over libnfs
+// and writes it to a node-local stage file, which the Proxmox Create path then
+// feeds to `qm importdisk` (Proxmox cannot importdisk an nfs:// URL directly — it
+// takes a local file). No download via the pod, no S3 client; the bytes flow
+// NFS → node, not NFS → pod → node.
+func (p *Provider) importDiskFromNFS(ctx context.Context, req *providerv1.ImportDiskRequest) (*providerv1.ImportDiskResponse, error) {
+	if p.client == nil {
+		return nil, errors.NewUnavailable("PVE client not configured", nil)
+	}
+	if p.ssh == nil {
+		return nil, errors.NewUnavailable("migration SSH data plane not configured (set PROVIDER_ENDPOINT and SSH credentials)", nil)
+	}
+
+	nfsURL := strings.TrimSpace(req.SourceUrl)
+	if !strings.HasPrefix(nfsURL, "nfs://") {
+		return nil, errors.NewInvalidSpec("nfs import source must be an nfs:// URL, got %q", nfsURL)
+	}
+
+	// NFS always stages qcow2 (the controller derives import format qcow2 for the
+	// nfs backend; the source provider's export wrote qcow2 to the export).
+	id := sanitizeProxmoxName(req.TargetName)
+	if req.TargetName == "" {
+		id = fmt.Sprintf("imported-disk-%d", time.Now().Unix())
+	}
+	stagePath := proxmoxImportStagePath(id, "qcow2")
+
+	// Never log credentials — only the paths.
+	p.logger.Info("Importing disk from NFS to Proxmox node (stage for qm importdisk at Create)",
+		"id", id, "source", nfsURL, "stage_path", stagePath, "storage_hint", req.StorageHint)
+
+	// Read the staged qcow2 straight from NFS and write the node-local stage file.
+	// `qm importdisk` (run by the Create path) needs a local file, not an nfs:// URL.
+	convertCmd := buildNFSImportConvertCommand(nfsURL, stagePath)
+	if _, stderr, err := p.ssh.runSSH(ctx, convertCmd); err != nil {
+		p.cleanupNodeFile(stagePath)
+		return nil, errors.NewInternal(
+			fmt.Sprintf("node-side qemu-img convert from nfs failed (stderr: %s)", strings.TrimSpace(stderr)), err)
+	}
+
+	// Validate the staged qcow2 on the node (ADR-0006 D5 structural integrity for
+	// NFS — there is no in-stream byte checksum from qemu-img).
+	if _, stderr, err := p.ssh.runSSH(ctx, fmt.Sprintf("qemu-img check %s", proxmoxShellQuote(stagePath))); err != nil {
+		p.cleanupNodeFile(stagePath)
+		return nil, errors.NewInternal(
+			fmt.Sprintf("qemu-img check failed on staged qcow2 %s (stderr: %s)", stagePath, strings.TrimSpace(stderr)), err)
+	}
+
+	p.logger.Info("Disk import from NFS staged on node (awaiting Create → qm importdisk)",
+		"id", id, "stage_path", stagePath)
+
+	// The disk is staged on the node. The Proxmox Create path consumes it via
+	// attachImportedDisk (qm importdisk into the freshly-created VM).
+	return &providerv1.ImportDiskResponse{
+		DiskId: id,
+		Path:   stagePath,
+		Task:   nil, // synchronous
+		// No ActualSizeBytes/Checksum: qemu-img emits no byte SHA256 over the libnfs
+		// read; integrity is the node-side qemu-img check above (ADR-0006 Slice 4).
+	}, nil
+}
+
+// buildNFSImportConvertCommand builds the node-side qemu-img argv that reads the
+// staged qcow2 from the nfs:// source and writes the node-local stage file for
+// `qm importdisk`. The source is a static staged file (not a running disk), so no
+// -U is needed; both the nfs:// URL and the stage path are shell-quoted (the URL
+// is security-sensitive — it is C7'-hardened by the controller, and this is the
+// single place its node-side quoting is pinned).
+func buildNFSImportConvertCommand(nfsURL, stagePath string) string {
+	return fmt.Sprintf("qemu-img convert -f qcow2 -O qcow2 %s %s",
+		proxmoxShellQuote(nfsURL), proxmoxShellQuote(stagePath))
+}

--- a/internal/providers/proxmox/provider_test.go
+++ b/internal/providers/proxmox/provider_test.go
@@ -280,15 +280,16 @@ func TestProxmoxProvider_GetCapabilities(t *testing.T) {
 	// `-c` for qcow2 targets (#219), so compression is advertised.
 	assert.True(t, resp.SupportsExportCompression, "Proxmox ExportDisk compresses qcow2 targets when Compress=true (#219)")
 
-	// ADR-0006: Proxmox advertises ONLY the S3 relay data path. The legacy pvc
-	// path does os.Open on node-local image paths the provider pod can't reach,
-	// so advertising pvc would be dishonest (#261 P0-3). nfs/direct unimplemented.
-	assert.Equal(t, []string{"s3"}, resp.SupportedExportBackends,
-		"Proxmox advertises s3-only export backend (pvc is not reachable off-node)")
-	assert.Equal(t, []string{"s3"}, resp.SupportedImportBackends,
-		"Proxmox advertises s3-only import backend (pvc is not reachable off-node)")
+	// ADR-0006: Proxmox advertises the S3 relay AND the NFS qemu-img data paths,
+	// both node-side (Slice 4). The legacy pvc path does os.Open on node-local
+	// image paths the provider pod can't reach, so advertising pvc would be
+	// dishonest (#261 P0-3); pvc stays excluded.
+	assert.Equal(t, []string{"s3", "nfs"}, resp.SupportedExportBackends,
+		"Proxmox advertises s3+nfs export backends (pvc is not reachable off-node)")
+	assert.Equal(t, []string{"s3", "nfs"}, resp.SupportedImportBackends,
+		"Proxmox advertises s3+nfs import backends (pvc is not reachable off-node)")
 	assert.Equal(t, []string{"relay"}, resp.SupportedTransferModes,
-		"the s3 path is relay-shaped (bytes flow node ↔ pod ↔ backend)")
+		"the s3 path is relay-shaped; nfs runs node-side and is exempt from the relay check")
 }
 
 func TestExportNeedsConversion(t *testing.T) {

--- a/internal/providers/proxmox/s3_test.go
+++ b/internal/providers/proxmox/s3_test.go
@@ -79,6 +79,20 @@ func TestBuildExportFlattenCommand(t *testing.T) {
 	})
 }
 
+// TestBuildNFSImportConvertCommand pins the node-side qemu-img argv that reads the
+// staged qcow2 from nfs:// into the node stage file: -f qcow2 -O qcow2, no -U
+// (static source), with both the nfs:// URL and the stage path shell-quoted so a
+// crafted URL cannot break out of the argument.
+func TestBuildNFSImportConvertCommand(t *testing.T) {
+	cmd := buildNFSImportConvertCommand(
+		"nfs://172.16.56.13/export/virtrigaud/vmmigrations/ns/web/import.qcow2",
+		"/var/tmp/.virtrigaud-import-web.qcow2")
+	assert.Equal(t,
+		"qemu-img convert -f qcow2 -O qcow2 'nfs://172.16.56.13/export/virtrigaud/vmmigrations/ns/web/import.qcow2' '/var/tmp/.virtrigaud-import-web.qcow2'",
+		cmd)
+	assert.NotContains(t, cmd, " -U ", "import source is a static staged file; -U is not needed")
+}
+
 // TestProxmoxExportStagePath asserts the export stage path is in the staging dir,
 // dot-prefixed and qcow2-suffixed, and sanitizes path separators out of the VM id
 // so it cannot escape the directory.
@@ -170,32 +184,43 @@ func s3GRPCCode(t *testing.T, err error) codes.Code {
 	return st.Code()
 }
 
-// TestExportDisk_NFSBackendRejected verifies the dispatch still rejects an
-// unimplemented backend (nfs) honestly, even though s3 is now accepted.
-func TestExportDisk_NFSBackendRejected(t *testing.T) {
+// TestExportDisk_NFSBackendPassesGate verifies the nfs backend is now accepted by
+// the dispatch (ADR-0006 Slice 4) and reaches the node-side data plane: with no
+// SSH transport it returns Unavailable, NOT the Unimplemented it returned before
+// the NFS provider existed. This proves the gate routes nfs to exportDiskToNFS.
+func TestExportDisk_NFSBackendPassesGate(t *testing.T) {
 	_, endpoint, err := pvefake.StartFakeServer()
 	require.NoError(t, err)
 	provider := createTestProvider(endpoint)
+	provider.ssh = nil // token-only deployment: data plane unavailable
 
 	_, err = provider.ExportDisk(context.Background(), &providerv1.ExportDiskRequest{
-		VmId:        "100",
-		BackendType: "nfs",
+		VmId:           "100",
+		BackendType:    "nfs",
+		DestinationUrl: "nfs://172.16.56.13/export/virtrigaud/vmmigrations/ns/web/export.qcow2",
 	})
-	assert.Equal(t, codes.Unimplemented, s3GRPCCode(t, err),
-		"nfs export backend is not implemented and must be rejected")
+	assert.NotEqual(t, codes.Unimplemented, s3GRPCCode(t, err),
+		"nfs export backend is implemented and must pass the gate")
+	assert.Equal(t, codes.Unavailable, s3GRPCCode(t, err),
+		"nfs export with no SSH data plane must return Unavailable")
 }
 
-// TestImportDisk_NFSBackendRejected mirrors the export rejection for import.
-func TestImportDisk_NFSBackendRejected(t *testing.T) {
+// TestImportDisk_NFSBackendPassesGate mirrors the export gate-pass for import.
+func TestImportDisk_NFSBackendPassesGate(t *testing.T) {
 	_, endpoint, err := pvefake.StartFakeServer()
 	require.NoError(t, err)
 	provider := createTestProvider(endpoint)
+	provider.ssh = nil
 
 	_, err = provider.ImportDisk(context.Background(), &providerv1.ImportDiskRequest{
 		BackendType: "nfs",
+		TargetName:  "web-migrated",
+		SourceUrl:   "nfs://172.16.56.13/export/virtrigaud/vmmigrations/ns/web/import.qcow2",
 	})
-	assert.Equal(t, codes.Unimplemented, s3GRPCCode(t, err),
-		"nfs import backend is not implemented and must be rejected")
+	assert.NotEqual(t, codes.Unimplemented, s3GRPCCode(t, err),
+		"nfs import backend is implemented and must pass the gate")
+	assert.Equal(t, codes.Unavailable, s3GRPCCode(t, err),
+		"nfs import with no SSH data plane must return Unavailable")
 }
 
 // TestExportDisk_S3NoSSHTransport verifies that an s3 export on a provider with no

--- a/internal/providers/proxmox/server.go
+++ b/internal/providers/proxmox/server.go
@@ -1437,16 +1437,26 @@ func exportNeedsConversion(sourceFormat, targetFormat string, compress bool) boo
 
 // ExportDisk exports a VM disk for migration
 func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskRequest) (*providerv1.ExportDiskResponse, error) {
-	// ADR-0006: accept the legacy pvc path and the S3 relay path; reject nfs and
-	// unknown backends honestly instead of silently falling through to pvc.
-	if err := migration.EnsurePVCOrS3Backend(req.BackendType); err != nil {
+	// ADR-0006: Proxmox disks live on the PVE node, so the pod-mounted pvc path can
+	// never work; accept only the S3 relay and the NFS qemu-img paths (both run
+	// node-side) and reject pvc/unknown backends honestly (Slice 4).
+	if err := migration.EnsureS3OrNFSBackend(req.BackendType); err != nil {
 		return nil, err
 	}
-	// Proxmox advertises relay-only transfer (RelayOnlyTransferModes); reject a
-	// `direct` request loudly instead of silently running it as relay (#261 P1-3,
-	// ADR-0006 D2). Mirrors the libvirt provider.
-	if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
-		return nil, err
+	// Proxmox's S3 path advertises relay-only transfer (RelayOnlyTransferModes);
+	// reject a `direct` request loudly instead of silently running it as relay
+	// (#261 P1-3, ADR-0006 D2). NFS is host/node-side by nature (the node's
+	// qemu-img writes nfs:// directly), so it is exempt from the relay check.
+	if req.BackendType != migration.BackendNFS {
+		if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
+			return nil, err
+		}
+	}
+
+	// ADR-0006 Slice 4 Proxmox SOURCE path: the node's qemu-img writes the
+	// flattened qcow2 straight to the NFS export (libnfs), no pod hop.
+	if req.BackendType == migration.BackendNFS {
+		return p.exportDiskToNFS(ctx, req)
 	}
 
 	// ADR-0006 Proxmox SOURCE path: stream the node disk to S3 over SSH.
@@ -1654,16 +1664,26 @@ func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskReq
 
 // ImportDisk imports a disk from an external source
 func (p *Provider) ImportDisk(ctx context.Context, req *providerv1.ImportDiskRequest) (*providerv1.ImportDiskResponse, error) {
-	// ADR-0006: accept the legacy pvc path and the S3 relay path; reject nfs and
-	// unknown backends honestly instead of silently falling through to pvc.
-	if err := migration.EnsurePVCOrS3Backend(req.BackendType); err != nil {
+	// ADR-0006: Proxmox disks live on the PVE node, so the pod-mounted pvc path can
+	// never work; accept only the S3 relay and the NFS qemu-img paths (both run
+	// node-side) and reject pvc/unknown backends honestly (Slice 4).
+	if err := migration.EnsureS3OrNFSBackend(req.BackendType); err != nil {
 		return nil, err
 	}
-	// Proxmox advertises relay-only transfer (RelayOnlyTransferModes); reject a
-	// `direct` request loudly instead of silently running it as relay (#261 P1-3,
-	// ADR-0006 D2). Mirrors the libvirt provider.
-	if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
-		return nil, err
+	// Proxmox's S3 path advertises relay-only transfer (RelayOnlyTransferModes);
+	// reject a `direct` request loudly instead of silently running it as relay
+	// (#261 P1-3, ADR-0006 D2). NFS is host/node-side by nature (the node's
+	// qemu-img reads nfs:// directly), so it is exempt from the relay check.
+	if req.BackendType != migration.BackendNFS {
+		if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
+			return nil, err
+		}
+	}
+
+	// ADR-0006 Slice 4 Proxmox TARGET path: the node's qemu-img reads the staged
+	// qcow2 from the NFS export and writes a node-local stage file for qm importdisk.
+	if req.BackendType == migration.BackendNFS {
+		return p.importDiskFromNFS(ctx, req)
 	}
 
 	// ADR-0006 Proxmox TARGET path: stage the S3 qcow2 on the node and return its


### PR DESCRIPTION
## What

Second provider of the **NFS staging backend** (ADR-0006 Slice 4), mirroring the libvirt host-side model ([#272](https://github.com/projectbeskar/virtrigaud/pull/272)). The **PVE node's `qemu-img`** writes/reads the staged qcow2 **directly to/from the `nfs://` export over libnfs** (qemu's `block-nfs` driver) — no provider-pod hop, no S3 client.

## How

- **`internal/providers/proxmox/nfs.go`** (new):
  - `exportDiskToNFS` — resolves the on-node disk path (`pvesm path` via `resolveNodeDiskPath`) and flattens straight to the controller-built, C7'-hardened `nfs://` URL, reusing the existing **tested** `buildExportFlattenCommand` argv builder (`qemu-img convert -U -f <fmt> -O qcow2 '<src>' '<nfs://…>'`).
  - `importDiskFromNFS` — converts `nfs://` → a node-local stage file (new pinned `buildNFSImportConvertCommand`) + `qemu-img check`, which the Create path then feeds to `qm importdisk` (Proxmox cannot `importdisk` an `nfs://` URL directly — it needs a local file).
- **`server.go`** — `ExportDisk`/`ImportDisk` gate switched `EnsurePVCOrS3Backend` → **`EnsureS3OrNFSBackend`**: accepts `nfs`, keeps `s3`, and now **rejects `pvc`** (aligning the gate with Proxmox's long-standing honest advertisement — its disks live on the node, so the pod-mounted pvc path can never work). `nfs` is **exempt from the relay-mode gate** (node-side transport); the `s3` path keeps relay-only enforcement.
- **`capabilities.go`** — advertises `nfs` alongside `s3` (`S3AndNFS*`).

## Tests

- `TestExportDisk_NFSBackendPassesGate` / `TestImportDisk_NFSBackendPassesGate` — flipped from the old `Unimplemented`-rejected assertions: `nfs` now passes the gate and reaches the node-side data plane (returns `Unavailable` with no SSH transport, **not** `Unimplemented`).
- `GetCapabilities` test asserts `[s3, nfs]` export/import backends.
- `TestBuildNFSImportConvertCommand` pins the import argv + shell-quoting of the security-sensitive `nfs://` URL.

Gate: `gofmt` clean, `golangci-lint` 0 issues, `go build ./...` OK, proxmox package tests pass.

## Integrity

NFS integrity for the qemu-img transport is the node-side `qemu-img check` on the converted qcow2 (qemu-img emits no in-stream byte checksum — same posture as libvirt NFS).

## Next

vSphere (pod-side `qemu-img nfs://` + `qemu-block-extra` image) provider, then lab validation against the OMS server (`172.16.56.13:/export/virtrigaud`) — with libvirt + Proxmox both serving `nfs`, the first end-to-end NFS paths are now wireable — followed by the C6 export-hardening/cleartext docs.

Refs #236. ADR-0006 Slice 4.