### PR TITLE
feat(vsphere): NFS migration via pod-side qemu-img nfs:// + qemu-block-extra image (ADR-0006 Slice 4, #236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-21 10:15] - feat(vsphere): NFS migration via pod-side qemu-img nfs:// + qemu-block-extra image (ADR-0006 Slice 4, #236)
+**Author:** @wrkode (William Rizzo)
+
+### Added
+- `internal/providers/vsphere/nfs.go` (new): `exportLocalVMDKToNFS` / `importDiskFromNFS`. Unlike libvirt/Proxmox (host/node-side), vSphere has no shell on the hypervisor, so it runs `qemu-img` **in the provider pod** — the same place it already converts for the S3 import. Export: the existing pipeline downloads + flattens the disk to a self-contained local vmdk, then the pod's qemu-img writes it **as qcow2 straight to the `nfs://` export over libnfs** (no S3 client, no second upload). Import: the pod's qemu-img reads the staged qcow2 **directly from `nfs://`** and converts it — in one pass — to the streamOptimized vmdk the vCenter NFC `HttpNfcLease` requires, then imports it via the **same `nfcImportStreamOptimized` path the S3 import uses** (the genuinely-subtle NFC logic stays shared; only the source leg differs).
+- `cmd/provider-vsphere/Dockerfile`: install `qemu-block-extra` — qemu's `block-nfs.so` (libnfs) driver. Without it the pod's qemu-img cannot open an `nfs://` URL.
+
+### Changed
+- `internal/providers/vsphere/server.go`: `ExportDisk`/`ImportDisk` gate on `migration.EnsurePVCS3OrNFSBackend` (accepts `nfs`, keeps pvc/s3); `nfs` is **exempt from the relay-mode gate** (it uses qemu-img's native transport, pod-side). `GetCapabilities` now advertises `nfs` in the export/import backends (`migration.PVCS3AndNFS*`). The export skips storage-client creation for `nfs` (validates the `nfs://` URL instead) and returns early after the qemu-img write; the import dispatches `nfs` to `importDiskFromNFS` before the s3 branch.
+
+### Why
+Third and final provider of the NFS backend (ADR-0006 Slice 4). With libvirt, Proxmox, and vSphere all advertising and serving `nfs`, every cross-hypervisor NFS migration path is now wireable end-to-end. vSphere's NFS legs reuse the lab-validated S3 download/flatten (export) and NFC lease import (import) machinery — only the byte-transport leg swaps to qemu-img's `nfs://` driver. NFS integrity is the post-import uuid query (qemu-img emits no in-stream byte checksum). Lab validation against the OMS server is the next step.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (vSphere provider image — adds `qemu-block-extra`)
+- [ ] Config change only
+
 ## [2026-06-21 09:30] - feat(proxmox): NFS migration via node-side qemu-img nfs:// (ADR-0006 Slice 4, #236)
 **Author:** @wrkode (William Rizzo)
 

--- a/cmd/provider-vsphere/Dockerfile
+++ b/cmd/provider-vsphere/Dockerfile
@@ -50,8 +50,12 @@ FROM ${BASE_IMAGE} as runtime
 # Install qemu-img and CA certificates, then upgrade any installed packages
 # to pick up security fixes that may not yet be baked into the base image
 # layer (matches the pattern used in cmd/provider-libvirt/Dockerfile).
+# qemu-block-extra ships qemu's block-nfs.so (libnfs) driver, which the
+# ADR-0006 Slice 4 NFS migration backend uses to read/write nfs:// directly
+# from the pod's qemu-img — without it, qemu-img cannot open an nfs:// URL.
 RUN apt-get update && apt-get install -y \
     qemu-utils \
+    qemu-block-extra \
     ca-certificates \
     && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/* \

--- a/internal/providers/vsphere/capabilities_test.go
+++ b/internal/providers/vsphere/capabilities_test.go
@@ -67,17 +67,18 @@ func TestGetCapabilities_StorageBackends(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, caps)
 
-	assert.Equal(t, []string{"pvc", "s3"}, caps.SupportedExportBackends,
-		"vSphere exports to pvc and s3 in Slice 1 (SOURCE of vSphere→S3→libvirt)")
-	assert.Equal(t, []string{"pvc", "s3"}, caps.SupportedImportBackends,
-		"vSphere imports from pvc and s3 in Slice 2 (TARGET of libvirt→S3→vSphere)")
+	assert.Equal(t, []string{"pvc", "s3", "nfs"}, caps.SupportedExportBackends,
+		"vSphere exports to pvc, s3 (Slice 1/2) and nfs (Slice 4)")
+	assert.Equal(t, []string{"pvc", "s3", "nfs"}, caps.SupportedImportBackends,
+		"vSphere imports from pvc, s3 (Slice 2) and nfs (Slice 4)")
 	assert.Equal(t, []string{"relay"}, caps.SupportedTransferModes)
 }
 
-// TestExportDisk_BackendGate verifies the ADR-0006 backend/mode gate at the top
-// of ExportDisk: nfs is Unimplemented, an explicit direct mode is InvalidArgument
-// (loud-fail, never a silent downgrade). These guards run before the nil-client
-// check, so a zero-value Provider suffices.
+// TestExportDisk_BackendGate verifies the ADR-0006 backend/mode gate at the top of
+// ExportDisk: as of Slice 4, nfs PASSES the backend gate (it is implemented) and
+// fails LATER at the nil-client check with codes.Unavailable, NOT Unimplemented;
+// an explicit direct mode on the s3 path is still InvalidArgument (loud-fail, never
+// a silent downgrade). The gate + nil-client checks run on a zero-value Provider.
 func TestExportDisk_BackendGate(t *testing.T) {
 	p := &Provider{}
 
@@ -85,6 +86,10 @@ func TestExportDisk_BackendGate(t *testing.T) {
 		VmId: "vm-1", BackendType: "nfs",
 	})
 	require.Error(t, nfsErr)
+	assert.NotEqual(t, codes.Unimplemented, status.Code(nfsErr),
+		"nfs export is implemented in Slice 4 and must pass the gate")
+	assert.Equal(t, codes.Unavailable, status.Code(nfsErr),
+		"nfs export must pass the gate and fail later at the nil-client check")
 
 	_, directErr := p.ExportDisk(context.Background(), &providerv1.ExportDiskRequest{
 		VmId: "vm-1", BackendType: "s3", TransferMode: "direct",
@@ -113,17 +118,21 @@ func TestImportDisk_S3BackendPassesGate(t *testing.T) {
 		"s3 import must pass the gate and fail later at the nil-client check")
 }
 
-// TestImportDisk_NFSBackendUnimplemented verifies nfs is still rejected with
-// codes.Unimplemented on the import path (only pvc/s3 are implemented). The gate
-// runs before the nil-client check, so a zero-value Provider suffices.
-func TestImportDisk_NFSBackendUnimplemented(t *testing.T) {
+// TestImportDisk_NFSBackendPassesGate verifies that, as of ADR-0006 Slice 4, an nfs
+// ImportDisk now PASSES the backend gate (vSphere is a TARGET over NFS) and fails
+// LATER at the nil-client check inside importDiskFromNFS with codes.Unavailable,
+// NOT codes.Unimplemented. Mirrors the s3-import-passes-gate test above.
+func TestImportDisk_NFSBackendPassesGate(t *testing.T) {
 	p := &Provider{}
 
 	_, nfsErr := p.ImportDisk(context.Background(), &providerv1.ImportDiskRequest{
-		SourceUrl:   "nfs://server/export/disk",
+		SourceUrl:   "nfs://server/export/disk.qcow2",
 		BackendType: "nfs",
+		TargetName:  "imported",
 	})
 	require.Error(t, nfsErr)
-	assert.Equal(t, codes.Unimplemented, status.Code(nfsErr),
-		"nfs import is not implemented (ADR-0006 Slice 4)")
+	assert.NotEqual(t, codes.Unimplemented, status.Code(nfsErr),
+		"nfs import is implemented in Slice 4 and must pass the gate")
+	assert.Equal(t, codes.Unavailable, status.Code(nfsErr),
+		"nfs import must pass the gate and fail later at the nil-client check")
 }

--- a/internal/providers/vsphere/nfs.go
+++ b/internal/providers/vsphere/nfs.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vmdk"
+
+	"github.com/projectbeskar/virtrigaud/internal/diskutil"
+	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
+	"github.com/projectbeskar/virtrigaud/sdk/provider/errors"
+)
+
+// exportLocalVMDKToNFS writes a self-contained local VMDK (already downloaded and
+// flattened by the ExportDisk pipeline) to the nfs:// export as qcow2, using the
+// provider POD's qemu-img over libnfs (qemu's block-nfs driver). This is the
+// vSphere SOURCE leg of the ADR-0006 Slice 4 NFS backend.
+//
+// Unlike libvirt/Proxmox — where a host/node-side qemu-img writes nfs:// — vSphere
+// has no shell on the hypervisor, so it runs qemu-img IN THE POD, the same place it
+// already converts qcow2→vmdk for the S3 import. The convert reads the local vmdk
+// and writes qcow2 straight to nfs://; no S3 client, no second upload. The NFS
+// backend always stages qcow2 (the controller derives import format qcow2 for nfs,
+// matching what the libvirt/Proxmox TARGETs read).
+//
+// diskutil runs qemu-img via exec with an argv slice (no shell), so the nfs:// URL
+// — built and C7'-hardened by the controller — passes through as a single argument
+// with no shell-injection surface.
+func (p *Provider) exportLocalVMDKToNFS(ctx context.Context, localVMDKPath, nfsURL string) error {
+	qemuImg := diskutil.NewQemuImg()
+	if !qemuImg.IsInstalled() {
+		return fmt.Errorf("qemu-img is not available in the provider image; cannot write nfs export")
+	}
+	if err := qemuImg.Convert(ctx, diskutil.ConvertOptions{
+		SourcePath:        localVMDKPath,
+		DestinationPath:   nfsURL,
+		SourceFormat:      diskutil.FormatVMDK,
+		DestinationFormat: diskutil.FormatQCOW2,
+		Compression:       false, // staged qcow2 is read once by the peer; skip compress
+	}); err != nil {
+		return fmt.Errorf("qemu-img convert vmdk -> nfs qcow2: %w", err)
+	}
+	return nil
+}
+
+// importDiskFromNFS implements the ADR-0006 Slice 4 vSphere TARGET path for the NFS
+// backend: the provider POD's qemu-img reads the staged qcow2 directly from the
+// nfs:// export over libnfs and converts it — in a single pass — to the
+// streamOptimized vmdk the vCenter NFC HttpNfcLease import requires, then imports
+// it onto a datastore as a native thin disk via the SAME NFC lease path the S3
+// import uses (p.nfcImportStreamOptimized — see s3import.go). It is the NFS
+// counterpart of importDiskFromS3; the only difference is the source leg (qemu-img
+// nfs:// read instead of an S3 download + separate convert).
+//
+// MECHANISM:
+//  1. qemu-img convert nfs://…qcow2 → /tmp/<id>.vmdk (-O vmdk subformat=streamOptimized).
+//     streamOptimized is MANDATORY for the NFC lease (vmdk.Stat rejects any other
+//     subformat with ErrInvalidFormat). block-nfs.so (qemu-block-extra) performs
+//     the NFS read.
+//  2. Resolve datastore + resource pool + folder + host placement.
+//  3. nfcImportStreamOptimized: OVF descriptor → HttpNfcLease → upload → detach +
+//     unregister the transient import VM, leaving "[<ds>] <id>/<id>.vmdk".
+//  4. QueryVirtualDiskUuid(final) — an error/empty uuid means a corrupt import.
+//  5. On any post-lease failure, best-effort delete the "[<ds>] <id>" folder.
+//
+// NFS integrity is the post-import uuid query (qemu-img emits no in-stream byte
+// checksum over the libnfs read), so the ImportDiskResponse carries no Checksum.
+func (p *Provider) importDiskFromNFS(ctx context.Context, req *providerv1.ImportDiskRequest) (*providerv1.ImportDiskResponse, error) {
+	if p.client == nil {
+		return nil, errors.NewUnavailable("vSphere client not configured", nil)
+	}
+
+	nfsURL := strings.TrimSpace(req.SourceUrl)
+	if !strings.HasPrefix(nfsURL, "nfs://") {
+		return nil, errors.NewInvalidSpec("nfs import source must be an nfs:// URL, got %q", nfsURL)
+	}
+
+	// <id> is the stable name for the temp vmdk, the import VM/disk name, the final
+	// datastore path, and the returned DiskId. vmdk.Import derives the on-datastore
+	// disk name from the local vmdk basename, so the local file MUST be "<id>.vmdk".
+	id := req.TargetName
+	if id == "" {
+		id = fmt.Sprintf("imported-disk-%d", time.Now().Unix())
+	}
+
+	p.logger.Info("Importing disk from NFS (qemu-img nfs:// -> streamOptimized vmdk + NFC lease)",
+		"id", id, "source", nfsURL, "backend", req.BackendType, "storage_hint", req.StorageHint)
+
+	// --- 1. READ + CONVERT in one pass: nfs:// qcow2 -> streamOptimized vmdk ---
+	// The pod's qemu-img reads the staged qcow2 directly from nfs:// (block-nfs) and
+	// writes the streamOptimized vmdk the NFC lease requires. No S3 download. The
+	// nfs:// URL passes through diskutil's exec argv unquoted-but-unshelled (no
+	// injection surface); it is C7'-hardened by the controller.
+	vmdkLocal := fmt.Sprintf("/tmp/%s.vmdk", id)
+	defer func() { _ = os.Remove(vmdkLocal) }()
+
+	qemuImg := diskutil.NewQemuImg()
+	if !qemuImg.IsInstalled() {
+		return nil, errors.NewInternal("qemu-img is not available in the provider image; cannot convert nfs import", nil)
+	}
+	if err := qemuImg.Convert(ctx, diskutil.ConvertOptions{
+		SourcePath:        nfsURL,
+		DestinationPath:   vmdkLocal,
+		SourceFormat:      diskutil.FormatQCOW2,
+		DestinationFormat: diskutil.FormatVMDK,
+		Subformat:         s3ImportSubformat, // streamOptimized — MANDATORY for the NFC lease
+	}); err != nil {
+		return nil, errors.NewInternal("failed to convert nfs import to streamOptimized vmdk", err)
+	}
+	// Fail fast if the converted file is not the streamOptimized format the NFC lease
+	// requires (defends against a qemu-img default change or a Subformat regression).
+	if _, statErr := vmdk.Stat(vmdkLocal); statErr != nil {
+		return nil, errors.NewInternal("converted vmdk is not a valid streamOptimized image for NFC import", statErr)
+	}
+
+	// --- 2. RESOLVE datastore + placement (pool, folder, host) ---
+	datastore, err := p.resolveImportDatastore(ctx, req.StorageHint)
+	if err != nil {
+		return nil, errors.NewInternal("failed to resolve target datastore", err)
+	}
+	dsName := datastore.Name()
+
+	datacenter, err := p.finder.DefaultDatacenter(ctx)
+	if err != nil {
+		return nil, errors.NewInternal("failed to get datacenter", err)
+	}
+	p.finder.SetDatacenter(datacenter)
+
+	pool, folder, host, err := p.resolveImportPlacement(ctx, datacenter)
+	if err != nil {
+		return nil, errors.NewInternal("failed to resolve import placement", err)
+	}
+
+	finalPath := fmt.Sprintf("[%s] %s/%s.vmdk", dsName, id, id)
+	folderPath := fmt.Sprintf("[%s] %s", dsName, id)
+
+	// From here on, on ANY failure best-effort delete the "[<ds>] <id>" folder so a
+	// failed import leaves no orphan datastore files (partial vmdk, descriptor).
+	importSucceeded := false
+	dsFileManager := NewDatastoreFileManager(p)
+	defer func() {
+		if importSucceeded {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+		if err := dsFileManager.DeleteFile(cleanupCtx, folderPath); err != nil {
+			p.logger.Warn("Failed to delete partial import folder after failure (manual cleanup may be needed)", "path", folderPath, "error", err)
+		}
+	}()
+
+	// --- 3. IMPORT via the SHARED NFC lease path (identical to S3; see s3import.go) ---
+	p.logger.Info("Importing streamOptimized vmdk via NFC lease", "dest", finalPath, "datastore", dsName)
+	if err := p.nfcImportStreamOptimized(ctx, vmdkLocal, id, datastore, datacenter, pool, folder, host); err != nil {
+		return nil, errors.NewInternal("failed to import vmdk via NFC lease", err)
+	}
+
+	// --- 4. VERIFY: a real, queryable disk uuid proves a sound import ---
+	vdm := object.NewVirtualDiskManager(p.client.Client)
+	uuid, err := vdm.QueryVirtualDiskUuid(ctx, finalPath, datacenter)
+	if err != nil {
+		return nil, errors.NewInternal("imported disk failed uuid query (likely corrupt import)", err)
+	}
+	if uuid == "" {
+		return nil, errors.NewInternal("imported disk has empty uuid (likely corrupt import)", nil)
+	}
+
+	importSucceeded = true
+	p.logger.Info("Disk import from NFS completed", "id", id, "path", finalPath)
+
+	return &providerv1.ImportDiskResponse{
+		DiskId: id,
+		Path:   finalPath,
+		Task:   nil, // synchronous
+		// No ActualSizeBytes/Checksum: qemu-img emits no in-stream byte SHA256 over
+		// the libnfs read; integrity is the post-import uuid query (ADR-0006 Slice 4).
+	}, nil
+}

--- a/internal/providers/vsphere/server.go
+++ b/internal/providers/vsphere/server.go
@@ -477,12 +477,14 @@ func (p *Provider) GetCapabilities(ctx context.Context, req *providerv1.GetCapab
 		SupportsExportCompression: true,                             // export uses the compressed streamOptimized VMDK format
 		// ADR-0006: vSphere is the SOURCE of the vSphere → S3 → libvirt relay
 		// (Slice 1) AND, as of Slice 2, the TARGET of the libvirt → S3 → vSphere
-		// reverse relay. It therefore both EXPORTS (vCenter datastore stream → pod
-		// → S3, native vmdk) and IMPORTS (download qcow2 → monolithicSparse vmdk →
-		// datastore-HTTP upload → CopyVirtualDisk inflate) over pvc AND s3. Only
-		// the relay transfer mode is implemented; direct is not.
-		SupportedExportBackends: migration.PVCAndS3ExportBackends(),
-		SupportedImportBackends: migration.PVCAndS3ImportBackends(),
+		// reverse relay, AND, as of Slice 4, both directions over NFS. It EXPORTS
+		// (vCenter datastore stream → pod, native vmdk → S3 upload OR → qcow2 on the
+		// nfs:// export) and IMPORTS (download/read qcow2 → streamOptimized vmdk →
+		// NFC HttpNfcLease) over pvc, s3 AND nfs. The s3/pvc paths are relay-only
+		// (direct is not implemented); nfs runs pod-side via qemu-img and the
+		// controller exempts it from the relay-mode check.
+		SupportedExportBackends: migration.PVCS3AndNFSExportBackends(),
+		SupportedImportBackends: migration.PVCS3AndNFSImportBackends(),
 		SupportedTransferModes:  migration.RelayOnlyTransferModes(),
 	}, nil
 }
@@ -3402,16 +3404,21 @@ func (p *Provider) extractSnapshotNames(snapshotTree []types.VirtualMachineSnaps
 //
 // The operation runs synchronously; Task in the response is nil.
 func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskRequest) (*providerv1.ExportDiskResponse, error) {
-	// ADR-0006: vSphere is a SOURCE for the S3 relay export (Slice 1). Accept pvc
-	// and s3; reject nfs/unknown honestly. Only the relay transfer mode is
-	// implemented; an explicit "direct" fails loudly (never a silent downgrade).
-	if err := migration.EnsurePVCOrS3Backend(req.BackendType); err != nil {
+	// ADR-0006: vSphere is a SOURCE for the S3 relay export (Slice 1) and the NFS
+	// qemu-img export (Slice 4). Accept pvc, s3, and nfs; reject unknown honestly.
+	// The s3/pvc paths are relay-only — an explicit "direct" fails loudly (never a
+	// silent downgrade); nfs runs pod-side via qemu-img's native transport and is
+	// exempt from the relay check.
+	if err := migration.EnsurePVCS3OrNFSBackend(req.BackendType); err != nil {
 		return nil, err
 	}
-	if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
-		return nil, err
+	if req.BackendType != migration.BackendNFS {
+		if err := migration.EnsureRelayMode(req.TransferMode); err != nil {
+			return nil, err
+		}
 	}
 	useS3 := req.BackendType == migration.BackendS3
+	useNFS := req.BackendType == migration.BackendNFS
 
 	if p.client == nil {
 		return nil, errors.NewUnavailable("vSphere client not configured", nil)
@@ -3439,11 +3446,13 @@ func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskReq
 		return nil, errors.NewInvalidSpec("unsupported export format: %s", targetFormat)
 	}
 
-	// ADR-0006 D4: the SOURCE exports its NATIVE format; the TARGET converts on
-	// import. For the S3 relay path vSphere always exports vmdk and libvirt
-	// converts vmdk→qcow2 on import. Force vmdk here regardless of req.Format so
-	// the staged object is the native disk.
-	if useS3 {
+	// ADR-0006 D4: for the S3 relay path the SOURCE exports its NATIVE format and
+	// the TARGET converts on import — vSphere always exports vmdk and libvirt
+	// converts vmdk→qcow2 on import. Force vmdk here so the staged object is the
+	// native disk. For NFS we also force vmdk through the download/flatten pipeline,
+	// then convert that self-contained local vmdk → qcow2 straight onto the nfs://
+	// export in one qemu-img pass (the NFS backend always stages qcow2).
+	if useS3 || useNFS {
 		targetFormat = "vmdk"
 	}
 
@@ -3463,30 +3472,39 @@ func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskReq
 	//   - s3:  the provider pod is the S3 client (relay export). Options come from
 	//          storage_options_json; credentials from the credentials map.
 	//   - pvc: the legacy path; the PVC is mounted at /mnt/migration-storage/<pvc>.
-	var storageConfig storage.StorageConfig
-	if useS3 {
-		storageConfig, err = migration.S3StorageConfigFromRequest(req.StorageOptionsJson, req.Credentials)
-		if err != nil {
-			return nil, errors.NewInvalidSpec("invalid s3 export configuration: %s", err.Error())
+	//   - nfs: NO storage client — the pod's qemu-img writes qcow2 straight to the
+	//          nfs:// export over libnfs (Slice 4); only validate the URL here.
+	var storageClient storage.Storage
+	if useNFS {
+		if !strings.HasPrefix(strings.TrimSpace(req.DestinationUrl), "nfs://") {
+			return nil, errors.NewInvalidSpec("nfs export destination must be an nfs:// URL, got %q", req.DestinationUrl)
 		}
 	} else {
-		// URL format: pvc://<pvc-name>/<file-path>
-		// Provider pods have PVCs mounted at /mnt/migration-storage/<pvc-name>
-		pvcName, perr := extractPVCNameFromURL(req.DestinationUrl)
-		if perr != nil {
-			return nil, errors.NewInternal("failed to extract PVC name from URL", perr)
+		var storageConfig storage.StorageConfig
+		if useS3 {
+			storageConfig, err = migration.S3StorageConfigFromRequest(req.StorageOptionsJson, req.Credentials)
+			if err != nil {
+				return nil, errors.NewInvalidSpec("invalid s3 export configuration: %s", err.Error())
+			}
+		} else {
+			// URL format: pvc://<pvc-name>/<file-path>
+			// Provider pods have PVCs mounted at /mnt/migration-storage/<pvc-name>
+			pvcName, perr := extractPVCNameFromURL(req.DestinationUrl)
+			if perr != nil {
+				return nil, errors.NewInternal("failed to extract PVC name from URL", perr)
+			}
+			storageConfig = storage.StorageConfig{
+				Type:      "pvc",
+				MountPath: fmt.Sprintf("/mnt/migration-storage/%s", pvcName),
+			}
 		}
-		storageConfig = storage.StorageConfig{
-			Type:      "pvc",
-			MountPath: fmt.Sprintf("/mnt/migration-storage/%s", pvcName),
-		}
-	}
 
-	storageClient, err := storage.NewStorage(storageConfig)
-	if err != nil {
-		return nil, errors.NewInternal("failed to create storage client", err)
+		storageClient, err = storage.NewStorage(storageConfig)
+		if err != nil {
+			return nil, errors.NewInternal("failed to create storage client", err)
+		}
+		defer storageClient.Close()
 	}
-	defer storageClient.Close()
 
 	// Create datastore file manager
 	dsManager := NewDatastoreFileManager(p)
@@ -3666,6 +3684,25 @@ func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskReq
 		uploadPath = tempFile
 	}
 
+	// ADR-0006 Slice 4 NFS SOURCE leg: the self-contained local vmdk is written
+	// straight to the nfs:// export AS qcow2 by the pod's qemu-img (libnfs) — no
+	// storage-client upload. Returns early; the s3/pvc upload below is skipped.
+	if useNFS {
+		nfsURL := strings.TrimSpace(req.DestinationUrl)
+		p.logger.Info("Writing disk to NFS export", "destination", nfsURL, "local_vmdk", uploadPath)
+		if err := p.exportLocalVMDKToNFS(ctx, uploadPath, nfsURL); err != nil {
+			return nil, errors.NewInternal("failed to write disk to nfs export", err)
+		}
+		p.logger.Info("Disk export to NFS completed", "export_id", exportID, "destination", nfsURL)
+		return &providerv1.ExportDiskResponse{
+			ExportId: exportID,
+			Task:     nil, // synchronous
+			// No EstimatedSizeBytes/Checksum: qemu-img emits no in-stream byte SHA256
+			// over the libnfs write; integrity is established target-side (the import's
+			// qemu-img read + post-import uuid query) — ADR-0006 Slice 4.
+		}, nil
+	}
+
 	// Upload to destination storage
 	p.logger.Info("Uploading disk to storage", "destination", req.DestinationUrl)
 
@@ -3733,16 +3770,23 @@ func (p *Provider) ExportDisk(ctx context.Context, req *providerv1.ExportDiskReq
 // passed as VMImage.Path in a subsequent Create request. The operation runs
 // synchronously; Task in the response is nil.
 func (p *Provider) ImportDisk(ctx context.Context, req *providerv1.ImportDiskRequest) (*providerv1.ImportDiskResponse, error) {
-	// ADR-0006: vSphere is a TARGET for the S3 relay import (Slice 2, the reverse
-	// of Slice 1's vSphere→S3→libvirt). Accept pvc and s3; reject nfs/unknown
-	// honestly instead of falling through to the pvc path.
-	if err := migration.EnsurePVCOrS3Backend(req.BackendType); err != nil {
+	// ADR-0006: vSphere is a TARGET for the S3 relay import (Slice 2, the reverse of
+	// Slice 1's vSphere→S3→libvirt) and the NFS qemu-img import (Slice 4). Accept
+	// pvc, s3, and nfs; reject unknown honestly instead of falling through to pvc.
+	if err := migration.EnsurePVCS3OrNFSBackend(req.BackendType); err != nil {
 		return nil, err
 	}
 
+	// ADR-0006 Slice 4 NFS import: the pod's qemu-img reads the staged qcow2 from
+	// the nfs:// export and converts it to a streamOptimized vmdk, then imports it
+	// via the same NFC lease path as S3 (see nfs.go). Never logs credentials.
+	if req.BackendType == migration.BackendNFS {
+		return p.importDiskFromNFS(ctx, req)
+	}
+
 	// S3 relay import (Approach 2): download the staged qcow2, convert to a
-	// monolithicSparse vmdk, upload via datastore-HTTP, and inflate with
-	// CopyVirtualDisk. Never logs the credentials map.
+	// streamOptimized vmdk, and import via the vCenter NFC HttpNfcLease. Never logs
+	// the credentials map.
 	if req.BackendType == migration.BackendS3 {
 		return p.importDiskFromS3(ctx, req)
 	}


### PR DESCRIPTION
> Supersedes #274 (auto-closed when its stacked base branch `feat/nfs-proxmox` was deleted on the #273 merge). Same vSphere-only change, now rebased directly onto `main`.

## What

Third and final provider of the **NFS staging backend** (ADR-0006 Slice 4). With libvirt (#272), Proxmox (#273), and now vSphere all serving `nfs`, **every cross-hypervisor NFS migration path is wireable end-to-end.**

## How — pod-side, not host-side

Unlike libvirt/Proxmox (host/node-side qemu-img over SSH), vSphere has no shell on the hypervisor, so it runs `qemu-img` **in the provider pod** — the same place it already converts for the S3 import. The NFS legs are just a `qemu-img convert` with an `nfs://` operand:

- **`internal/providers/vsphere/nfs.go`** (new):
  - `exportLocalVMDKToNFS` — the existing ExportDisk pipeline downloads + flattens the disk to a self-contained **local vmdk**; the pod's qemu-img then writes it **as qcow2 straight to the `nfs://` export over libnfs** (no S3 client, no second upload).
  - `importDiskFromNFS` — the pod's qemu-img reads the staged qcow2 **directly from `nfs://`** and converts it, in one pass, to the **streamOptimized vmdk** the vCenter NFC `HttpNfcLease` requires, then imports it via the **same `nfcImportStreamOptimized` path the S3 import uses**. The genuinely-subtle NFC logic (lease host-rewrite, Unregister-not-Destroy, folder-collision cleanup) stays **shared** — only the source leg differs.
- **`cmd/provider-vsphere/Dockerfile`** — install `qemu-block-extra` (qemu's `block-nfs.so` / libnfs driver). Without it the pod's qemu-img cannot open an `nfs://` URL. The one packaging change.
- **`server.go`** — `ExportDisk`/`ImportDisk` gate on `EnsurePVCS3OrNFSBackend` (accepts `nfs`, keeps pvc/s3); `nfs` is **exempt from the relay-mode gate** (pod-side qemu-img transport). `GetCapabilities` advertises `nfs` (`PVCS3AndNFS*`). Export skips storage-client creation for `nfs` (validates the URL instead) and returns early; import dispatches `nfs` → `importDiskFromNFS` before the s3 branch.

## Safety

`diskutil.QemuImg.Convert` runs `qemu-img` via `exec.CommandContext` with an **argv slice (no shell)** and applies no `filepath.Clean`/`os.Stat` to the operands, so the controller-built, C7'-hardened `nfs://` URL passes through as a single argument with **no shell-injection surface**.

## Tests

- `GetCapabilities` asserts `[pvc, s3, nfs]` export/import backends.
- `TestExportDisk_BackendGate` / `TestImportDisk_NFSBackendPassesGate` — flipped from `Unimplemented`-rejected to gate-pass (`nfs` reaches the nil-client check → `Unavailable`); the s3 direct-mode loud-fail assertion is retained.

Gate: `gofmt` clean, `golangci-lint` 0 issues, `go build ./...` OK, full vSphere + migration + libvirt suites pass.

## Integrity

NFS integrity is the post-import uuid query (`QueryVirtualDiskUuid`) — qemu-img emits no in-stream byte checksum over the libnfs transfer (same posture as the libvirt/Proxmox NFS providers).

Refs #236. ADR-0006 Slice 4.