### PR TITLE
docs(migration): NFS backend guide, examples, and ADR-0006 Slice 4 validation (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-21 15:30] - docs(migration): NFS backend guide, examples, and ADR-0006 Slice 4 validation (#236)
+**Author:** @wrkode (William Rizzo)
+
+### Changed
+- `examples/vmmigration-nfs.yaml`: rewritten from the stale Slice-0 PVC-on-NFS model to the validated `storage.type: nfs` qemu-img backend (server/export/uid/gid), with inline requirements (mandatory `nfs.uid/gid`, reachability/ACL, host allowlist) and C6 hardening notes.
+- `examples/migration/README.md`: new **NFS staging backend** section (per-provider transport table, the mandatory uid/gid rule, flat staging object, C3 host allowlist, C6 cleartext/`root_squash`/one-export-per-tenant hardening); added the NFS example to the table; corrected the now-stale "Proxmox is S3-only" claim (Proxmox advertises s3 **and** nfs).
+- `docs/adr/0006-storage-backend-agnostic-cross-hypervisor-migration.md`: **Slice 4 — NFS backend, validated 2026-06-21** implementation-log entry + a "Slice 4 decisions & findings" subsection (qemu-img native transport; Proxmox kernel-mount because pve-qemu has no libnfs; uid/gid mandatory; flat key; target-side integrity; C6 posture).
+
+### Why
+Document the NFS migration backend lab-validated across all three providers in both directions, and the operational requirements operators must follow (uid/gid, export hardening).
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [x] Documentation only
+
 ## [2026-06-21 14:30] - fix(proxmox): NFS migration via kernel mount (pve-qemu lacks libnfs) (ADR-0006 Slice 4, #236)
 **Author:** @wrkode (William Rizzo)
 

--- a/docs/adr/0006-storage-backend-agnostic-cross-hypervisor-migration.md
+++ b/docs/adr/0006-storage-backend-agnostic-cross-hypervisor-migration.md
@@ -315,6 +315,49 @@ the planned libvirt→libvirt and `direct`-mode slices. As shipped:
   **Proxmox → vSphere**, and **vSphere → Proxmox** all reach `Ready`. Combined
   with Slices 1–2 (vSphere ⇄ libvirt) this closes the **complete 3-hypervisor S3
   matrix** for #236; only the NFS backend and the `direct` mode remain.
+- **Slice 4 — NFS backend, all three providers, both directions, validated
+  2026-06-21.** The disk is staged on an NFS export and moved with **qemu-img's
+  native transport** (no PVC, no relay, no S3 credentials). libvirt (host-side) and
+  vSphere (pod-side) use qemu-img's `nfs://` libnfs driver directly; **Proxmox uses
+  a kernel NFS mount** because `pve-qemu-kvm` ships no libnfs driver (`qemu-img`
+  rejects `nfs://` with `Unknown protocol 'nfs'`). Validated end-to-end against an
+  OpenMediaVault server: libvirt↔libvirt, libvirt→vSphere, vSphere→libvirt,
+  libvirt→Proxmox, and Proxmox→libvirt all reach `Ready`. With the S3 matrix
+  (Slices 1–3) this completes #236's backend-agnostic goal; only the `direct` mode
+  and resumability hardening (Slice 5) remain.
+
+### Slice 4 decisions & findings (NFS backend)
+
+1. **qemu-img native transport, not a PVC mount.** libvirt and vSphere shell out to
+   `qemu-img convert` against an `nfs://<server><export>/<key>?uid=&gid=` URL — the
+   mature libnfs client qemu/KVM already use. No Go/Rust NFS client, no privileged
+   pod mount. The Debian `qemu-block-extra` package provides `block-nfs.so`; it is
+   baked into the vSphere provider image and is present on the libvirt host.
+2. **Proxmox cannot use libnfs — it kernel-mounts.** `pve-qemu-kvm` is built without
+   the libnfs block driver, so the Proxmox provider mounts the export with the
+   node's kernel NFS client (exactly how PVE's first-class NFS storage mounts) and
+   runs `qemu-img` against the mount. The export is **two-stage**: `qemu-img` as
+   root flattens the root-owned source to a local temp, then the temp is copied onto
+   the export as the migration's `nfs.uid/gid` via `setpriv` — a single process
+   cannot be both root (to read the source) and the share's uid (to write the
+   export), which only libnfs (URL-set uid) can decouple.
+3. **`nfs.uid`/`nfs.gid` (C5) are mandatory in practice.** AUTH_SYS authorizes by
+   the numeric uid/gid the client presents; each provider's qemu-img runs as a
+   different identity, so all legs must be pinned to the export owner's uid/gid or
+   the import fails `NFS3ERR_ACCES`. This was the first cross-provider lab finding.
+4. **The staged object is FLAT.** NFS is a real filesystem — it cannot create a
+   nested key's parent directories the way an S3 key prefix does (a nested key fails
+   the libnfs mount with `MNT3ERR_NOENT`). The controller stages
+   `vmmigrations-<ns>-<name>-<stage>.qcow2` in the export root.
+5. **Integrity is target-side.** qemu-img emits no in-stream byte checksum over the
+   NFS transport, so D5's dual checksum degrades to a target-side `qemu-img check` /
+   post-import uuid query rather than a SHA256 match. The security re-bless accepted
+   this for the qemu-img model.
+6. **Security posture (C6).** AUTH_SYS/NFSv3 is cleartext with no Kerberos; the
+   uid/gid is an assertion, not an authenticated identity. Operators must run the
+   export on a trusted network, keep `root_squash` on, and use one export per
+   tenant. The server host is SSRF-gated by `--migration-storage-allowed-hosts`
+   (C3, shared with S3).
 
 ### Slice 2 decisions & findings (refine D3/D4 for the vSphere target)
 

--- a/examples/migration/README.md
+++ b/examples/migration/README.md
@@ -10,9 +10,12 @@ VirtRigaud's validated cross-hypervisor migration is **storage-backend-agnostic*
 and **never traverse a CSI PVC**. The source exports its native disk format and
 the target converts on import. This is the validated path across **all three
 providers in any direction** — vSphere, libvirt, and Proxmox (ADR-0006 Slices
-1–3). The Proxmox provider is **S3/relay-only**: it does not advertise a PVC, NFS,
-or `direct` backend, so a `storage.type: pvc` migration with a Proxmox source or
-target fails capability validation.
+1–3). An **NFS** staging backend is the validated second option across all three
+providers (ADR-0006 Slice 4 — see the [NFS section](#nfs-staging-backend-adr-0006-slice-4)
+below). The Proxmox provider advertises **s3 and nfs** (not PVC): its disks live on
+the PVE node, so the pod-mounted PVC path can never reach them, and a
+`storage.type: pvc` migration with a Proxmox source or target fails capability
+validation.
 
 A legacy PVC-backed model also exists for the vSphere/libvirt directions (a
 ReadWriteMany StorageClass), but it is compat-only and does not work for Proxmox
@@ -37,6 +40,7 @@ Key points before using these examples:
 | [libvirt-to-vsphere.yaml](./libvirt-to-vsphere.yaml) | Libvirt/KVM → vSphere | S3 | **Tested** (ADR-0006 Slice 2) |
 | [vsphere-to-proxmox.yaml](./vsphere-to-proxmox.yaml) | vSphere → Proxmox VE | S3 | **Tested** (ADR-0006 Slice 3) |
 | [proxmox-to-libvirt.yaml](./proxmox-to-libvirt.yaml) | Proxmox VE → Libvirt/KVM | S3 | **Tested** (ADR-0006 Slice 3) |
+| [`../vmmigration-nfs.yaml`](../vmmigration-nfs.yaml) | Any ↔ Any | NFS | **Tested** (ADR-0006 Slice 4) |
 
 ## Quick start (S3, vSphere ↔ libvirt)
 
@@ -81,6 +85,51 @@ the same S3/relay shape. Note that the Proxmox **Provider's** Secret must carry
 both an API token (`token_id`/`token_secret`) and SSH credentials (`ssh_user` +
 `ssh_password` and/or `ssh_privatekey`) plus a pinned `known_hosts`, because the
 Proxmox disk data plane runs `qemu-img`/`qm` on the PVE node over SSH.
+
+## NFS staging backend (ADR-0006 Slice 4)
+
+NFS is the validated **second** staging backend. Instead of an object store, the
+disk is staged on an NFS export and moved with **qemu-img's native transport** —
+no PVC, no provider-pod relay, no S3 credentials. It is validated across **all
+three providers in both directions** (libvirt ↔ vSphere ↔ Proxmox). Set
+`storage.type: nfs` with `storage.nfs.{server,export,uid,gid}` — see
+[`../vmmigration-nfs.yaml`](../vmmigration-nfs.yaml).
+
+**Per-provider transport (an implementation detail, but it drives the
+requirements below):**
+
+| Provider | Who runs qemu-img | NFS client |
+|----------|-------------------|------------|
+| libvirt  | the libvirt **host** (over SSH) | qemu-img `nfs://` (libnfs) |
+| vSphere  | the provider **pod** | qemu-img `nfs://` (libnfs) |
+| Proxmox  | the PVE **node** | **kernel NFS mount** — `pve-qemu-kvm` ships no libnfs, so the node mounts the export (as its native NFS storage does) and qemu-img works against the mount |
+
+**Operational requirements:**
+
+- **`nfs.uid` / `nfs.gid` are effectively mandatory for cross-provider
+  migrations.** AUTH_SYS authorizes by the numeric uid/gid the client presents,
+  and each provider's qemu-img runs as a different identity (the libvirt SSH user,
+  the vSphere pod's `uid 65532`, the Proxmox node's root). Set them to the uid/gid
+  that **owns the export's files** so every leg can read *and* write the same
+  staged object. (Proxmox presents them via `setpriv`; libvirt/vSphere via the
+  libnfs URL.) Omitting them works only when every leg already presents a trusted
+  uid.
+- **Reachability + ACL.** The server must be reachable from each provider's data
+  plane — the hypervisor host/node for libvirt/Proxmox, the provider **pod** for
+  vSphere (its egress is a cluster node IP) — and the export ACL must allow those
+  client IPs.
+- **Host allowlist (C3).** The server host must pass the operator's
+  `--migration-storage-allowed-hosts`; loopback/link-local/metadata targets are
+  always rejected.
+- **Flat staging object.** The staged disk is a single flat file in the export
+  root, `vmmigrations-<ns>-<name>-<stage>.qcow2` (NFS, unlike S3 keys, cannot
+  auto-create directories). One export per tenant keeps these from colliding.
+
+**Hardening (ADR-0006 C6).** AUTH_SYS over NFSv3 is **cleartext with no Kerberos**
+— the uid/gid is an assertion, not an authenticated identity. Run the migration
+export only on a **trusted network**, keep **`root_squash` on**, give each tenant
+its **own export**, and prefer narrow per-client ACLs over broad subnets. The disk
+bytes themselves are not encrypted in transit.
 
 ## Reference
 

--- a/examples/vmmigration-nfs.yaml
+++ b/examples/vmmigration-nfs.yaml
@@ -1,89 +1,74 @@
-# NFS-staged cross-hypervisor migration.
+# VMMigration over the NFS staging backend (ADR-0006 Slice 4).
 #
-# There are TWO ways to involve NFS, and they are different:
+# The NFS backend stages the disk on an NFS export and moves it with qemu-img's
+# native transport — there is NO PVC and NO provider-pod relay. Each provider
+# reaches the export the way that is natural for it:
+#   - libvirt  : the libvirt HOST's qemu-img writes/reads nfs:// over libnfs.
+#   - vSphere  : the provider POD's qemu-img writes/reads nfs:// over libnfs.
+#   - Proxmox  : the PVE NODE kernel-mounts the export (pve-qemu has no libnfs)
+#                and qemu-img works against the mount.
 #
-#  1. WORKING TODAY — PVC backed by an NFS StorageClass. The migration uses the
-#     standard `storage.type: pvc` path; the PVC just happens to be provisioned
-#     on NFS. This is the recommended approach and is shown first below.
+# REQUIREMENTS (read before using):
+#   1. nfs.uid / nfs.gid are effectively MANDATORY for cross-provider migrations.
+#      AUTH_SYS authorizes by the numeric uid/gid the client presents, and each
+#      provider's qemu-img runs as a different process identity (the libvirt SSH
+#      user, the vSphere pod's uid 65532, the Proxmox node's root). Set uid/gid to
+#      the identity that OWNS the export's files so every provider can read AND
+#      write the same staged object. Omitting them works only when every leg
+#      happens to present a uid the export already trusts.
+#   2. The NFS server must be reachable from the data plane of BOTH providers
+#      (the hypervisor host/node for libvirt/Proxmox, the provider pod for
+#      vSphere) and must allow those client IPs in the export ACL.
+#   3. The server host must pass the operator's migration-storage host allowlist
+#      (--migration-storage-allowed-hosts); loopback/link-local/metadata targets
+#      are always rejected (ADR-0006 C3).
 #
-#  2. SURFACE ONLY (ADR-0006 Slice 0) — the native `storage.type: nfs` backend.
-#     It exists in the CRD/proto/capability surface but has NO transfer logic
-#     yet, so it is rejected at the Validating phase with:
-#
-#       storage backend "nfs" is not yet implemented; only "pvc" is supported
-#       today (ADR-0006 Slice 0)
-#
-#     The native-nfs snippet is shown second, commented, for review stability.
-#
-# Currently tested migration path: vSphere → Libvirt/KVM. Other directions are
-# roadmap.
-
-# NFS StorageClass — create once per cluster (approach #1).
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: nfs-migration-storage
-provisioner: nfs.csi.k8s.io
-parameters:
-  server: nfs-server.company.local
-  share: /export/vm-migrations
-volumeBindingMode: Immediate
-reclaimPolicy: Delete
-
----
-# VMMigration using a PVC on the NFS-backed StorageClass (approach #1 — WORKS).
+# Harden the export (ADR-0006 C6): one export per tenant, root_squash on, and
+# remember AUTH_SYS + NFSv3 are CLEARTEXT with no Kerberos — run it only on a
+# trusted migration network.
 apiVersion: infra.virtrigaud.io/v1beta1
 kind: VMMigration
 metadata:
-  name: libvirt-to-proxmox-migration
+  name: app-libvirt-to-vsphere-nfs
   namespace: default
 spec:
   source:
     vmRef:
-      name: legacy-app-libvirt
-    createSnapshot: true
+      name: app-on-libvirt
+    # A powered-off source gives a clean cold copy; a snapshot is optional and
+    # not required for NFS. (Leave createSnapshot unset/false to avoid the
+    # multi-disk/CDROM snapshot pitfall.)
+    createSnapshot: false
     powerOffBeforeMigration: true
-
   target:
-    name: legacy-app-proxmox
+    name: app-on-vsphere
     providerRef:
-      name: proxmox-cluster
-      namespace: default
+      name: vsphere-prod
     classRef:
-      name: standard-4cpu-8gb
+      name: standard-2cpu-4gb
     networks:
-      - name: vlan-100-production
-    placementRef:
-      name: proxmox-node-2
-
-  # PVC on an NFS StorageClass — the working path today.
+      - name: primary
+        networkRef:
+          name: vm-network
+    powerOn: false
   storage:
-    type: pvc
-    pvc:
-      storageClassName: nfs-migration-storage
-      size: 200Gi
-      accessMode: ReadWriteMany
-
-  # ----------------------------------------------------------------------------
-  # Approach #2 (ADR-0006 Slice 0, SURFACE ONLY — rejected at validation today):
-  # replace the `storage:` block above with the native nfs backend below.
-  #
-  # storage:
-  #   type: nfs
-  #   transferMode: auto        # auto | relay | direct
-  #   nfs:
-  #     server: nfs-server.company.local
-  #     export: /export/vm-migrations
-  #     path: legacy-app/        # optional sub-path within the export
-  #     readOnly: false
-  # ----------------------------------------------------------------------------
-
+    type: nfs
+    nfs:
+      # NFS server exporting the staging share (IP or hostname; a hostname is
+      # resolved and SSRF-checked by the controller).
+      server: 172.16.56.13
+      # Absolute exported path on the server. The staged object is a single flat
+      # file in this export root: vmmigrations-<ns>-<name>-<stage>.qcow2 (NFS
+      # cannot auto-create directories the way S3 keys do).
+      export: /export/virtrigaud
+      # AUTH_SYS identity presented to the server — set to the export owner's
+      # uid/gid (see REQUIREMENTS above). Mandatory in practice for cross-provider.
+      uid: 1000
+      gid: 1000
+    # transferMode is informational for nfs: the qemu-img transport is neither
+    # "relay" nor pod-mediated, and the controller exempts nfs from the relay gate.
+    transferMode: auto
   options:
-    diskFormat: qcow2
-    compress: false
+    cleanupPolicy: OnSuccess
     verifyChecksums: true
-    timeout: "4h"
-    retryPolicy:
-      maxRetries: 3
-      retryDelay: "3m"
-      backoffMultiplier: 2
+    timeout: 1h


### PR DESCRIPTION
## What

Documentation for the **NFS migration backend** (ADR-0006 Slice 4), lab-validated across all three providers in both directions.

- **`examples/vmmigration-nfs.yaml`** — rewritten from the stale Slice-0 *PVC-on-NFS* model to the validated **`storage.type: nfs`** qemu-img backend (`server`/`export`/`uid`/`gid`), with inline requirements and C6 hardening notes.
- **`examples/migration/README.md`** — new **NFS staging backend** section: the per-provider transport table (libnfs for libvirt/vSphere, **kernel-mount for Proxmox** since pve-qemu has no libnfs), the **mandatory `nfs.uid/gid`** rule, the flat staging object, the C3 host allowlist, and C6 hardening (cleartext AUTH_SYS, `root_squash`, one export per tenant). Adds the NFS example to the table and corrects the now-stale "Proxmox is S3-only" claim.
- **`docs/adr/0006-…md`** — **Slice 4 — NFS backend, validated 2026-06-21** implementation-log entry + a "Slice 4 decisions & findings" subsection.

## Validation captured

libvirt↔libvirt, libvirt→vSphere, vSphere→libvirt, libvirt→Proxmox, Proxmox→libvirt — all reached `Ready` against the lab OpenMediaVault server. The findings that became operator requirements (mandatory uid/gid → `NFS3ERR_ACCES`; flat key → `MNT3ERR_NOENT`; Proxmox `Unknown protocol 'nfs'` → kernel-mount) are documented.

Docs-only; example YAML validated as parseable.

Refs #236. ADR-0006 Slice 4.