### PR TITLE
fix(libvirt): select <domain type=kvm> when the host has /dev/kvm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-30 12:00] - fix(libvirt): select <domain type=kvm> when the host has /dev/kvm (#282)
+**Author:** @jing2uo (Komh)
+
+### Fixed
+- `internal/providers/libvirt/provider_virsh.go`: probe the (possibly remote) host for a **readable** `/dev/kvm` (`test -r`) and render `<domain type='kvm'>` instead of the hard-coded `qemu`, restoring hardware acceleration. Falls back to `qemu` when `/dev/kvm` is absent, unreadable, or the probe fails. On the fallback path a second `test -e` probe distinguishes the two causes in the log: **absent** → `INFO` (expected on a TCG-only host), **present-but-unreadable** → `WARN` with remediation (grant the qemu user read access to fix device-cgroup/permission restrictions). Decision logic split into `domainTypeFromProbe` and covered by a table test.
+
+### Why
+Hard-coded `type='qemu'` forced TCG software emulation on KVM-capable hosts (~100% CPU, glacial boot). `test -r` (not `-e`) ensures a present-but-unopenable `/dev/kvm` — e.g. device-cgroup/permission restrictions in containerized libvirt — still falls back to `qemu` rather than rendering a `kvm` domain that fails to start; the absent-vs-unreadable log split tells the operator whether the fallback is expected or a misconfiguration they should fix. Fixes #282.
+
+### Impact
+- [ ] Breaking change
+- [ ] Requires cluster rollout
+- [ ] Config change only
+- [ ] Documentation only
+
 ## [2026-06-21 15:30] - docs(migration): NFS backend guide, examples, and ADR-0006 Slice 4 validation (#236)
 **Author:** @wrkode (William Rizzo)
 

--- a/internal/providers/libvirt/domaintype_test.go
+++ b/internal/providers/libvirt/domaintype_test.go
@@ -1,0 +1,27 @@
+package libvirt
+
+import "testing"
+
+// TestDomainTypeFromProbe locks in the KVM-detection fallback (#282): a readable
+// /dev/kvm selects hardware-accelerated "kvm"; both failure cases (absent, or
+// present-but-unreadable) fall back to "qemu" (TCG), which starts on any host.
+func TestDomainTypeFromProbe(t *testing.T) {
+	tests := []struct {
+		name     string
+		readable bool
+		exists   bool
+		want     string
+	}{
+		{"readable -> kvm", true, false, "kvm"},
+		{"present but unreadable -> qemu", false, true, "qemu"},
+		{"absent -> qemu", false, false, "qemu"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := domainTypeFromProbe(tt.readable, tt.exists); got != tt.want {
+				t.Errorf("domainTypeFromProbe(readable=%v, exists=%v) = %q, want %q",
+					tt.readable, tt.exists, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/providers/libvirt/provider_virsh.go
+++ b/internal/providers/libvirt/provider_virsh.go
@@ -188,7 +188,7 @@ func (p *Provider) createVMWithCloudInit(ctx context.Context, req contracts.Crea
 	}
 
 	// Generate domain XML with proper disk and cloud-init ISO
-	domainXML, err := p.generateDomainXMLWithStorage(req, diskPath, cloudInitISOPath)
+	domainXML, err := p.generateDomainXMLWithStorage(ctx, req, diskPath, cloudInitISOPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate domain XML: %w", err)
 	}
@@ -1176,7 +1176,7 @@ func (p *Provider) generateNetworkInterfacesXML(networks []contracts.NetworkAtta
 }
 
 // generateDomainXMLWithStorage creates libvirt domain XML with proper storage configuration
-func (p *Provider) generateDomainXMLWithStorage(req contracts.CreateRequest, diskPath, cloudInitISOPath string) (string, error) {
+func (p *Provider) generateDomainXMLWithStorage(ctx context.Context, req contracts.CreateRequest, diskPath, cloudInitISOPath string) (string, error) {
 	// Extract specifications from request
 	cpuCount := int32(1)    // default
 	memoryMB := int64(1024) // default 1GB
@@ -1302,7 +1302,13 @@ func (p *Provider) generateDomainXMLWithStorage(req contracts.CreateRequest, dis
 	// <memory>==<currentMemory>, <vcpu placement='static'>N</vcpu> layout.
 	cpuMem := buildCPUMemoryXML(cpuCount, memoryMB, cpuHotAddEnabled, memoryHotAddEnabled)
 
-	domainXML := fmt.Sprintf(`<domain type='qemu'>
+	// Pick the domain type from the host: KVM for hardware acceleration when
+	// available, otherwise TCG software emulation. Hard-coding either value is
+	// wrong — 'qemu' cripples guests on KVM hosts (~100% CPU, glacial boot),
+	// while 'kvm' fails to start on hosts without /dev/kvm.
+	domainType := p.detectDomainType(ctx)
+
+	domainXML := fmt.Sprintf(`<domain type='%s'>
   <name>%s</name>
   <uuid>%s</uuid>
   %s
@@ -1380,6 +1386,7 @@ func (p *Provider) generateDomainXMLWithStorage(req contracts.CreateRequest, dis
     </memballoon>
   </devices>
 </domain>`,
+		domainType,
 		req.Name,
 		uuid,
 		cpuMem.Memory,
@@ -1392,6 +1399,20 @@ func (p *Provider) generateDomainXMLWithStorage(req contracts.CreateRequest, dis
 		networkInterfacesXML)
 
 	return domainXML, nil
+}
+
+// detectDomainType returns the libvirt <domain type> for new domains: "kvm" when
+// the (possibly remote) host exposes /dev/kvm (hardware acceleration), otherwise
+// "qemu" (TCG software emulation). qemu is the safe fallback — it starts on any
+// host, including when the probe itself fails — whereas a kvm domain fails to
+// start without /dev/kvm. The probe runs over the same ssh/local path as the
+// provider's other host-side checks (cf. the `test -f <image>` existence probe).
+func (p *Provider) detectDomainType(ctx context.Context) string {
+	if _, err := p.virshProvider.runVirshCommand(ctx, "!", "test", "-e", "/dev/kvm"); err != nil {
+		log.Printf("INFO Host has no usable /dev/kvm; using domain type 'qemu' (software emulation)")
+		return "qemu"
+	}
+	return "kvm"
 }
 
 // generateUUID creates a simple UUID for the domain

--- a/internal/providers/libvirt/provider_virsh.go
+++ b/internal/providers/libvirt/provider_virsh.go
@@ -1408,11 +1408,34 @@ func (p *Provider) generateDomainXMLWithStorage(ctx context.Context, req contrac
 // start without /dev/kvm. The probe runs over the same ssh/local path as the
 // provider's other host-side checks (cf. the `test -f <image>` existence probe).
 func (p *Provider) detectDomainType(ctx context.Context) string {
-	if _, err := p.virshProvider.runVirshCommand(ctx, "!", "test", "-e", "/dev/kvm"); err != nil {
-		log.Printf("INFO Host has no usable /dev/kvm; using domain type 'qemu' (software emulation)")
-		return "qemu"
+	// Happy path: one round-trip. `test -r` covers both "exists" and "readable".
+	if _, err := p.virshProvider.runVirshCommand(ctx, "!", "test", "-r", "/dev/kvm"); err == nil {
+		return domainTypeFromProbe(true, false)
 	}
-	return "kvm"
+	// Not readable — second probe (only on the failure path) tells the operator
+	// whether /dev/kvm is simply absent (expected on a TCG-only host) or present
+	// but unopenable (a host-side permission/cgroup misconfiguration to fix).
+	_, existsErr := p.virshProvider.runVirshCommand(ctx, "!", "test", "-e", "/dev/kvm")
+	return domainTypeFromProbe(false, existsErr == nil)
+}
+
+// domainTypeFromProbe maps the /dev/kvm probe outcomes to a domain type and logs
+// the reason for any fallback. readable = `test -r /dev/kvm` succeeded; exists is
+// consulted only when !readable (from `test -e`) to distinguish absent from
+// present-but-unreadable. Split out so the decision/logging is unit-testable
+// without execing the probe.
+func domainTypeFromProbe(readable, exists bool) string {
+	switch {
+	case readable:
+		return "kvm"
+	case exists:
+		log.Printf("WARN /dev/kvm is present but not readable by the libvirt/qemu user " +
+			"(device-cgroup or permission restriction); using domain type 'qemu' (software emulation). " +
+			"Grant the qemu user read access to /dev/kvm to enable hardware acceleration.")
+	default:
+		log.Printf("INFO Host has no /dev/kvm; using domain type 'qemu' (software emulation)")
+	}
+	return "qemu"
 }
 
 // generateUUID creates a simple UUID for the domain


### PR DESCRIPTION
## What

The libvirt provider hard-coded the domain type as `<domain type='qemu'>` when generating domain XML, forcing **TCG software emulation** regardless of host support. On KVM-capable hosts this pegged guests at ~100% CPU and made them boot glacially (VNC stuck on the "display not initialized" placeholder), so VMs looked broken when they were merely running unaccelerated.

This picks the domain type from the host instead.

Fixes #282.

## How

- Add `Provider.detectDomainType(ctx)` — probes the (possibly remote) host for `/dev/kvm` over the same ssh/local path the provider already uses for host-side checks (cf. the existing `test -f <image>` existence probe), returning `kvm` when present and `qemu` otherwise.
- `generateDomainXMLWithStorage` now takes `ctx` and renders the detected type instead of a literal.

### Fallback / safety

`qemu` is used whenever `/dev/kvm` is absent **and** whenever the probe itself fails. A `qemu` domain starts on any host, whereas a hard-coded `kvm` domain fails to start on a host without `/dev/kvm` — so correctness (the VM boots) is preferred over performance when host support is unknown. A blunt hard-coded `kvm` is intentionally avoided for that reason.

## Testing

- `go build ./...`, `go vet ./internal/providers/libvirt/`, and `go test ./internal/providers/libvirt/` all pass; `gofmt` clean.
- Manually verified on a remote KVM host (`qemu+ssh`): with the detection in place a fresh domain reached an `Ubuntu 22.04 / login:` prompt in ~40s with CPU no longer pinned, vs. minutes-with-no-display under the previous `type='qemu'`.

Same function/area as the already-fixed hard-coded `<emulator>` portability bug (#253); same "don't hard-code host-specific domain XML" theme.
