### PR TITLE
fix(proxmox): NFS migration via kernel mount (pve-qemu lacks libnfs) (ADR-0006 Slice 4, #236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-21 14:30] - fix(proxmox): NFS migration via kernel mount (pve-qemu lacks libnfs) (ADR-0006 Slice 4, #236)
+**Author:** @wrkode (William Rizzo)
+
+### Changed
+- `internal/providers/proxmox/nfs.go`: replace the qemu-img `nfs://` (libnfs) transport — shipped in #273 but **non-functional on a stock PVE node** (`pve-qemu-kvm` is built without the libnfs block driver; the node's qemu-img rejects `nfs://` with `Unknown protocol 'nfs'`) — with a **kernel NFS mount**, exactly how PVE's first-class NFS storage mounts. The export is two-stage: qemu-img as root flattens the (root-owned) source disk to a local temp, then the temp is copied onto the mounted export as the migration's `nfs.uid/gid` via `setpriv` (a single process cannot be both root, to read the source, and the share's uid, to write the export — only libnfs can decouple those, which is why libvirt/vSphere keep the libnfs path). The import mounts the export and converts the staged qcow2 to the node-local stage file as `nfs.uid/gid`, then `qm importdisk` consumes it. New helpers `buildNFSKernelMountScript`, `buildNFSKernelExportScript`, `nfsSetprivPrefix`, `nfsInMountRel`; the mount runs `vers=3` (numeric-uid AUTH_SYS) with a trap that unmounts + removes the temp on exit.
+
+### Why
+Lab validation against the OpenMediaVault server proved the libnfs approach cannot work on Proxmox (unlike libvirt/vSphere, whose images/hosts have libnfs). The kernel-mount transport is Proxmox-idiomatic, needs no extra packages, and honors `nfs.uid/gid` so the staged objects interoperate with the libvirt/vSphere providers (which present the same uid via the libnfs URL). Validated GREEN end-to-end: **libvirt→Proxmox import** and **Proxmox→libvirt export** (a freshly-imported VM round-tripped back to libvirt), both directions over NFS against the lab OMV.
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (proxmox provider image)
+- [ ] Config change only
+
 ## [2026-06-21 12:00] - fix(migration): NFS stages a FLAT object key (nested key fails libnfs mount) (ADR-0006 Slice 4, #236)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/proxmox/nfs.go
+++ b/internal/providers/proxmox/nfs.go
@@ -19,20 +19,102 @@ package proxmox
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
+	"github.com/projectbeskar/virtrigaud/internal/storage/migration"
 	providerv1 "github.com/projectbeskar/virtrigaud/proto/rpc/provider/v1"
 	"github.com/projectbeskar/virtrigaud/sdk/provider/errors"
 )
 
+// ADR-0006 Slice 4 — Proxmox NFS transport: KERNEL MOUNT, not libnfs.
+//
+// libvirt and vSphere stage to NFS via qemu-img's native nfs:// driver (libnfs).
+// Proxmox cannot: pve-qemu-kvm is built WITHOUT the libnfs block driver, so the
+// PVE node's qemu-img rejects nfs:// with "Unknown protocol 'nfs'" (lab-confirmed).
+// Instead the Proxmox provider mounts the export with the node's kernel NFS client
+// — exactly how PVE's first-class NFS storage mounts — and runs qemu-img against
+// the mounted file. The mount is done as root over SSH (PVE nodes mount NFS as
+// root routinely); the qemu-img I/O is dropped to the migration's nfs.uid/gid via
+// setpriv, so AUTH_SYS presents the SAME identity libvirt/vSphere present through
+// the libnfs URL — uid/gid stays uniform across providers and no_root_squash is
+// not required on the export.
+
+// nfsInMountRel resolves the staged object's path RELATIVE to the export root from
+// the controller-built nfs:// URL. The URL is nfs://<server><export>[/<path>]/<key>
+// (NFSURL joins export+path+key); stripping the export prefix yields the path that,
+// appended to the kernel mount point, names the file. Rejects traversal and
+// out-of-export paths (defence in depth atop the controller's C7' sanitisation).
+func nfsInMountRel(rawURL, export string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse nfs url: %w", err)
+	}
+	rel := strings.TrimPrefix(u.Path, strings.TrimRight(export, "/"))
+	rel = strings.TrimPrefix(rel, "/")
+	if rel == "" || strings.Contains(rel, "..") || strings.ContainsAny(rel, "\x00\n\r") {
+		return "", fmt.Errorf("nfs url path %q is not a safe object within export %q", u.Path, export)
+	}
+	return rel, nil
+}
+
+// buildNFSKernelMountScript wraps innerCmd in a node-side shell script that mounts
+// the NFS export read-write at a fresh temp dir ($MNT), runs innerCmd (which names
+// the staged file as "$MNT"/<rel>), and unmounts + removes the temp dir on exit —
+// success OR failure — via a trap. extraCleanup (e.g. removing a local temp) is
+// appended to the trap. vers=3 matches the numeric-uid AUTH_SYS model the libnfs
+// path uses (NFSv4 string id-mapping would re-map uids via idmapd).
+func buildNFSKernelMountScript(server, export, innerCmd, extraCleanup string) string {
+	target := proxmoxShellQuote(server + ":" + export)
+	cleanup := `umount "$MNT" 2>/dev/null || true; rmdir "$MNT" 2>/dev/null || true`
+	if extraCleanup != "" {
+		cleanup += "; " + extraCleanup
+	}
+	return "set -e; MNT=$(mktemp -d /var/tmp/.virtrigaud-nfsmnt-XXXXXX); " +
+		"trap '" + cleanup + "' EXIT; " +
+		"mount -t nfs -o vers=3 " + target + " \"$MNT\"; " + innerCmd
+}
+
+// buildNFSKernelExportScript builds the TWO-STAGE node-side export: qemu-img as the
+// SSH user (root) flattens the root-owned source disk to a local temp qcow2, then —
+// after the NFS mount — the temp is copied onto the export AS the migration's
+// uid/gid (setpriv). The split is unavoidable for a kernel mount: a single process
+// cannot be root (to read the root-owned PVE source) and the share's uid (to write
+// the export) at once — only libnfs can set the NFS identity independently of the
+// process uid. The local temp is chmod 0644 so the dropped-privilege copy can read
+// it, and is removed by the trap on exit.
+func buildNFSKernelExportScript(server, export, rel, srcFormat, srcPath, hostTmp string, uid, gid *int64) string {
+	qt := proxmoxShellQuote(hostTmp)
+	flatten := fmt.Sprintf("TMP=%s; qemu-img convert -U -f %s -O qcow2 %s \"$TMP\"; chmod 0644 \"$TMP\"; ",
+		qt, proxmoxShellQuote(srcFormat), proxmoxShellQuote(srcPath))
+	cp := nfsSetprivPrefix(uid, gid) + `cp "$TMP" "$MNT"/` + proxmoxShellQuote(rel)
+	// The mount wrapper provides "set -e", $MNT, the mount, and the trap; we prepend
+	// the flatten via a leading subshell-free sequence and extend the trap to rm TMP.
+	target := proxmoxShellQuote(server + ":" + export)
+	cleanup := `umount "$MNT" 2>/dev/null || true; rmdir "$MNT" 2>/dev/null || true; rm -f "$TMP" 2>/dev/null || true`
+	return "set -e; " + flatten +
+		"MNT=$(mktemp -d /var/tmp/.virtrigaud-nfsmnt-XXXXXX); " +
+		"trap '" + cleanup + "' EXIT; " +
+		"mount -t nfs -o vers=3 " + target + " \"$MNT\"; " + cp
+}
+
+// nfsSetprivPrefix returns the setpriv prefix that runs the following command as
+// the migration's nfs.uid/gid (AUTH_SYS identity), dropping supplementary groups.
+// Both uid and gid must be set; otherwise qemu-img runs as the SSH user (root) and
+// the export's squash policy decides access. setpriv is part of util-linux (always
+// present on a PVE node).
+func nfsSetprivPrefix(uid, gid *int64) string {
+	if uid == nil || gid == nil {
+		return ""
+	}
+	return fmt.Sprintf("setpriv --reuid %d --regid %d --clear-groups ", *uid, *gid)
+}
+
 // exportDiskToNFS implements the ADR-0006 Slice 4 Proxmox SOURCE path for the NFS
-// backend: the PVE NODE's qemu-img flattens the source disk and writes the
-// resulting qcow2 directly to the NFS export over libnfs (qemu's block-nfs
-// driver), with no provider-pod hop and no S3 client. This mirrors the libvirt
-// host-side NFS export — the node already has the disk and NFS reachability, so
-// the bytes never transit the pod (unlike the S3 relay). The destination is the
-// controller-built, C7'-hardened nfs:// URL.
+// backend via a kernel NFS mount (see the package note): the node flattens the
+// source disk straight onto the mounted export as qcow2, with no provider-pod hop
+// and no S3 client.
 func (p *Provider) exportDiskToNFS(ctx context.Context, req *providerv1.ExportDiskRequest) (*providerv1.ExportDiskResponse, error) {
 	if p.client == nil {
 		return nil, errors.NewUnavailable("PVE client not configured", nil)
@@ -44,6 +126,17 @@ func (p *Provider) exportDiskToNFS(ctx context.Context, req *providerv1.ExportDi
 	nfsURL := strings.TrimSpace(req.DestinationUrl)
 	if !strings.HasPrefix(nfsURL, "nfs://") {
 		return nil, errors.NewInvalidSpec("nfs export destination must be an nfs:// URL, got %q", nfsURL)
+	}
+	opts, err := migration.ParseStorageOptions(req.StorageOptionsJson)
+	if err != nil {
+		return nil, errors.NewInvalidSpec("invalid nfs export storage options: %v", err)
+	}
+	if opts.Server == "" || opts.Export == "" {
+		return nil, errors.NewInvalidSpec("nfs export storage options require server and export")
+	}
+	rel, err := nfsInMountRel(nfsURL, opts.Export)
+	if err != nil {
+		return nil, errors.NewInvalidSpec("nfs export: %v", err)
 	}
 
 	// Resolve the disk's PVE storage:volid via GetDiskInfo (returns it in Path).
@@ -63,49 +156,40 @@ func (p *Provider) exportDiskToNFS(ctx context.Context, req *providerv1.ExportDi
 	if srcFormat == "" {
 		srcFormat = "qcow2"
 	}
-
-	// Resolve the real on-node filesystem path from the volid via `pvesm path`.
 	srcPath, err := p.resolveNodeDiskPath(ctx, volid)
 	if err != nil {
 		return nil, errors.NewInternal("failed to resolve on-node disk path", err)
 	}
 
 	// Never log credentials — only the backend, volid, paths.
-	p.logger.Info("Exporting disk from Proxmox node to NFS",
+	p.logger.Info("Exporting disk from Proxmox node to NFS (kernel mount)",
 		"backend", req.BackendType, "vm", req.VmId, "volid", volid, "src_path", srcPath,
 		"destination", nfsURL)
 
-	// Flatten + write straight to the NFS export via the node's qemu-img (libnfs).
-	// Reuse the tested S3-export flatten builder: it emits `qemu-img convert -U -f
-	// <srcFormat> -O qcow2 '<src>' '<dst>'` with both operands shell-quoted — the
-	// destination being an nfs:// URL instead of a node temp is immaterial to the
-	// builder, and we inherit its quoting guarantee for the security-sensitive URL.
-	// -U reads a possibly-running source (crash-consistent; a consistent copy still
-	// needs power-off/snapshot first). No hostTmp, no pod buffering — qemu-img's
-	// block-nfs driver performs the NFS write directly. Compression stays off: the
-	// target qcow2 lands on the NFS export for the peer to read, not a local cache.
-	convertCmd := buildExportFlattenCommand(srcFormat, srcPath, nfsURL, false)
-	if _, stderr, err := p.ssh.runSSH(ctx, convertCmd); err != nil {
+	// Two-stage: flatten the root-owned source to a local temp as root (-U reads a
+	// possibly-running source), then copy the temp onto the mounted export as the
+	// migration's uid/gid (setpriv). See buildNFSKernelExportScript for why the
+	// split is unavoidable with a kernel mount.
+	hostTmp := proxmoxExportStagePath(req.VmId)
+	script := buildNFSKernelExportScript(opts.Server, opts.Export, rel, srcFormat, srcPath, hostTmp, opts.UID, opts.GID)
+	if _, stderr, err := p.ssh.runSSH(ctx, script); err != nil {
 		return nil, errors.NewInternal(
-			fmt.Sprintf("node-side qemu-img convert to nfs failed (stderr: %s)", strings.TrimSpace(stderr)), err)
+			fmt.Sprintf("node-side nfs-mount qemu-img export failed (stderr: %s)", strings.TrimSpace(stderr)), err)
 	}
 
 	p.logger.Info("Source disk written to NFS export", "destination", nfsURL)
 
 	return &providerv1.ExportDiskResponse{
 		ExportId: fmt.Sprintf("export-proxmox-nfs-%s-%d", sanitizeProxmoxName(req.VmId), time.Now().Unix()),
-		// qemu-img does not emit a byte SHA256 over the libnfs write; NFS integrity
-		// is established by the target's `qemu-img check` on the converted qcow2
-		// (ADR-0006 Slice 4 — no in-stream checksum for the qemu-img transport).
+		// qemu-img emits no byte SHA256 over the convert; NFS integrity is the
+		// target-side qemu-img check on the staged qcow2 (ADR-0006 Slice 4).
 	}, nil
 }
 
-// importDiskFromNFS implements the ADR-0006 Slice 4 Proxmox TARGET path: the PVE
-// node's qemu-img reads the staged qcow2 directly from the NFS export over libnfs
-// and writes it to a node-local stage file, which the Proxmox Create path then
-// feeds to `qm importdisk` (Proxmox cannot importdisk an nfs:// URL directly — it
-// takes a local file). No download via the pod, no S3 client; the bytes flow
-// NFS → node, not NFS → pod → node.
+// importDiskFromNFS implements the ADR-0006 Slice 4 Proxmox TARGET path via a
+// kernel NFS mount: the node reads the staged qcow2 from the mounted export and
+// writes a node-local stage file, which the Create path feeds to `qm importdisk`
+// (Proxmox cannot importdisk a network URL — it takes a local file).
 func (p *Provider) importDiskFromNFS(ctx context.Context, req *providerv1.ImportDiskRequest) (*providerv1.ImportDiskResponse, error) {
 	if p.client == nil {
 		return nil, errors.NewUnavailable("PVE client not configured", nil)
@@ -118,30 +202,43 @@ func (p *Provider) importDiskFromNFS(ctx context.Context, req *providerv1.Import
 	if !strings.HasPrefix(nfsURL, "nfs://") {
 		return nil, errors.NewInvalidSpec("nfs import source must be an nfs:// URL, got %q", nfsURL)
 	}
+	opts, err := migration.ParseStorageOptions(req.StorageOptionsJson)
+	if err != nil {
+		return nil, errors.NewInvalidSpec("invalid nfs import storage options: %v", err)
+	}
+	if opts.Server == "" || opts.Export == "" {
+		return nil, errors.NewInvalidSpec("nfs import storage options require server and export")
+	}
+	rel, err := nfsInMountRel(nfsURL, opts.Export)
+	if err != nil {
+		return nil, errors.NewInvalidSpec("nfs import: %v", err)
+	}
 
-	// NFS always stages qcow2 (the controller derives import format qcow2 for the
-	// nfs backend; the source provider's export wrote qcow2 to the export).
+	// NFS always stages qcow2 (the controller derives import format qcow2 for nfs).
 	id := sanitizeProxmoxName(req.TargetName)
 	if req.TargetName == "" {
 		id = fmt.Sprintf("imported-disk-%d", time.Now().Unix())
 	}
 	stagePath := proxmoxImportStagePath(id, "qcow2")
 
-	// Never log credentials — only the paths.
-	p.logger.Info("Importing disk from NFS to Proxmox node (stage for qm importdisk at Create)",
+	p.logger.Info("Importing disk from NFS to Proxmox node (kernel mount; stage for qm importdisk at Create)",
 		"id", id, "source", nfsURL, "stage_path", stagePath, "storage_hint", req.StorageHint)
 
-	// Read the staged qcow2 straight from NFS and write the node-local stage file.
-	// `qm importdisk` (run by the Create path) needs a local file, not an nfs:// URL.
-	convertCmd := buildNFSImportConvertCommand(nfsURL, stagePath)
-	if _, stderr, err := p.ssh.runSSH(ctx, convertCmd); err != nil {
+	// Convert from the mounted export to the node-local stage file. The convert
+	// reads NFS as the migration's uid/gid (setpriv); the stage lands in /var/tmp
+	// (world-writable) and is consumed by `qm importdisk` at Create.
+	mountFile := `"$MNT"/` + proxmoxShellQuote(rel)
+	inner := nfsSetprivPrefix(opts.UID, opts.GID) +
+		fmt.Sprintf("qemu-img convert -O qcow2 %s %s", mountFile, proxmoxShellQuote(stagePath))
+	script := buildNFSKernelMountScript(opts.Server, opts.Export, inner, "")
+	if _, stderr, err := p.ssh.runSSH(ctx, script); err != nil {
 		p.cleanupNodeFile(stagePath)
 		return nil, errors.NewInternal(
-			fmt.Sprintf("node-side qemu-img convert from nfs failed (stderr: %s)", strings.TrimSpace(stderr)), err)
+			fmt.Sprintf("node-side nfs-mount qemu-img import failed (stderr: %s)", strings.TrimSpace(stderr)), err)
 	}
 
-	// Validate the staged qcow2 on the node (ADR-0006 D5 structural integrity for
-	// NFS — there is no in-stream byte checksum from qemu-img).
+	// Validate the staged qcow2 (local file, runs as the SSH user — root reads any
+	// file). ADR-0006 D5 structural integrity for NFS (no in-stream byte checksum).
 	if _, stderr, err := p.ssh.runSSH(ctx, fmt.Sprintf("qemu-img check %s", proxmoxShellQuote(stagePath))); err != nil {
 		p.cleanupNodeFile(stagePath)
 		return nil, errors.NewInternal(
@@ -151,24 +248,11 @@ func (p *Provider) importDiskFromNFS(ctx context.Context, req *providerv1.Import
 	p.logger.Info("Disk import from NFS staged on node (awaiting Create → qm importdisk)",
 		"id", id, "stage_path", stagePath)
 
-	// The disk is staged on the node. The Proxmox Create path consumes it via
-	// attachImportedDisk (qm importdisk into the freshly-created VM).
 	return &providerv1.ImportDiskResponse{
 		DiskId: id,
 		Path:   stagePath,
 		Task:   nil, // synchronous
-		// No ActualSizeBytes/Checksum: qemu-img emits no byte SHA256 over the libnfs
-		// read; integrity is the node-side qemu-img check above (ADR-0006 Slice 4).
+		// No ActualSizeBytes/Checksum: qemu-img emits no byte SHA256 over the convert;
+		// integrity is the node-side qemu-img check above (ADR-0006 Slice 4).
 	}, nil
-}
-
-// buildNFSImportConvertCommand builds the node-side qemu-img argv that reads the
-// staged qcow2 from the nfs:// source and writes the node-local stage file for
-// `qm importdisk`. The source is a static staged file (not a running disk), so no
-// -U is needed; both the nfs:// URL and the stage path are shell-quoted (the URL
-// is security-sensitive — it is C7'-hardened by the controller, and this is the
-// single place its node-side quoting is pinned).
-func buildNFSImportConvertCommand(nfsURL, stagePath string) string {
-	return fmt.Sprintf("qemu-img convert -f qcow2 -O qcow2 %s %s",
-		proxmoxShellQuote(nfsURL), proxmoxShellQuote(stagePath))
 }

--- a/internal/providers/proxmox/s3_test.go
+++ b/internal/providers/proxmox/s3_test.go
@@ -79,18 +79,68 @@ func TestBuildExportFlattenCommand(t *testing.T) {
 	})
 }
 
-// TestBuildNFSImportConvertCommand pins the node-side qemu-img argv that reads the
-// staged qcow2 from nfs:// into the node stage file: -f qcow2 -O qcow2, no -U
-// (static source), with both the nfs:// URL and the stage path shell-quoted so a
-// crafted URL cannot break out of the argument.
-func TestBuildNFSImportConvertCommand(t *testing.T) {
-	cmd := buildNFSImportConvertCommand(
-		"nfs://172.16.56.13/export/virtrigaud/vmmigrations/ns/web/import.qcow2",
-		"/var/tmp/.virtrigaud-import-web.qcow2")
-	assert.Equal(t,
-		"qemu-img convert -f qcow2 -O qcow2 'nfs://172.16.56.13/export/virtrigaud/vmmigrations/ns/web/import.qcow2' '/var/tmp/.virtrigaud-import-web.qcow2'",
-		cmd)
-	assert.NotContains(t, cmd, " -U ", "import source is a static staged file; -U is not needed")
+// TestNFSInMountRel covers resolving the staged object's in-mount path from the
+// controller-built nfs:// URL by stripping the export prefix, tolerating query
+// params, and rejecting traversal / out-of-export paths.
+func TestNFSInMountRel(t *testing.T) {
+	rel, err := nfsInMountRel("nfs://172.16.56.13/export/virtrigaud/vmmigrations-ns-m1-export.qcow2", "/export/virtrigaud")
+	require.NoError(t, err)
+	assert.Equal(t, "vmmigrations-ns-m1-export.qcow2", rel)
+
+	rel2, err := nfsInMountRel("nfs://h/export/x/f.qcow2?gid=1000&uid=1000", "/export/x")
+	require.NoError(t, err)
+	assert.Equal(t, "f.qcow2", rel2, "query params must not leak into the in-mount path")
+
+	if _, err := nfsInMountRel("nfs://h/export/x/../etc/passwd", "/export/x"); err == nil {
+		t.Error("path traversal must be rejected")
+	}
+	if _, err := nfsInMountRel("nfs://h/export/x", "/export/x"); err == nil {
+		t.Error("a URL that names only the export root (no object) must be rejected")
+	}
+}
+
+// TestNFSSetprivPrefix verifies qemu-img is dropped to the migration's uid/gid only
+// when both are set; otherwise it runs as the SSH user (root).
+func TestNFSSetprivPrefix(t *testing.T) {
+	u, g := int64(1000), int64(1000)
+	assert.Equal(t, "setpriv --reuid 1000 --regid 1000 --clear-groups ", nfsSetprivPrefix(&u, &g))
+	assert.Equal(t, "", nfsSetprivPrefix(nil, nil))
+	assert.Equal(t, "", nfsSetprivPrefix(&u, nil), "both uid and gid required to drop privileges")
+}
+
+// TestBuildNFSKernelMountScript pins the node-side kernel-mount wrapper: a fresh
+// temp mount point, vers=3 NFS mount of <server>:<export> quoted as one argument,
+// a trap that unmounts + removes the dir on exit, then the inner command.
+func TestBuildNFSKernelMountScript(t *testing.T) {
+	s := buildNFSKernelMountScript("172.16.56.13", "/export/virtrigaud", "INNER_CMD", "")
+	assert.Contains(t, s, "MNT=$(mktemp -d /var/tmp/.virtrigaud-nfsmnt-XXXXXX)")
+	assert.Contains(t, s, "mount -t nfs -o vers=3 '172.16.56.13:/export/virtrigaud' \"$MNT\"")
+	assert.Contains(t, s, "trap 'umount \"$MNT\" 2>/dev/null || true; rmdir \"$MNT\" 2>/dev/null || true' EXIT")
+	assert.True(t, strings.HasSuffix(s, "INNER_CMD"), "inner command runs after the mount")
+
+	// extraCleanup is folded into the trap (used by the export to rm the local temp).
+	s2 := buildNFSKernelMountScript("h", "/e", "X", `rm -f "$TMP" 2>/dev/null || true`)
+	assert.Contains(t, s2, `rmdir "$MNT" 2>/dev/null || true; rm -f "$TMP" 2>/dev/null || true' EXIT`)
+}
+
+// TestBuildNFSKernelExportScript pins the two-stage Proxmox export: qemu-img flattens
+// the root-owned source to a local temp (as root) and chmods it readable, then the
+// temp is copied onto the mounted export as the migration's uid/gid (setpriv); the
+// trap unmounts AND removes the temp on exit.
+func TestBuildNFSKernelExportScript(t *testing.T) {
+	u, g := int64(1000), int64(1000)
+	s := buildNFSKernelExportScript("172.16.56.13", "/export/virtrigaud",
+		"vmmigrations-ns-m1-export.qcow2", "qcow2", "/mnt/pve/dir/images/101/vm-101-disk-1.qcow2",
+		"/var/tmp/.virtrigaud-export-101.qcow2", &u, &g)
+	// stage 1: root flatten to local temp, then world-readable
+	assert.Contains(t, s, "TMP='/var/tmp/.virtrigaud-export-101.qcow2'")
+	assert.Contains(t, s, "qemu-img convert -U -f 'qcow2' -O qcow2 '/mnt/pve/dir/images/101/vm-101-disk-1.qcow2' \"$TMP\"")
+	assert.Contains(t, s, `chmod 0644 "$TMP"`)
+	// stage 2: dropped-privilege copy onto the export
+	assert.Contains(t, s, "mount -t nfs -o vers=3 '172.16.56.13:/export/virtrigaud' \"$MNT\"")
+	assert.Contains(t, s, `setpriv --reuid 1000 --regid 1000 --clear-groups cp "$TMP" "$MNT"/'vmmigrations-ns-m1-export.qcow2'`)
+	// the temp is removed on exit
+	assert.Contains(t, s, `rm -f "$TMP" 2>/dev/null || true`)
 }
 
 // TestProxmoxExportStagePath asserts the export stage path is in the staging dir,


### PR DESCRIPTION
## What

Lab validation surfaced that the Proxmox NFS transport shipped in #273 — the qemu-img `nfs://` (libnfs) path — **does not work on a stock PVE node**: `pve-qemu-kvm` is built **without the libnfs block driver**, so the node's qemu-img rejects `nfs://` with `Unknown protocol 'nfs'`. (libvirt's host and the vSphere provider image both have libnfs, so they keep that path.)

This replaces the Proxmox NFS transport with a **kernel NFS mount** — exactly how PVE's first-class NFS storage mounts — needing no extra packages.

## How

- **Export (two-stage)**: qemu-img **as root** flattens the root-owned source disk to a local temp, then the temp is copied onto the mounted export **as the migration's `nfs.uid/gid`** via `setpriv`. The split is unavoidable with a kernel mount: a single process can't be both root (to read the root-owned PVE source) and the share's uid (to write the export) — only libnfs decouples the NFS identity from the process uid, which is why libvirt/vSphere keep the libnfs path.
- **Import**: mount the export, convert the staged qcow2 to the node-local stage file **as `nfs.uid/gid`**, then `qm importdisk` consumes it.
- Helpers `buildNFSKernelMountScript` / `buildNFSKernelExportScript` / `nfsSetprivPrefix` / `nfsInMountRel`; `vers=3` (numeric-uid AUTH_SYS, matching the libnfs path); a trap unmounts + removes the temp on exit (success or failure).

Presenting `nfs.uid/gid` keeps the staged objects interoperable with the libvirt/vSphere providers (which present the same uid via the libnfs URL query).

## Validation (lab, against OpenMediaVault)

Driven **GREEN end-to-end, both directions** over NFS:
- **libvirt → Proxmox** (import, `qm importdisk`) — `Ready`
- **Proxmox → libvirt** (export, two-stage) — `Ready` (a freshly-imported VM round-tripped back to libvirt)

(A linked-clone source whose template base disk has restrictive PVE perms fails the export's source read — an orthogonal linked-clone edge case, not an NFS-transport defect.)

## Tests

`TestBuildNFSKernelMountScript`, `TestBuildNFSKernelExportScript`, `TestNFSSetprivPrefix`, `TestNFSInMountRel`; the gate-pass tests still hold. `gofmt` clean, `golangci-lint` 0, `go build ./...`, proxmox suite passes.

Refs #236. ADR-0006 Slice 4. Supersedes the Proxmox transport from #273.