### PR TITLE
fix(libvirt): ListVMs dumps domain XML once, not per-domain SSH fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-06-30 17:00] - fix(libvirt): ListVMs dumps domain XML once, not per-domain SSH fan-out (#285)
+**Author:** @jing2uo (Komh)
+
+### Fixed
+- `internal/providers/libvirt/{provider_virsh.go,virsh.go,domainxml.go}`: `ListVMs` no longer fans out one `virsh domstate`/`dumpxml`/stat SSH round-trip per domain (the `1 + N` blow-up that tripped the reconcile deadline on hosts with many VMs). It now runs one `virsh list --all` for name+state and one `dumpxml` per domain parsed locally with `encoding/xml`, extracting only what list/adoption needs (identity, vCPU, memory, disk paths+format, NIC MACs). The same XML shape is returned by go-libvirt's `DomainGetXMLDesc`, so the parser carries straight over to the native-client work in #257.
+- `internal/providers/libvirt/virsh.go`: `parseDomainListTable` slices rows by the header's `Name`/`State` column byte-offsets instead of `strings.Fields`, so a domain named `Windows Server 2019` is no longer truncated to `Windows` with its power state mis-read as `Off` — a real adoption hazard, since adoption discovers pre-existing, human-named domains. It also warns instead of silently returning zero domains when the output has no header separator or no Name/State columns (an empty host still prints the separator, so that path means the format changed).
+- `internal/providers/libvirt/domainxml.go`: `MemoryMiB` reads the `<memory unit=…>` attribute and errors on a non-KiB unit rather than blindly dividing by 1024. dumpxml is always KiB today, so this is a guard for the go-libvirt XML path in #257, where the unit is not guaranteed.
+
+### Why
+On hosts with many domains the per-domain SSH fan-out pushed `ListVMs` past the reconcile deadline, so adoption/listing timed out. Collapsing to `1 + N` round-trips with local XML parsing fixes the deadline and, as a side effect, makes disk format come from `<driver type>` (more reliable than the old path-suffix guess).
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (libvirt provider image)
+- [ ] Config change only
 ## [2026-06-30 12:00] - fix(libvirt): select <domain type=kvm> when the host has /dev/kvm (#282)
 **Author:** @jing2uo (Komh)
 

--- a/internal/providers/libvirt/domainxml.go
+++ b/internal/providers/libvirt/domainxml.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+)
+
+// domainXML is the minimal subset of `virsh dumpxml` output that ListVMs/adoption
+// needs: identity, cpu, memory, disk paths+format, and NIC MACs. Everything here
+// is config (not runtime state), so power state still comes from `virsh list`.
+type domainXML struct {
+	Name    string   `xml:"name"`
+	UUID    string   `xml:"uuid"`
+	VCPU    int32    `xml:"vcpu"` // <vcpu>N</vcpu> — configured vCPU count
+	Memory  memValue `xml:"memory"`
+	Devices struct {
+		Disks []struct {
+			Device string `xml:"device,attr"`
+			Driver struct {
+				Type string `xml:"type,attr"`
+			} `xml:"driver"`
+			Source struct {
+				File string `xml:"file,attr"`
+			} `xml:"source"`
+		} `xml:"disk"`
+		Interfaces []struct {
+			MAC struct {
+				Address string `xml:"address,attr"`
+			} `xml:"mac"`
+		} `xml:"interface"`
+	} `xml:"devices"`
+}
+
+// memValue is a <memory>/<currentMemory> element: its value plus the unit
+// attribute. virsh dumpxml normalizes to KiB and omits the unit (or sets it to
+// "KiB"), but the same struct also parses go-libvirt's DomainGetXMLDesc output
+// for #257, where the unit is not guaranteed — so the unit is captured, not
+// assumed away.
+type memValue struct {
+	KiB  int64  `xml:",chardata"`
+	Unit string `xml:"unit,attr"`
+}
+
+// parseDomainXML unmarshals a single `virsh dumpxml` document.
+func parseDomainXML(raw string) (*domainXML, error) {
+	var d domainXML
+	if err := xml.Unmarshal([]byte(raw), &d); err != nil {
+		return nil, fmt.Errorf("failed to parse domain XML: %w", err)
+	}
+	return &d, nil
+}
+
+// MemoryMiB returns the configured memory in MiB. libvirt hardcodes unit='KiB'
+// in its XML formatter (domain_conf.c) and the docs guarantee "output is always
+// in KiB", so for libvirt-produced XML this never sees another unit — the guard
+// is a contract check, not a converter. It errors on a non-KiB unit (XML from a
+// non-libvirt source, a hand-written fixture, a future schema change) rather
+// than silently mis-scaling via a blind /1024.
+func (d *domainXML) MemoryMiB() (int64, error) {
+	if u := d.Memory.Unit; u != "" && u != "KiB" {
+		return 0, fmt.Errorf("unexpected memory unit %q (want KiB)", u)
+	}
+	return d.Memory.KiB / 1024, nil
+}
+
+// Disks returns the file-backed data disks, skipping cdrom/floppy and cloud-init
+// ISOs. Size is 0: it is not in the XML and adoption does not need it (the old
+// local os.Stat on a remote path always yielded 0 anyway).
+func (d *domainXML) Disks(domainName string) []contracts.DiskInfo {
+	var disks []contracts.DiskInfo
+	for _, disk := range d.Devices.Disks {
+		if disk.Device != "disk" {
+			continue
+		}
+		path := disk.Source.File
+		if path == "" {
+			continue // non-file source (network/block) — not handled here
+		}
+		if strings.HasSuffix(path, "-cidata.iso") || strings.HasSuffix(path, "cloud-init.iso") {
+			continue
+		}
+		format := disk.Driver.Type
+		if format == "" {
+			format = "qcow2"
+		}
+		disks = append(disks, contracts.DiskInfo{
+			ID:      fmt.Sprintf("%s-disk-%d", domainName, len(disks)),
+			Path:    path,
+			SizeGiB: 0,
+			Format:  format,
+		})
+	}
+	return disks
+}
+
+// Networks returns one entry per NIC with its MAC. IPs are intentionally empty:
+// they are not needed at list/adoption time and are discovered by the normal VM
+// reconcile afterwards.
+func (d *domainXML) Networks() []contracts.NetworkInfo {
+	var networks []contracts.NetworkInfo
+	for _, iface := range d.Devices.Interfaces {
+		networks = append(networks, contracts.NetworkInfo{
+			MAC:       iface.MAC.Address,
+			IPAddress: "",
+		})
+	}
+	return networks
+}

--- a/internal/providers/libvirt/domainxml_test.go
+++ b/internal/providers/libvirt/domainxml_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import "testing"
+
+const sampleDomainXML = `<domain type='kvm'>
+  <name>web-01</name>
+  <uuid>4dea22b3-1d52-d8f3-2516-782e98ab3fa0</uuid>
+  <memory unit='KiB'>2097152</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <devices>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='/var/lib/libvirt/images/web-01.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source file='/var/lib/libvirt/images/web-01-cidata.iso'/>
+      <target dev='sda' bus='sata'/>
+    </disk>
+    <interface type='network'>
+      <mac address='52:54:00:12:34:56'/>
+      <source network='default'/>
+    </interface>
+  </devices>
+</domain>`
+
+func TestParseDomainXML(t *testing.T) {
+	dx, err := parseDomainXML(sampleDomainXML)
+	if err != nil {
+		t.Fatalf("parseDomainXML: %v", err)
+	}
+	if dx.Name != "web-01" {
+		t.Errorf("Name = %q, want web-01", dx.Name)
+	}
+	if dx.UUID != "4dea22b3-1d52-d8f3-2516-782e98ab3fa0" {
+		t.Errorf("UUID = %q", dx.UUID)
+	}
+	if dx.VCPU != 2 {
+		t.Errorf("VCPU = %d, want 2", dx.VCPU)
+	}
+	if dx.Memory.KiB != 2097152 {
+		t.Errorf("Memory = %d, want 2097152 KiB", dx.Memory.KiB)
+	}
+	if mib, err := dx.MemoryMiB(); err != nil || mib != 2048 {
+		t.Errorf("MemoryMiB() = %d, %v; want 2048, nil", mib, err)
+	}
+}
+
+// A non-KiB memory unit (possible from go-libvirt XML, never from dumpxml) must
+// error rather than silently mis-scale via a blind /1024.
+func TestDomainXMLMemoryMiB_rejectsNonKiB(t *testing.T) {
+	dx, err := parseDomainXML(`<domain><memory unit='MiB'>2048</memory></domain>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dx.MemoryMiB(); err == nil {
+		t.Error("MemoryMiB() = nil error, want error for unit='MiB'")
+	}
+}
+
+// Disks() must keep only device="disk", drop the cdrom/cloud-init ISO, take the
+// format from <driver type>, and leave size 0 (not present in XML).
+func TestDomainXMLDisks_filtersCdromAndCloudInit(t *testing.T) {
+	dx, err := parseDomainXML(sampleDomainXML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	disks := dx.Disks("web-01")
+	if len(disks) != 1 {
+		t.Fatalf("got %d disks, want 1 (cdrom/cidata excluded): %+v", len(disks), disks)
+	}
+	d := disks[0]
+	if d.Path != "/var/lib/libvirt/images/web-01.qcow2" {
+		t.Errorf("Path = %q", d.Path)
+	}
+	if d.Format != "qcow2" {
+		t.Errorf("Format = %q, want qcow2", d.Format)
+	}
+	if d.SizeGiB != 0 {
+		t.Errorf("SizeGiB = %d, want 0 (not in XML)", d.SizeGiB)
+	}
+}
+
+func TestDomainXMLNetworks_extractsMAC(t *testing.T) {
+	dx, err := parseDomainXML(sampleDomainXML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nets := dx.Networks()
+	if len(nets) != 1 {
+		t.Fatalf("got %d networks, want 1", len(nets))
+	}
+	if nets[0].MAC != "52:54:00:12:34:56" {
+		t.Errorf("MAC = %q", nets[0].MAC)
+	}
+	if nets[0].IPAddress != "" {
+		t.Errorf("IPAddress = %q, want empty at list time", nets[0].IPAddress)
+	}
+}
+
+// parseDomainListTable replaces the per-domain `virsh domstate` N+1: one
+// `virsh list --all` gives name+state. State can be two words ("shut off").
+func TestParseDomainListTable(t *testing.T) {
+	// "Windows Server 2019" exercises a name with interior spaces: column-offset
+	// slicing must keep it whole, where the old Fields() split truncated it to
+	// "Windows" and folded the rest into the state.
+	out := ` Id   Name                  State
+------------------------------------------
+ 1    web-01                running
+ -    Windows Server 2019   shut off
+ 3    cache-01              paused
+`
+	domains := parseDomainListTable(out)
+	if len(domains) != 3 {
+		t.Fatalf("got %d domains, want 3: %+v", len(domains), domains)
+	}
+	want := map[string]string{"web-01": "running", "Windows Server 2019": "shut off", "cache-01": "paused"}
+	for _, d := range domains {
+		if want[d.Name] != d.State {
+			t.Errorf("domain %q state = %q, want %q", d.Name, d.State, want[d.Name])
+		}
+	}
+}
+
+func TestParseDomainListTable_empty(t *testing.T) {
+	out := ` Id   Name   State
+--------------------------
+`
+	if domains := parseDomainListTable(out); len(domains) != 0 {
+		t.Errorf("got %d domains, want 0", len(domains))
+	}
+}

--- a/internal/providers/libvirt/provider_virsh.go
+++ b/internal/providers/libvirt/provider_virsh.go
@@ -2001,127 +2001,57 @@ func (p *Provider) ListVMs(ctx context.Context) ([]contracts.VMInfo, error) {
 	log.Printf("INFO Found %d domains", len(domains))
 
 	var vmInfos []contracts.VMInfo
-	guestAgent := NewGuestAgentProvider(p.virshProvider)
 
 	for _, domain := range domains {
-		// Get domain information
-		domainInfo, err := p.virshProvider.getDomainInfo(ctx, domain.Name)
+		// Everything ListVMs/adoption needs (cpu, memory, disk path+format, NIC
+		// MAC, uuid) lives in the domain XML, so one `virsh dumpxml` per domain
+		// replaces the old dominfo + 5 monitoring calls + 2 guest-agent probes
+		// that blocked on agent timeouts and blew the gRPC deadline. Power state
+		// comes from `virsh list` (already fetched in listDomains). IPs are not
+		// needed here — the normal VM reconcile discovers them after adoption.
+		raw, err := p.virshProvider.runVirshCommand(ctx, "dumpxml", domain.Name)
 		if err != nil {
-			log.Printf("WARN Failed to get domain info for %s: %v", domain.Name, err)
+			log.Printf("WARN Failed to dump XML for %s: %v", domain.Name, err)
+			continue
+		}
+		dx, err := parseDomainXML(raw.Stdout)
+		if err != nil {
+			log.Printf("WARN Failed to parse XML for %s: %v", domain.Name, err)
 			continue
 		}
 
-		// Extract power state
-		powerState := p.mapLibvirtPowerState(domainInfo["State"])
+		powerState := string(p.mapLibvirtPowerState(domain.State))
 
-		// Extract IP addresses
-		var ips []string
-		if guestIPs := domainInfo["guest_ip_addresses"]; guestIPs != "" {
-			ips = strings.Split(guestIPs, ",")
-			// Filter out empty strings
-			var validIPs []string
-			for _, ip := range ips {
-				ip = strings.TrimSpace(ip)
-				if ip != "" {
-					validIPs = append(validIPs, ip)
-				}
-			}
-			ips = validIPs
-		}
-
-		// Extract CPU count
-		cpu, err := p.extractCPUCount(domainInfo)
-		if err != nil {
-			log.Printf("WARN Failed to extract CPU count for %s: %v", domain.Name, err)
+		cpu := dx.VCPU
+		if cpu == 0 {
 			cpu = 1 // Default to 1 CPU
 		}
-
-		// Extract memory (convert from KiB to MiB)
-		memoryKB, err := p.extractMemoryKB(domainInfo)
+		memoryMiB, err := dx.MemoryMiB()
 		if err != nil {
-			log.Printf("WARN Failed to extract memory for %s: %v", domain.Name, err)
-			memoryKB = 1024 // Default to 1 GiB
-		}
-		memoryMiB := memoryKB / 1024
-
-		// Extract disk information
-		var disks []contracts.DiskInfo
-		diskPaths, err := p.getDomainDiskPaths(ctx, domain.Name)
-		if err == nil {
-			for i, diskPath := range diskPaths {
-				// Get disk size
-				sizeGiB := int32(0)
-				if stat, err := os.Stat(diskPath); err == nil {
-					sizeGiB = int32(stat.Size() / (1024 * 1024 * 1024))
-					if sizeGiB == 0 && stat.Size() > 0 {
-						sizeGiB = 1
-					}
-				}
-
-				// Detect disk format from path
-				format := "qcow2"
-				if strings.HasSuffix(diskPath, ".raw") {
-					format = "raw"
-				} else if strings.HasSuffix(diskPath, ".vmdk") {
-					format = "vmdk"
-				}
-
-				diskInfo := contracts.DiskInfo{
-					ID:      fmt.Sprintf("%s-disk-%d", domain.Name, i),
-					Path:    diskPath,
-					SizeGiB: sizeGiB,
-					Format:  format,
-				}
-				disks = append(disks, diskInfo)
-			}
+			log.Printf("WARN %s: %v; skipping", domain.Name, err)
+			continue
 		}
 
-		// Extract network information
-		var networks []contracts.NetworkInfo
-		// Try to get network info from guest agent if VM is running
-		powerStateStr := string(powerState)
-		if powerStateStr == "On" {
-			if guestInfo, err := guestAgent.GetGuestInfo(ctx, domain.Name); err == nil {
-				for _, iface := range guestInfo.NetworkInterfaces {
-					networkInfo := contracts.NetworkInfo{
-						Name:      iface.Name,
-						MAC:       iface.HardwareAddr,
-						IPAddress: "",
-					}
-					if len(iface.IPAddresses) > 0 {
-						networkInfo.IPAddress = iface.IPAddresses[0]
-					}
-					networks = append(networks, networkInfo)
-				}
-			}
+		providerRaw := map[string]string{
+			"domain_name": domain.Name,
+			"domain_id":   domain.ID,
+			"state":       domain.State,
+			"power_state": powerState,
+		}
+		if dx.UUID != "" {
+			providerRaw["uuid"] = dx.UUID
 		}
 
-		// Build provider raw metadata
-		providerRaw := make(map[string]string)
-		providerRaw["domain_name"] = domain.Name
-		providerRaw["domain_id"] = domain.ID
-		providerRaw["state"] = domain.State
-		providerRaw["power_state"] = powerStateStr
-		if domainInfo["UUID"] != "" {
-			providerRaw["uuid"] = domainInfo["UUID"]
-		}
-		if domainInfo["Guest OS"] != "" {
-			providerRaw["guest_os"] = domainInfo["Guest OS"]
-		}
-
-		vmInfo := contracts.VMInfo{
+		vmInfos = append(vmInfos, contracts.VMInfo{
 			ID:          domain.Name, // Use domain name as ID
 			Name:        domain.Name,
-			PowerState:  powerStateStr,
-			IPs:         ips,
+			PowerState:  powerState,
 			CPU:         cpu,
 			MemoryMiB:   memoryMiB,
-			Disks:       disks,
-			Networks:    networks,
+			Disks:       dx.Disks(domain.Name),
+			Networks:    dx.Networks(),
 			ProviderRaw: providerRaw,
-		}
-
-		vmInfos = append(vmInfos, vmInfo)
+		})
 	}
 
 	return vmInfos, nil

--- a/internal/providers/libvirt/virsh.go
+++ b/internal/providers/libvirt/virsh.go
@@ -592,36 +592,79 @@ func (v *VirshProvider) runVirshCommandOnce(ctx context.Context, args ...string)
 
 // listDomains lists all domains (VMs) using virsh
 func (v *VirshProvider) listDomains(ctx context.Context) ([]VirshDomain, error) {
-	// Get all domains (running and shut off)
-	result, err := v.runVirshCommand(ctx, "list", "--all", "--name")
+	// One `virsh list --all` yields name AND state for every domain, replacing the
+	// old per-domain `virsh domstate` N+1 (one SSH round-trip per VM).
+	result, err := v.runVirshCommand(ctx, "list", "--all")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list domains: %w", err)
 	}
+	return parseDomainListTable(result.Stdout), nil
+}
 
-	var domains []VirshDomain
-	lines := strings.Split(strings.TrimSpace(result.Stdout), "\n")
+// parseDomainListTable parses `virsh list --all` table output (columns: Id,
+// Name, State). Both Name ("Windows Server 2019") and State ("shut off") can
+// contain spaces, so rows are sliced by the header's column byte-offsets, not
+// by whitespace splitting — Fields() would corrupt a spaced name. virsh sizes
+// each column to its widest value, so the State header offset always sits at or
+// past the longest name; the Name column safely absorbs interior spaces.
+func parseDomainListTable(stdout string) []VirshDomain {
+	lines := strings.Split(stdout, "\n")
 
+	// The dashed line separates the header from the rows; the header is above it.
+	sep := -1
 	for i, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
+		if strings.HasPrefix(strings.TrimSpace(line), "---") {
+			sep = i
+			break
+		}
+	}
+	if sep < 1 {
+		// No recognizable table. An empty host still prints header + separator,
+		// so reaching here means the format changed — warn instead of silently
+		// returning zero domains (which would look like "adopt nothing").
+		if strings.TrimSpace(stdout) != "" {
+			log.Printf("WARN virsh list output has no header separator; parsed 0 domains")
+		}
+		return nil
+	}
+	header := lines[sep-1]
+	nameAt := strings.Index(header, "Name")
+	stateAt := strings.Index(header, "State")
+	if nameAt < 0 || stateAt <= nameAt {
+		log.Printf("WARN virsh list header missing Name/State columns; parsed 0 domains")
+		return nil
+	}
+
+	// NOTE: byte offsets, not rune offsets. Fine for ASCII names (incl. spaces);
+	// a CJK domain name could misalign — sanitizeVMName makes that rare.
+	var domains []VirshDomain
+	for _, line := range lines[sep+1:] {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
-
-		// Get domain state
-		stateResult, err := v.runVirshCommand(ctx, "domstate", line)
-		state := "unknown"
-		if err == nil {
-			state = strings.TrimSpace(stateResult.Stdout)
+		name := strings.TrimSpace(colSlice(line, nameAt, stateAt))
+		state := strings.TrimSpace(colSlice(line, stateAt, len(line)))
+		if name == "" {
+			continue // malformed / short row
 		}
-
 		domains = append(domains, VirshDomain{
-			ID:    fmt.Sprintf("%d", i),
-			Name:  line,
+			ID:    fmt.Sprintf("%d", len(domains)),
+			Name:  name,
 			State: state,
 		})
 	}
+	return domains
+}
 
-	return domains, nil
+// colSlice returns line[from:to], clamped to the line length for short rows.
+func colSlice(line string, from, to int) string {
+	if from > len(line) {
+		return ""
+	}
+	if to > len(line) {
+		to = len(line)
+	}
+	return line[from:to]
 }
 
 // startDomain starts a defined domain


### PR DESCRIPTION
## What

`Provider.ListVMs` issued ~8 SSH round-trips per domain over `qemu+ssh://` — `dominfo`, `enrichDomainInfo`'s five monitoring calls (`dommemstat` / `cpu-stats` / `domiflist` / block-stats / `guestinfo`), a `dumpxml`, and a second `GetGuestInfo` guest-agent probe — on top of `listDomains()` still running one `virsh domstate` per domain (the N+1 #256 removed from the `Validate` path but deliberately left inside `listDomains()` for its other callers). The two guest-agent calls each block ~1–2s on timeout when no agent is installed, so on a ~45-domain host `ListVMs` ran past its hard-coded 2-minute gRPC deadline → adoption's `discoverUnmanagedVMs` got `DeadlineExceeded` and adopted nothing. Full root-cause writeup in #284.

Everything `ListVMs`/adoption needs — cpu, memory, disk path+format, NIC MAC, uuid — is already in the domain XML, and power state is in `virsh list`. This collapses the per-domain work to a single `virsh dumpxml`, parsed locally with Go's stdlib `encoding/xml`.

- **`listDomains()`**: one `virsh list --all` (name + state) replaces the per-domain `domstate` N+1 (new `parseDomainListTable`). This completes what #256 started — the `clone` / reconfigure callers that still use `listDomains()` benefit too.
- **`ListVMs`**: one `dumpxml` per domain; drops `getDomainInfo` (dominfo + 5 monitoring calls), the running-VM guest-agent probe, and the local `os.Stat` on a remote disk path (it always returned 0 — disk size is now honestly 0, which adoption does not need).
- **new `domainXML` parser + `Disks()` / `Networks()`**: disk format now comes from `<driver type>` instead of guessing the path suffix, and NIC MACs are captured for stopped VMs too. No new dependency. IPs are left empty — the normal VM reconcile discovers them after adoption.

Round-trips per `ListVMs` drop from ~8N to **1 + N** over the warm multiplexed SSH connection, with no per-domain guest-agent timeouts. The `encoding/xml` parse logic carries straight over to the native libvirt client proposed in #257 (`DomainGetXMLDesc` returns the same domain XML).

## Testing

**Unit:** new tests cover both parsers, disk filtering (cdrom / cloud-init excluded), and MAC extraction. `go build ./...`, `go vet ./...`, and the `internal/providers/libvirt` package suite pass.

**Live cluster (the same host that surfaced #284):** the provider built from this branch was deployed against a real libvirt host with **45 domains** over `qemu+ssh://` (stock `manager:v0.3.9` — the fix is entirely provider-side).

- Before the fix (recorded in #284): `ListVMs` hit `DeadlineExceeded` ~2 min in and **0 VMs were adopted** — only the one pre-existing managed VM (`asdf`) had a CR.
- After the fix: adoption completes — **44 of the 45 domains are adopted** (`virtrigaud.io/adopted: "true"`), the 45th being `asdf`, which was already managed (1 managed + 44 adopted = 45 CRs, matching the provider's `CONNECTED VMS = 45`, `HEALTHY = true`).
- The cpu / memory parsed from each domain's XML land correctly on the adopted CRs — synthesized classes range from `adopted-1cpu-1024mb` to `adopted-16cpu-32768mb` — and running VMs pick up their IPs on the subsequent normal reconcile, confirming the "no IPs at list time" path.

Adoption completing at all confirms `ListVMs` now returns within the manager's 2-minute deadline, which it previously always exceeded.

Fixes #284.
