### PR TITLE
fix(migration): NFS stages a FLAT object key (nested key fails libnfs mount) (ADR-0006 Slice 4, #236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-21 12:00] - fix(migration): NFS stages a FLAT object key (nested key fails libnfs mount) (ADR-0006 Slice 4, #236)
+**Author:** @wrkode (William Rizzo)
+
+### Fixed
+- `internal/controller/vmmigration_controller.go`: the NFS staging key is now a single flat filename `vmmigrations-<ns>-<name>-<stage>.qcow2` in the export root (or the operator's optional `path`), instead of the nested `vmmigrations/<ns>/<name>/<stage>.qcow2`. Unlike S3 — where a slashed key creates the prefix implicitly — NFS is a real filesystem: every parent directory must already exist, and qemu-img/libnfs (the only NFS client in the data plane) cannot `mkdir`. A nested key therefore failed the libnfs mount with `MNT3ERR_NOENT`. Surfaced by the first live libvirt↔libvirt NFS migration against the lab OpenMediaVault server.
+
+### Why
+Lab validation of the ADR-0006 Slice 4 NFS backend: a real qemu-img `nfs://` write cannot create intermediate directories, so the staged object must live where a directory already exists. ns/name/stage are encoded into the single filename so the object stays unique and traceable. The PVC and S3 backends are unchanged (PVC mkdirs on a mounted volume; S3 keys are flat prefixes).
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (manager)
+- [ ] Config change only
+
 ## [2026-06-21 10:15] - feat(vsphere): NFS migration via pod-side qemu-img nfs:// + qemu-block-extra image (ADR-0006 Slice 4, #236)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/controller/vmmigration_controller.go
+++ b/internal/controller/vmmigration_controller.go
@@ -2704,7 +2704,14 @@ func (r *VMMigrationReconciler) generateStorageURL(ctx context.Context, migratio
 		if nfs == nil || nfs.Server == "" || nfs.Export == "" {
 			return "", fmt.Errorf("nfs storage configuration (server, export) is required")
 		}
-		key := fmt.Sprintf("vmmigrations/%s/%s/%s.qcow2", migration.Namespace, migration.Name, stage)
+		// FLAT key (ADR-0006 Slice 4): unlike S3, where a "a/b/c.qcow2" key creates
+		// the prefix implicitly, NFS is a real filesystem — every parent directory
+		// must already exist, and qemu-img/libnfs (the only NFS client in the data
+		// plane) cannot mkdir. A nested key therefore fails the libnfs mount with
+		// MNT3ERR_NOENT. We encode namespace/name/stage into a SINGLE filename so the
+		// staged object stays unique and traceable while needing only the export
+		// root (or the operator's optional, pre-created `path`) to exist.
+		key := fmt.Sprintf("vmmigrations-%s-%s-%s.qcow2", migration.Namespace, migration.Name, stage)
 		return storagemigration.NFSURL(storagemigration.StorageOptions{
 			Server: nfs.Server,
 			Export: nfs.Export,

--- a/internal/controller/vmmigration_nfs_controller_test.go
+++ b/internal/controller/vmmigration_nfs_controller_test.go
@@ -57,15 +57,24 @@ func TestStorageOptionsJSON_NFS(t *testing.T) {
 }
 
 // TestGenerateStorageURL_NFS verifies the controller builds the hardened nfs://
-// staging URL for an nfs migration.
+// staging URL for an nfs migration. The staging object is a FLAT filename in the
+// export root (not a nested key): NFS requires every parent directory to pre-exist
+// and qemu-img/libnfs cannot mkdir, so a nested key fails the mount with
+// MNT3ERR_NOENT (ADR-0006 Slice 4, lab-surfaced). ns/name/stage are encoded into
+// the single filename.
 func TestGenerateStorageURL_NFS(t *testing.T) {
 	r := &VMMigrationReconciler{}
 	got, err := r.generateStorageURL(context.Background(), nfsMigration("172.16.56.13", "/export/virtrigaud", ""), "export")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := "nfs://172.16.56.13/export/virtrigaud/vmmigrations/mig/m1/export.qcow2"; got != want {
+	if want := "nfs://172.16.56.13/export/virtrigaud/vmmigrations-mig-m1-export.qcow2"; got != want {
 		t.Errorf("got %q want %q", got, want)
+	}
+	// The staged object must be a single path segment under the export — no '/'
+	// after the export root — or NFS cannot create it without a pre-made directory.
+	if strings.Count(strings.TrimPrefix(got, "nfs://172.16.56.13/export/virtrigaud/"), "/") != 0 {
+		t.Errorf("nfs staging key must be flat (no nested dirs), got %q", got)
 	}
 }
 


### PR DESCRIPTION
## What

First **lab-surfaced** fix of the ADR-0006 Slice 4 NFS backend. The NFS staging key was nested — `vmmigrations/<ns>/<name>/<stage>.qcow2` — mirroring the S3 key layout. But NFS is a real filesystem: **every parent directory must already exist**, and qemu-img/libnfs (the only NFS client in the data plane) **cannot `mkdir`**. So the very first live migration failed the libnfs mount with:

```
qemu-img: nfs://172.16.56.13/export/virtrigaud/vmmigrations/mig-s3/libvirt-nfs-test/export.qcow2:
  Failed to mount nfs share: mount_cb: RPC error: Mount failed with error MNT3ERR_NOENT(2)
```

## Fix

Flatten the key to a single filename in the export root (or the operator's optional, pre-created `path`):

```
vmmigrations-<ns>-<name>-<stage>.qcow2
```

ns/name/stage are still encoded, so the staged object stays unique and traceable; it just needs only the export root to exist (which it always does). One line in `generateStorageURL`'s `nfs` case. **PVC and S3 backends are unchanged** — PVC mkdirs on a mounted volume, S3 keys are flat prefixes.

## Validation

Driven GREEN end-to-end: a real **libvirt→libvirt NFS migration** against the lab OpenMediaVault server (`demo-ubuntu-libvirt` → `demo-ubuntu-nfs`), `Exporting → Importing → Creating → Ready`, target VM powered on. The pre-fix run failed at the mount; the post-fix run completed.

## Tests

`TestGenerateStorageURL_NFS` updated to assert the flat key + a guard that the staged object has no nested `/` after the export root. `gofmt` clean, `go build ./...`, controller suite passes.

Refs #236. ADR-0006 Slice 4.