### PR TITLE
fix(libvirt): cap concurrent virsh forks + drop duplicate provider Validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to VirtRigaud will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-07-01 16:16] - fix(libvirt): cap concurrent virsh forks + drop duplicate provider Validate (#288)
+**Author:** @jing2uo (Komh)
+
+### Changed
+- `internal/providers/libvirt/virsh.go`: bound concurrent virsh/ssh subprocess forks with a semaphore at the single exec chokepoint (`runVirshCommandOnce`). Default 4, override via `VIRTRIGAUD_LIBVIRT_MAX_CONCURRENT_VIRSH`. Context-aware acquire (no slot leaked on cancel); a nil semaphore (zero-value provider, e.g. tests) is unbounded.
+- `internal/controller/virtualmachine_controller.go`: remove the redundant provider `Validate` in `reconcileVM` — `Resolver.GetProvider` already validates the client on both the cached and new-client paths, and the image-prepare/create RPCs that follow are themselves the liveness test. Drops the now-dead `errReasonProviderValidate` const.
+- `charts/virtrigaud-provider-runtime/examples/values-libvirt.yaml`: document the `VIRTRIGAUD_LIBVIRT_MAX_CONCURRENT_VIRSH` knob (default 4).
+
+### Why
+Post-adoption, the manager reconciles every newly adopted VM with 10-way concurrency, and each reconcile validated the provider twice. libvirt `Validate` is a real `virsh list --all --name` over SSH, so the burst became a process-fork storm on the host: `cannot fork child process: Resource temporarily unavailable`. The semaphore caps the actually-exhausted resource (host forks) for all buffered virsh calls regardless of control-plane concurrency; dropping the duplicate Validate halves validation demand. (The s3import/s3export disk-stream and `scp` paths fork outside this cap by design — see the PR discussion.)
+
+### Impact
+- [ ] Breaking change
+- [x] Requires cluster rollout (libvirt provider image)
+- [ ] Documentation only
+- **Metric attribution:** with `errReasonProviderValidate` removed, validation failures now count under `errReasonProviderResolve`. Any dashboard/alert keying on the `provider-validate` reason will go silent.
+
 ## [2026-06-30 17:00] - fix(libvirt): ListVMs dumps domain XML once, not per-domain SSH fan-out (#285)
 **Author:** @jing2uo (Komh)
 
@@ -20,6 +37,7 @@ On hosts with many domains the per-domain SSH fan-out pushed `ListVMs` past the 
 - [ ] Breaking change
 - [x] Requires cluster rollout (libvirt provider image)
 - [ ] Config change only
+
 ## [2026-06-30 12:00] - fix(libvirt): select <domain type=kvm> when the host has /dev/kvm (#282)
 **Author:** @jing2uo (Komh)
 

--- a/charts/virtrigaud-provider-runtime/examples/values-libvirt.yaml
+++ b/charts/virtrigaud-provider-runtime/examples/values-libvirt.yaml
@@ -8,6 +8,10 @@ env:
     value: "info"
   - name: LIBVIRT_URI
     value: "qemu:///system"
+  # Caps concurrent virsh/ssh subprocess forks so a reconcile burst can't exhaust
+  # the libvirt host's fork limit ("cannot fork child process"). Default 4 (#288).
+  # - name: VIRTRIGAUD_LIBVIRT_MAX_CONCURRENT_VIRSH
+  #   value: "4"
 
 resources:
   limits:

--- a/internal/controller/virtualmachine_controller.go
+++ b/internal/controller/virtualmachine_controller.go
@@ -54,7 +54,6 @@ const (
 	errReasonDepsNotFound     = "deps-not-found"
 	errReasonDepsError        = "deps-error"
 	errReasonProviderResolve  = "provider-resolve"
-	errReasonProviderValidate = "provider-validate"
 	errReasonProviderDescribe = "provider-describe"
 	errReasonProviderTask     = "provider-task-status"
 	errReasonProviderDelete   = "provider-delete"
@@ -209,16 +208,13 @@ func (r *VirtualMachineReconciler) reconcileVM(ctx context.Context, vm *infravir
 	}
 	logger.V(1).Info("Provider instance obtained successfully", "provider", provider.Name)
 
-	// Validate provider
-	logger.V(1).Info("Validating provider connectivity")
-	if err := providerInstance.Validate(ctx); err != nil {
-		logger.Error(err, "Provider validation failed - will retry in 5s", "provider", provider.Name)
-		k8s.SetReadyCondition(&vm.Status.Conditions, metav1.ConditionFalse, k8s.ReasonProviderError, fmt.Sprintf("Provider validation failed: %v", err))
-		metrics.RecordError(errReasonProviderValidate, metrics.ComponentManager)
-		r.updateStatus(ctx, vm)
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-	logger.V(1).Info("Provider validation successful", "provider", provider.Name)
+	// Provider liveness is already verified by getProviderInstance →
+	// Resolver.GetProvider (it validates the cached/new client before returning).
+	// Re-validating here doubled the real virsh-over-ssh Validate calls on every
+	// reconcile, which — under 10-way concurrency post-adoption — became a fork
+	// storm on the libvirt host (#288). The image-prepare / create RPCs below are
+	// themselves the liveness test: a dead provider fails them and the reconcile
+	// requeues.
 
 	// Ensure the referenced image is prepared on this provider before creating
 	// the VM (lazy, VM-create-driven prepare — issue #154). This is a no-op for

--- a/internal/providers/libvirt/virsh.go
+++ b/internal/providers/libvirt/virsh.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -32,6 +33,16 @@ import (
 const (
 	sshPrivateKeyDir  = "/tmp/virtrigaud-libvirt"
 	sshPrivateKeyPath = sshPrivateKeyDir + "/ssh-privatekey"
+
+	// defaultMaxConcurrentVirsh bounds how many virsh/ssh subprocesses this
+	// provider forks at once. Each virsh-over-ssh call is a real process fork
+	// on the provider pod and the remote host; an unbounded burst (e.g. the
+	// post-adoption Validate storm with 10-way reconcile concurrency) exhausts
+	// the host fork limit and yields "cannot fork child process". Override with
+	// VIRTRIGAUD_LIBVIRT_MAX_CONCURRENT_VIRSH (see #288). This is a fixed cap; the
+	// strategic fix (#255/#256) is a persistent libvirt connection, after which
+	// it can be raised or removed.
+	defaultMaxConcurrentVirsh = 4
 )
 
 // VirshProvider implements a virsh command-line based libvirt provider
@@ -50,6 +61,12 @@ type VirshProvider struct {
 	// (WARN on the escape hatch, INFO when verifying). Defaults to
 	// slog.Default() when nil.
 	logger *slog.Logger
+
+	// execSem bounds concurrent virsh/ssh subprocess forks (see
+	// defaultMaxConcurrentVirsh). nil means unbounded (zero-value provider, e.g.
+	// in tests). Set by NewVirshProvider; shared across all goroutines using
+	// this provider instance.
+	execSem chan struct{}
 }
 
 // VirshDomain represents a VM domain from virsh list output
@@ -75,7 +92,36 @@ func (e *VirshError) Error() string {
 // NewVirshProvider creates a new virsh-based provider
 func NewVirshProvider(config *ProviderConfig) *VirshProvider {
 	return &VirshProvider{
-		config: config,
+		config:  config,
+		execSem: make(chan struct{}, maxConcurrentVirshFromEnv()),
+	}
+}
+
+// maxConcurrentVirshFromEnv returns the concurrent-virsh fork cap, honoring
+// VIRTRIGAUD_LIBVIRT_MAX_CONCURRENT_VIRSH (positive int) and falling back to
+// defaultMaxConcurrentVirsh otherwise.
+func maxConcurrentVirshFromEnv() int {
+	if s := os.Getenv("VIRTRIGAUD_LIBVIRT_MAX_CONCURRENT_VIRSH"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			return n
+		}
+		log.Printf("WARN Ignoring invalid VIRTRIGAUD_LIBVIRT_MAX_CONCURRENT_VIRSH=%q, using default %d", s, defaultMaxConcurrentVirsh)
+	}
+	return defaultMaxConcurrentVirsh
+}
+
+// acquireExecSlot blocks until a virsh/ssh fork slot is free or ctx is done,
+// returning a release func to call when the subprocess finishes. A nil execSem
+// (zero-value provider) is treated as unbounded.
+func (v *VirshProvider) acquireExecSlot(ctx context.Context) (release func(), err error) {
+	if v.execSem == nil {
+		return func() {}, nil
+	}
+	select {
+	case v.execSem <- struct{}{}:
+		return func() { <-v.execSem }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }
 
@@ -455,6 +501,14 @@ func retryOnTransientSSH(ctx context.Context, attempt func() (*VirshResult, erro
 // error handling. Special case: if first arg is "!", execute the remaining args
 // as a direct command (not virsh).
 func (v *VirshProvider) runVirshCommandOnce(ctx context.Context, args ...string) (*VirshResult, error) {
+	// Bound concurrent subprocess forks so a reconcile burst cannot exhaust the
+	// host fork limit (cannot fork child process). Held only across the fork.
+	release, err := v.acquireExecSlot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	start := time.Now()
 
 	var cmd *exec.Cmd
@@ -563,7 +617,7 @@ func (v *VirshProvider) runVirshCommandOnce(ctx context.Context, args ...string)
 	log.Printf("DEBUG Executing: %s", command)
 
 	// Run the command
-	err := cmd.Run()
+	err = cmd.Run()
 	duration := time.Since(start)
 
 	result := &VirshResult{

--- a/internal/providers/libvirt/virsh_execsem_test.go
+++ b/internal/providers/libvirt/virsh_execsem_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package libvirt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The execSem semaphore bounds concurrent virsh/ssh subprocess forks so a burst
+// of concurrent reconciles cannot exhaust the remote host's fork limit
+// (post-adoption Validate storm, #288).
+
+func TestNewVirshProviderHasBoundedExecSem(t *testing.T) {
+	v := NewVirshProvider(nil)
+	require.NotNil(t, v.execSem)
+	assert.GreaterOrEqual(t, cap(v.execSem), 1)
+}
+
+func TestAcquireExecSlotNilSemUnbounded(t *testing.T) {
+	// A zero-value provider (e.g. constructed directly in a test) has no
+	// semaphore and must not block.
+	v := &VirshProvider{}
+	release, err := v.acquireExecSlot(context.Background())
+	require.NoError(t, err)
+	release()
+}
+
+func TestAcquireExecSlotBoundsConcurrency(t *testing.T) {
+	v := &VirshProvider{execSem: make(chan struct{}, 1)}
+
+	rel1, err := v.acquireExecSlot(context.Background())
+	require.NoError(t, err)
+
+	// A second acquire must block while the only slot is held.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		r, e := v.acquireExecSlot(ctx)
+		if e == nil {
+			r()
+		}
+		done <- e
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("acquireExecSlot should block while the slot is held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Cancelling the waiter's context unblocks it with an error (no slot leaked).
+	cancel()
+	require.Error(t, <-done)
+
+	// Releasing the held slot lets a fresh acquire succeed.
+	rel1()
+	r, err := v.acquireExecSlot(context.Background())
+	require.NoError(t, err)
+	r()
+}


### PR DESCRIPTION
Fixes #288.

## Problem

After adoption succeeds, the manager reconciles the burst of newly adopted
`VirtualMachine` CRs with 10-way concurrency. Each reconcile validated the
provider **twice** (once in `Resolver.GetProvider`, once explicitly in
`reconcileVM`), and libvirt `Validate` is a real `virsh list --all --name` over
SSH — i.e. a process fork per call. The concurrent fork load exhausts the
host's process limit:

```
error: failed to connect to the hypervisor
error: cannot fork child process: Resource temporarily unavailable
```

## Fix

Two changes — reduce demand, then cap supply at the resource that actually
runs out (host process forks):

### 1. Drop the duplicate `Validate` from the reconcile hot path

`reconcileVM` no longer calls `providerInstance.Validate()` — `getProviderInstance`
→ `Resolver.GetProvider` already validates the client before returning it, and
the image-prepare / create RPCs that immediately follow are themselves the
liveness test (a dead provider fails them and the reconcile requeues). This
halves validation demand. The now-unused `errReasonProviderValidate` const is
removed.

### 2. Bound concurrent virsh/ssh subprocess forks

A semaphore at the single exec chokepoint (`runVirshCommandOnce`) caps how many
virsh/ssh subprocesses the provider forks at once. Default **4**, override via
`VIRTRIGAUD_LIBVIRT_MAX_CONCURRENT_VIRSH`. The acquire is context-aware (a
cancelled reconcile doesn't block or leak a slot); a nil semaphore
(zero-value provider, e.g. in tests) means unbounded.

Every **buffered** virsh call routes through this chokepoint, so the cap covers
the path that caused #288 — `Validate`, the `ListVMs` dumpxml fan-out,
`Describe`, and any future buffered RPC — regardless of control-plane
concurrency. Under sustained load these calls queue and back off via the
existing SSH-retry + 5s requeue rather than crashing.

**Scope:** the two streaming paths — `runSSHStdin` (s3import/s3export disk
transfer) and the `scp` path in `server.go` — build their own
`exec.CommandContext` and fork **outside** this cap, by design: a multi-GB
transfer holds a slot for minutes, so sharing the 4-slot RPC pool would starve
reconciles. They are low-cardinality (one per migration, not a 10-way burst), so
they are left uncapped here; a separate small budget for streams is the right
follow-up if their fork load ever matters. So this bounds all buffered virsh
calls, not literally every fork the provider makes.

SSH ControlMaster multiplexing (#194) already reuses the connection, so the
remaining cost is purely process count — which is exactly what the semaphore
bounds.

## Tests

- `virsh_execsem_test.go`: deterministic coverage of the semaphore — bound
  blocks past capacity, context cancel unblocks without leaking a slot, release
  frees a slot, constructor yields a bounded semaphore, nil semaphore is
  unbounded.
- `go build ./...`, `go vet`, and the libvirt package tests pass.

## Metric attribution

With `errReasonProviderValidate` removed, validation failures now count under
`errReasonProviderResolve`. Any dashboard/alert keying on the `provider-validate`
reason will go silent — noted in the CHANGELOG.

## Strategic follow-up

The endgame remains #255/#256: a persistent native libvirt connection instead
of subprocess-per-call, after which validation cost largely disappears and this
cap can be raised or removed. The `defaultMaxConcurrentVirsh` const is marked
accordingly.

## Validation on a live cluster

Verified end-to-end on a `kind`-hosted manager against a live libvirt host with
~45 domains, using an integrated build that stacks this fix on top of the
`ListVMs` single-dumpxml fix and the `<domain type=kvm>` detection fix. With the
fork cap + duplicate-validate removal in place, the post-adoption wave no longer
produces `cannot fork child process`; adoption completes and the adopted VMs
stabilize. Confirmed the problem is resolved.
