### PR TITLE
feat(libvirt): native control-plane transport over libvirt SDK — Describe first (ADR-0007/0008)

### DIFF
--- a/cmd/provider-libvirt/Dockerfile
+++ b/cmd/provider-libvirt/Dockerfile
@@ -50,6 +50,7 @@ ARG TARGETARCH
 ARG VERSION=dev
 ARG GIT_SHA=unknown
 RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+    -tags libvirt_native \
     -ldflags "-X github.com/projectbeskar/virtrigaud/internal/version.Version=${VERSION} -X github.com/projectbeskar/virtrigaud/internal/version.GitSHA=${GIT_SHA}" \
     -a -o provider-libvirt cmd/provider-libvirt/main.go
 
@@ -58,6 +59,7 @@ FROM ${BASE_IMAGE}
 RUN apt-get update && apt-get install -y \
     libvirt0 \
     libvirt-clients \
+    libssh2-1 \
     libxml2 \
     ca-certificates \
     openssh-client \

--- a/docs/adr/0007-libvirt-native-control-transport.md
+++ b/docs/adr/0007-libvirt-native-control-transport.md
@@ -1,0 +1,251 @@
+# ADR-0007: Migrate the libvirt control plane to a native libvirt SDK transport
+
+## Status
+
+**Proposed (2026-06-29).** The control plane stays on `virsh` by default; the native path is
+opt-in. The binding and transport choice this migration depends on is decided separately in
+[ADR-0008](./0008-libvirt-go-binding-and-transport-selection.md).
+
+**Author**: Komh ([@jing2uo](https://github.com/jing2uo))
+
+**Tracking**: the motivating problem is the libvirt `Describe` storm
+([#290](https://github.com/projectbeskar/virtrigaud/issues/290)); the native-client direction is
+[#257](https://github.com/projectbeskar/virtrigaud/issues/257).
+
+**Related**:
+
+- [ADR-0008](./0008-libvirt-go-binding-and-transport-selection.md) — *which* binding/transport
+  (official CGO binding + `qemu+libssh2`); this ADR is *how* the migration is structured.
+- [ADR-0004](./0004-libvirt-ssh-host-key-verification.md) — trust contract preserved across the
+  migration.
+- [ADR-0001](./0001-transport-grpc-and-capi-integration.md) — gRPC contract unchanged; this is
+  entirely below the provider gRPC surface.
+- `internal/providers/libvirt/{transport.go,transport_native.go,provider.go,virsh.go,provider_virsh.go,guest_agent.go}`
+
+---
+
+## Context
+
+### The control-plane tax
+
+The libvirt provider is a `virsh`-CLI-over-SSH client: every control-plane operation resolves to
+one or more of `virsh …`, `ssh … virsh …`, or `ssh … <host command>`, through
+`VirshProvider.runVirshCommand()`. A bounded exec semaphore was already added to stop
+subprocess/fork storms — a strong signal that the **transport model itself** is now the
+bottleneck. The same architectural tax surfaced three times, each patched tactically while the
+root cause (subprocess-per-call over SSH) remained:
+
+- `ListVMs` slowness (N+1 `virsh` fan-out) → tactical: one `dumpxml` per VM;
+- a post-adoption `Validate` fork storm → tactical: drop duplicate validate + exec semaphore;
+- a `Describe` 30s-deadline storm → the companion issue, still open in spirit.
+
+### Why a native SDK is the structural fix
+
+A persistent native libvirt client turns each control call into a typed RPC on one connection: no
+per-call `virsh` fork, no per-call SSH handshake, no semaphore queueing. It is feasible here
+because the provider is **already a CGO build** (`Makefile` builds `provider-libvirt` with
+`CGO_ENABLED=1`; CI installs `libvirt-dev`; the Dockerfile installs `libvirt-dev` in the build
+stage and `libvirt0` at runtime). Moving from "CGO provider that shells out to `virsh`" to "CGO
+provider that links a native client" is **not** a build-system paradigm shift.
+
+### The transport trap (non-code risk)
+
+Current security/compat behaviour is coupled to literally launching `ssh`: explicit argv, host-key
+policy via a written `~/.ssh/config`, mounted `known_hosts`, `sshpass` for passwords, per-command
+retry. A native transport changes connection establishment, so transport/auth/host-key is a
+first-class design item — decided in ADR-0008. "It still connects" is not a sufficient bar.
+
+---
+
+## Decision
+
+### 1. Migrate the control plane; keep the data plane on SSH
+
+Move **only the control-plane hot paths** onto the native client; **keep the SSH host-command
+runner** for data-plane work the SDK cannot replace.
+
+- **Migrate (control plane):** `Validate`, `Describe`, `ListVMs`, `Reconfigure`, `Power`,
+  `Snapshot*`, and the domain-control parts of `Create`/`Delete`.
+- **Keep on SSH (data plane):** `ImagePrepare`, `ImportDisk`, `ExportDisk`, clone disk
+  copy/overlay/NVRAM, cloud-init ISO, file ownership/permission/SELinux relabel, all `qemu-img`.
+
+The SDK solves the libvirt RPC/control plane; it does **not** solve remote host filesystem
+orchestration. These primitives remain necessary regardless of transport and stay on the host
+runner: `qemu-img info|convert|resize|check`, `curl`/`wget`, `genisoimage`, `cp`, `rm`, `chmod`,
+`chown`, `restorecon`. What changes is that control-plane hot paths stop using that channel; only
+storage/image/file paths still do.
+
+### 2. Target architecture: split transport concerns
+
+Introduce two abstractions inside `internal/providers/libvirt`, and have `Provider` compose both:
+
+- a **control transport** for domain/libvirt-RPC operations (the native client; today
+  `controlTransport` in `transport.go`), and
+- a **host-command runner** for remote command/file/data-plane work (extracted from the
+  `runVirshCommand("!", …)` paths).
+
+```go
+// control plane (native): lookup/state/info/XML/ifaddr/stats/agent, power, resize, snapshots
+type controlTransport interface { Validate(...); Describe(...); /* … */ }
+// data plane (SSH): remote exec + file copy for qemu-img/genisoimage/chown/restorecon/...
+type HostCommandRunner interface { Run(...); CopyToHost(...) }
+```
+
+The exact names are not important; the separation is. It makes obvious which methods can move
+immediately and which still depend on the host command channel.
+
+### 3. Opt-in gate, build-tag seam, fail-closed, default virsh
+
+- Runtime gate `LIBVIRT_CONTROL_TRANSPORT=virsh|native` (default `virsh`) → live A/B in kind or
+  shared clusters without a flag day; rollback by env change, not rebuild.
+- Build-tag seam `//go:build libvirt_native`: the native CGO code is isolated so the default
+  `go build`/`go test` on machines without `libvirt-dev` is unaffected; the provider image is
+  built with `-tags libvirt_native`. The non-tagged shim registers the native dialer via an
+  `init()` so `Provider` references only an interface, never the CGO types.
+- **No silent downgrade**: native-requested-but-uninitialisable fails closed in **both**
+  constructor paths — the K8s-API constructor returns the error; the container-mode constructor
+  (which cannot return one) **exits**, keeping the pod visibly not-Ready. Falling back to virsh
+  is not an option here: the init failure may itself be a host-key trust failure, and switching
+  transports on a trust failure is exactly the drift ADR-0004 forbids.
+- Startup logging states which transport is active and the host-key verification posture.
+
+### 4. Split `Describe` (do not port the sweep)
+
+The current `Describe` is a per-VM "comprehensive monitoring" sweep (`getDomainInfo` →
+`enrichDomainInfo` + a guest-agent layer): ~15 `virsh`/`ssh` subprocesses, many optional
+guest-agent calls that fail on agent-less fleets but still cost a round-trip each. Porting it 1:1
+would preserve the conceptual mistake. Split into:
+
+1. **cheap `Describe`** (reconcile-safe): existence, power state, best-effort IPs, console URL,
+   minimal provider-raw — the fields the controller actually consumes;
+2. **opt-in `DescribeRich`**: memory/block stats + guest-agent OS/hostname/fs/users — off the hot
+   path, every guest-agent call time-bounded and best-effort (an absent/slow agent must never gate
+   reconcile; it degrades to host-side stats only).
+
+`DescribeRich` **lands unwired in the first PR** (implementation + integration tests only, no
+production caller): its intended consumer is a lower-frequency periodic monitoring collector,
+whose gate and cadence are a later-phase decision. Wiring it into the reconcile path would
+recreate the exact over-fetch this split removes.
+
+This enforces the contract — `Describe` *"should be cheap and resilient to call frequently"* — in
+code structure, not just intent.
+
+### 5. Connection lifecycle: keepalive + rate-limited redial
+
+The virsh path is stateless — a fresh subprocess per call — so it is self-healing for free and a
+hung call is killable for free (process timeout). A persistent native connection gives neither,
+and both must be designed, not hoped for:
+
+- **Dead-peer detection**: libvirt keepalive (`SetKeepAlive`, serviced by the default event loop)
+  declares the peer dead after `interval × count` (5s × 3) unanswered probes and closes the
+  socket. Socket close also **unblocks any in-flight CGO call** stuck on the dead connection —
+  the closest available substitute for `ctx` cancellation, which blocking CGO calls cannot honor.
+  This trade-off (per-call kill-on-timeout is lost; keepalive-driven close is the bound on a hung
+  peer) is accepted and disclosed here.
+- **Self-healing**: every transport method acquires the connection through a single accessor that
+  checks `IsAlive` (a local socket-state check, not an RPC) and redials on failure with a rate
+  limit (10s backoff), re-running the host-key hard-fail gate on every redial. A `libvirtd`
+  restart or dropped SSH session costs one redial, not a provider pod restart.
+- **Failure semantics**: while the connection is down, calls return errors (retryable at the
+  manager) — never `Exists: false`, so a transport outage can never be misread as "VM gone".
+
+---
+
+## Payoff by surface (why this order)
+
+| Surface | Today | Native | Payoff |
+|---|---|---|---|
+| `Validate` | `virsh list --all --name` (fork+ssh per call) | `Connect.IsAlive` | **very high** |
+| `Describe` | monitoring sweep → 30s deadline | typed lookup + split rich path | **very high** |
+| `Reconfigure` | drags full `getDomainInfo` to compare state | `GetState`+`GetInfo`, disk only on change | **high** |
+| `ListVMs` | `list --all` + `dumpxml`/VM over ssh | native enumerate + XML on the connection | **moderate–high** |
+| `Power`/`Snapshot*` | one `virsh` per op | typed domain/snapshot ops | **moderate** |
+| `ImagePrepare`/`Import`/`Export`/clone | qemu-img + transfer + SELinux | only trims incidental `virsh` | **low** |
+
+The native SDK does **not** make `Describe` cheap by itself if the requirement stays "collect
+comprehensive monitoring every reconcile" — that is why §4 splits it. The SDK removes the
+transport overhead; the split removes the over-fetch.
+
+---
+
+## Phased rollout
+
+- **Phase 0 — groundwork & safety rails**: `controlTransport` seam (`transport.go`), native impl
+  (`transport_native.go`), `LIBVIRT_CONTROL_TRANSPORT` gate, build-tag isolation, fail-closed,
+  startup transport/verification logging.
+- **Phase 1 — `Validate`**: cheap native liveness probe; no subprocess/fork; no manager/provider
+  contract change.
+- **Phase 2 — `Describe` (split first)**: cheap `Describe` + opt-in `DescribeRich`; native
+  lookup/state/info/ifaddr/XML + bounded guest-agent. No semantic regression for existence /
+  power-state correction / IP discovery / reconfigure gating.
+- **Phase 3 — `Reconfigure`**: native state/info + live vCPU/memory setters; keep guest-fs
+  extension / disk-grow helpers on the host path; stop dragging the `Describe`-class chain in.
+- **Phase 4 — `ListVMs`**: native enumeration + XML, same `contracts.VMInfo` for adoption. This
+  also removes the need for the insecure opt-out on the discovery path in a read-only-rootfs pod,
+  where the system `ssh` client cannot receive the host-key config (ADR-0008 §transport) — itself
+  an argument for the migration.
+- **Phase 5 — lifecycle**: `Power`, `Snapshot{Create,Delete,Revert}`, domain-control parts of
+  `Create`/`Delete` — mostly straightforward SDK substitutions once the transport exists.
+- **Phase 6 — optional cleanup**: re-evaluate whether `virsh` is needed at all; extract the SSH
+  host-command runner (`hostrunner_ssh.go`) from `runVirshCommand("!", …)`; shrink runtime deps;
+  revisit `ImagePrepare`/`Import`/`Export`/clone. Optional — the operational pain is gone by then.
+
+---
+
+## Consequences
+
+- The control-plane storms (`Validate` fork storm, `Describe` 30s deadline) are removed at the
+  root, not patched.
+- A clean control/data-plane split. **Files likely to shrink** over phases: `virsh.go`,
+  `provider_virsh.go`, `guest_agent.go`, parts of `clone.go`. **Files likely to stay substantial**
+  (real host/file/data work): `storage.go`, `image.go`, `cloudinit.go`, `s3export.go`,
+  `s3import.go`, `nfs.go`.
+- New build/runtime dependency (decided in ADR-0008): the native binding + `libssh2-1` in the
+  runtime image.
+- The single-host, single-connection native client is the natural **host-agent** primitive for a
+  future per-host-pod cluster (the libvirt multi-host cluster RFC / #257, Option 2) — keep it
+  single-connection; do not evolve it into an in-process multi-host pool (that is Option 1's
+  SPOF/debt path).
+- Backward-compatible: default stays `virsh`; native is opt-in and env-reversible.
+
+---
+
+## Appendix A — virsh → SDK call mapping
+
+| Concern | virsh (today) | native SDK |
+|---|---|---|
+| liveness | `list --all --name` | `Connect.IsAlive` |
+| lookup/state/info | `list --all` / `domstate` / `dominfo` | `LookupDomainByName` / `GetState` / `GetInfo` |
+| XML | `dumpxml` | `GetXMLDesc` |
+| IPs | `domiflist` / `domifaddr` / `guestinfo` | `ListAllInterfaceAddresses` (lease+agent sources) |
+| mem/cpu | `dommemstat` / `cpu-stats` | `MemoryStats` / typed CPU+state info |
+| disk stats | `domblklist` / `domblkinfo` / `domblkstat` | XML + `BlockStats` |
+| power | `start` / `destroy` / `shutdown` | `Create` / `Destroy` / `Shutdown` / `Reboot` |
+| reconfigure | `setvcpus` / `setmem` / `setmaxmem` / `blockresize` | typed setters + `BlockResize` |
+| snapshots | `snapshot-create-as` / `-delete` / `-revert` | `DomainSnapshotCreateXML` + revert/delete |
+| guest agent | `qemu-agent-command …` | `QemuAgentCommand` (bounded timeout) |
+
+## Appendix B — file plan
+
+- **Add**: `transport.go` (seam), `transport_native.go` (native client); later
+  `hostrunner.go` / `hostrunner_ssh.go` (extract the `! …` host-command path), and
+  `describe_basic.go` if the cheap path outgrows `transport_native.go`.
+- **Refactor/shrink over phases**: `provider.go` (construction chooses transport),
+  `virsh.go` (toward virsh-transport-only), `provider_virsh.go` (split by behaviour, not the de
+  facto monolith), `guest_agent.go` (stop assuming agent calls are shell-invoked).
+- **Unchanged (data plane)**: `storage.go`, `image.go`, `cloudinit.go`, `s3export.go`,
+  `s3import.go`, `nfs.go`.
+
+## Appendix C — testing & rollout
+
+- **Unit**: transport init `virsh` vs `native`; cheap-`Describe` semantics; `Validate` behaviour;
+  host-key/auth config resolution.
+- **Integration (kind / shared cluster)**: A/B `virsh` baseline vs `native` — startup, `Validate`,
+  adoption/`ListVMs`, steady-state reconcile, `Describe` latency under manager restart, snapshot
+  create/delete, power on/off.
+- **Perf**: before/after `Validate` and `Describe` latency, manager `Failed to describe VM` count,
+  provider subprocess count / absence of fork storms.
+- **Rollout**: merge with default `virsh`; enable `native` in test envs; flip default only after
+  auth/host-key parity (ADR-0008), `Describe` storm materially improved, and rollback confirmed.
+- **Avoid**: porting `Describe` mechanically; making data-plane work a prerequisite; removing
+  `virsh` before native proves remote-auth parity; assuming ADR-0004 "comes for free."

--- a/docs/adr/0008-libvirt-go-binding-and-transport-selection.md
+++ b/docs/adr/0008-libvirt-go-binding-and-transport-selection.md
@@ -1,0 +1,205 @@
+# ADR-0008: Libvirt Go binding & transport selection — official CGO binding + `qemu+libssh2`
+
+## Status
+
+**Proposed (2026-06-29).** Decides *which* native binding and *which* transport the
+[ADR-0007](./0007-libvirt-native-control-transport.md) control-plane migration uses.
+
+**Author**: Komh ([@jing2uo](https://github.com/jing2uo))
+
+**Related**:
+
+- [ADR-0007](./0007-libvirt-native-control-transport.md) — the migration this binding/transport
+  choice serves (the *how*; this ADR is the *which*).
+- [ADR-0004](./0004-libvirt-ssh-host-key-verification.md) — the trust contract preserved:
+  same credentials Secret, same `known_hosts`, verification on by default, single insecure escape
+  hatch, hard-fail on missing trust material, no TOFU.
+
+---
+
+## Decision
+
+1. **Binding: the official CGO binding `libvirt.org/go/libvirt`** — not
+   `digitalocean/go-libvirt`.
+2. **Transport: `qemu+libssh2://`** with the host-key policy carried on the URI
+   (`known_hosts` / `known_hosts_verify`) — not `qemu+ssh://`.
+
+These are one coherent thesis: a control transport that is **complete**, **institutionally
+maintained**, and whose **host-key verification is deterministic and auditable** without depending
+on the system `ssh` client's config discovery.
+
+---
+
+## Context
+
+The native migration needs a Go libvirt binding and a way to reach a remote host over SSH while
+preserving ADR-0004 trust semantics. Two bindings are realistic candidates, and within the chosen
+binding, libvirt offers more than one SSH transport. Both choices are security-significant: the
+provider runs in a read-only-rootfs Kubernetes pod, and the host-key story behaves differently
+there than on a developer laptop.
+
+### The two candidate bindings
+
+| | `libvirt.org/go/libvirt` (official) | `digitalocean/go-libvirt` |
+|---|---|---|
+| Mechanism | CGO over libvirt's C client | pure-Go, libvirt RPC wire protocol |
+| CGO / `libvirt-dev` | **required** | not needed |
+| Connection | libvirt URI (`NewConnect(uri)`), libvirt's own remote driver | caller supplies the socket (you dial SSH yourself) |
+| API coverage | **complete** C API | generated 1:1 from RPC; gaps below |
+| `ConnectIsAlive` (cheap liveness) | **yes** | **no** (hand-roll via a cheap RPC) |
+| Typed params (memstat/blockstat) | typed helpers | **raw `nparams`**, hand-decode |
+| Events / streams | yes | yes (streams hand-wired) |
+| Reconnect | caller's job | caller's job (no helper) |
+| Releases | **monthly semver**, latest v1.12003.0 (2026-04-28) | **0 tags ever**; pseudo-versions; README: *"API not stable… vendor it"* |
+| Maintainers | **libvirt core devs** (Berrangé, Krempa, Privoznik, Hrdina @ Red Hat) | **bus-factor ≈ 1** (Geoff Hickey); both founders left DO |
+| Backlog (verified) | 2 open issues, 0 open MRs | 13 issues, a 3-year-stale human PR |
+| Sibling health | n/a | `go-qemu` ~13 months without a human commit |
+
+Sources: gitlab.com/libvirt/libvirt-go-module, libvirt.org/uri.html, libvirt.org/golang.html;
+github.com/digitalocean/go-libvirt (+ GitHub API for tags/commits/PRs), DigitalOcean's 2016
+launch blog.
+
+---
+
+## Why the official binding wins for this project
+
+Three reasons compound; none alone is decisive, together they are.
+
+### 1. Institutional health (the biggest non-technical factor)
+
+The official binding is maintained by the **libvirt project itself** — the same Red Hat engineers
+who write libvirt — with **monthly semver releases tracking libvirt versions** and a
+**near-empty backlog**. `go-libvirt` is a **single-maintainer** project under the DigitalOcean
+banner where **both original authors have left the company**, ships **no tagged releases** (you
+pin a SHA and vendor it), self-describes its API as *"not stable,"* and its sibling `go-qemu` has
+gone ~13 months without a human commit. For a security-sensitive transport we expect to depend on
+for years, "maintained by the libvirt team, monthly releases" beats "vendor-and-pin a
+bus-factor-1 dependency."
+
+### 2. Completeness — the gaps land on us with `go-libvirt`
+
+The control surface we need is present in **both**. But `go-libvirt` specifically lacks things a
+long-lived provider wants:
+
+- **No `ConnectIsAlive`** — our cheap `Validate` probe (proven at ~30µs in the deployed provider)
+  would need a hand-rolled substitute.
+- **Raw typed-params** — memory/block stats come back as raw `nparams` to decode by hand, per call
+  site, where the official binding gives typed helpers.
+- **No reconnect helper** — both make us write reconnect, but go-libvirt gives less to build on.
+
+None are blockers, but each is work the official binding hands us for free.
+
+### 3. CGO is already paid, and the binding reuses existing trust material
+
+The libvirt provider is **already a CGO build** (Makefile `CGO_ENABLED=1`; Dockerfile installs
+`libvirt-dev`/`libvirt0`). So `go-libvirt`'s headline advantage — "no CGO" — is a benefit the
+project **does not need to buy**; it already pays CGO for the current provider. Meanwhile the
+official binding talks libvirt URIs, so it reuses the **exact same** credentials Secret,
+`known_hosts`, and key/password auth the provider already mounts (ADR-0004) — no new trust surface.
+
+> The one genuine virtue of `go-libvirt` is that it owns the SSH dial in Go, so host-key
+> verification can be an explicit `ssh.HostKeyCallback`. That is a real strength — but the official
+> binding reaches the **same** "explicit, deterministic, config-independent host-key verification"
+> through `qemu+libssh2` URI params (below), **without** taking on go-libvirt's governance and
+> completeness costs. So this virtue does not flip the decision.
+
+---
+
+## Why `qemu+libssh2://` over `qemu+ssh://`
+
+This is the sharper half of the decision, grounded in a problem **reproduced** both on a laptop
+and inside the deployed provider pod.
+
+### How each transport enforces host keys
+
+- **`qemu+ssh://`** shells out to the system `ssh` binary. Host-key policy
+  (`StrictHostKeyChecking`, `UserKnownHostsFile`) is **not** expressible on the libvirt URI — it
+  comes from the **ssh client config**. The provider therefore writes a `~/.ssh/config`
+  (`createSSHConfig`) and hopes `ssh` reads it.
+- **`qemu+libssh2://`** uses libssh2 **in-process**; host-key policy is carried **on the URI**:
+  `known_hosts=<path>` + `known_hosts_verify=normal|auto|ignore`. No ssh client, no config file.
+
+### The `qemu+ssh` fragility, reproduced
+
+Modern OpenSSH resolves `~/.ssh/config` from the **password-database home directory**, and
+**ignores `$HOME`**. Confirmed two ways:
+
+- **Laptop (OpenSSH 10.3):** with `HOME` pointed at a temp dir holding a strict config, `ssh -G`
+  still reported `stricthostkeychecking ask` and the *personal* `known_hosts`; `ssh -v` showed it
+  read `/home/<user>/.ssh/config`, never the temp one.
+- **Deployed provider pod (OpenSSH 9.2, read-only rootfs):** the passwd home `/home/app` is
+  **read-only**, so `createSSHConfig` falls back to `/tmp/.ssh/config` and sets `HOME=/tmp`. We
+  verified in-pod that **even with `HOME=/tmp`**, `ssh -G` resolves `stricthostkeychecking ask` +
+  `/home/app/.ssh/known_hosts` and reads only `/etc/ssh/ssh_config` — the provider's policy
+  **never reaches `ssh`**. `virsh` then fails: `Cannot recv data: Host key verification failed`.
+
+So under `qemu+ssh`, in exactly the environment we deploy into, the host-key policy is **silently
+undeliverable**. The verifying path can't connect, and the only way to make `virsh` connect is the
+insecure opt-out (`no_verify=1`, which libvirt passes as a command-line `-o
+StrictHostKeyChecking=no` — the one place ssh *does* honor it). That is a forced choice between
+"broken" and "insecure" — the worst kind of fragility for a trust boundary, and exactly the
+*"secure by accident"* drift ADR-0004 exists to prevent.
+
+### `qemu+libssh2` makes it deterministic
+
+Because libssh2 reads the policy off the URI, none of the above applies — the policy is enforced
+in-process:
+
+- **Correct key** in `known_hosts` → connects.
+- **Wrong host key** → connection **rejected** with `!!! SSH HOST KEY VERIFICATION FAILED !!!:
+  Identity of host … differs … man in the middle attack`, and `known_hosts` is **not** rewritten
+  (no accept-new / no TOFU).
+- **Missing/empty `known_hosts`** → the provider's pre-flight gate hard-fails with an actionable
+  error (no TOFU), before any connection.
+- **Explicit insecure opt-out** (`LIBVIRT_INSECURE_SKIP_HOST_KEY_VERIFICATION=true`) → the single,
+  audit-flagged bypass still works (maps to `known_hosts_verify=ignore`).
+
+This is the **same ADR-0004 trust contract** — same `known_hosts` file, same hard-fail default,
+same single opt-out — but enforced **in-process and config-independent**, so it holds in the
+read-only pod where `qemu+ssh` cannot.
+
+---
+
+## Putting it together
+
+- `go-libvirt`'s sole real advantage (explicit, Go-owned host-key verification) is **also
+  achievable with the official binding** — via `qemu+libssh2` URI params — proven deterministic
+  and config-independent.
+- Choosing `qemu+libssh2` therefore **neutralizes the only reason to consider `go-libvirt`**,
+  while the official binding keeps everything else it is better at: institutional maintenance, a
+  complete API (incl. `IsAlive`/typed params), CGO already paid, and reuse of the existing
+  ADR-0004 trust material.
+
+→ **Official binding + `qemu+libssh2` = the explicit-verification virtue of go-libvirt, without its
+governance and completeness costs.**
+
+---
+
+## Consequences
+
+- New dependency `libvirt.org/go/libvirt` (CGO) + `libssh2-1` in the runtime image.
+- Pinned to `qemu+libssh2`; `qemu+ssh` remains a usable fallback only where the deployment can
+  guarantee the ssh client reads the provider config (e.g. a writable passwd home) — but
+  `qemu+libssh2` is the default because it does not depend on that guarantee.
+- The trust contract (ADR-0004) is preserved exactly; no new libvirt TLS/PKI surface is introduced.
+- **Auth parity is a gate for changing the default transport**: the current virsh path supports
+  password auth (`sshpass`), and caveat 3 below records that the libssh2 password path is not yet
+  exercised. Until it is verified (or password support is explicitly declared key-only for
+  native), `LIBVIRT_CONTROL_TRANSPORT` must default to `virsh` — this is the "auth/host-key
+  parity" precondition in ADR-0007's rollout section, made explicit.
+
+---
+
+## Operational caveats for `qemu+libssh2`
+
+Seeding/usage details for the runbook — **not** binding deficiencies (libssh2 1.11.1 supports
+OpenSSH-format keys, RSA-SHA2, and ed25519):
+
+1. **Seed `known_hosts` with all host-key types.** libssh2 verifies against the algorithm it
+   negotiates; a `known_hosts` holding only (say) ed25519 yields a spurious "identity differs" when
+   another type is negotiated. Seed with an unrestricted `ssh-keyscan <host>` (not `-t ed25519`).
+2. **The private key must be authorized on the host.** libssh2 offers only the `keyfile=` you pin,
+   with no ssh-agent multi-key fallback, so an unauthorized key yields `Username/PublicKey
+   combination invalid` — a *wrong-key* error, **not** a libssh2 limitation.
+3. **Password auth** (`sshauth=password`) is the one path not yet exercised; verify before relying
+   on it. Key auth is the supported path.

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
 	k8s.io/klog/v2 v2.130.1
+	libvirt.org/go/libvirt v1.12003.0
 	sigs.k8s.io/controller-runtime v0.20.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,8 @@ k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJ
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+libvirt.org/go/libvirt v1.12003.0 h1:3ek4ObakscdShZRloa9s8/mGhK7xVduqNmAkb15ZEDQ=
+libvirt.org/go/libvirt v1.12003.0/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=

--- a/internal/providers/libvirt/provider.go
+++ b/internal/providers/libvirt/provider.go
@@ -41,6 +41,12 @@ type Provider struct {
 	// Virsh-based provider (replaces libvirt-go)
 	virshProvider *VirshProvider
 
+	// nativeTransport, when non-nil, serves the migrated control-plane methods
+	// (Validate/Describe) via the native libvirt-go SDK instead of virsh. Set
+	// only when LIBVIRT_CONTROL_TRANSPORT=native and the binary was built with
+	// -tags libvirt_native. nil => everything stays on virsh.
+	nativeTransport controlTransport
+
 	// cached credentials
 	credentials *Credentials
 }
@@ -144,6 +150,23 @@ func New() *Provider {
 		log.Printf("INFO Successfully initialized virsh provider")
 	}
 
+	// Opt-in native control transport for migrated hot paths (Validate/Describe),
+	// same as the K8s-API constructor. Container mode can't return an error, so
+	// fail-closed here means exiting: a native-init failure may BE a host-key
+	// trust failure, and downgrading to another transport on a trust failure is
+	// exactly the drift ADR-0004 forbids (no silent downgrade). Crashing keeps
+	// the pod visibly not-Ready instead of quietly serving virsh.
+	if nativeTransportEnabled() {
+		nt, err := buildNativeTransport(virshProvider)
+		if err != nil {
+			log.Fatalf("FATAL LIBVIRT_CONTROL_TRANSPORT=native requested but failed to initialize (fail-closed, ADR-0007/0004): %v", err)
+		}
+		p.nativeTransport = nt
+		log.Printf("INFO libvirt control transport: native (libvirt-go SDK)")
+	} else {
+		log.Printf("INFO libvirt control transport: virsh")
+	}
+
 	return p
 }
 
@@ -186,12 +209,31 @@ func NewProvider(ctx context.Context, k8sClient client.Client, provider *v1beta1
 		return nil, contracts.NewRetryableError("failed to initialize virsh provider", err)
 	}
 
+	// Optionally bring up the native control transport for migrated hot paths
+	// (Validate/Describe). Opt-in via LIBVIRT_CONTROL_TRANSPORT=native. Fail
+	// closed if requested but unavailable — no silent downgrade (preserves the
+	// ADR-0004 trust contract; see docs/adr/0007-libvirt-native-control-transport.md
+	// and docs/adr/0008-libvirt-go-binding-and-transport-selection.md).
+	if nativeTransportEnabled() {
+		nt, err := buildNativeTransport(virshProvider)
+		if err != nil {
+			return nil, contracts.NewRetryableError("native control transport requested but failed to initialize", err)
+		}
+		p.nativeTransport = nt
+		log.Printf("INFO libvirt control transport: native (libvirt-go SDK)")
+	} else {
+		log.Printf("INFO libvirt control transport: virsh")
+	}
+
 	log.Printf("INFO Successfully created virsh-based provider via K8s API")
 	return p, nil
 }
 
 // Validate ensures the provider connection is healthy using virsh
 func (p *Provider) Validate(ctx context.Context) error {
+	if p.nativeTransport != nil {
+		return p.nativeTransport.Validate(ctx)
+	}
 	if p.virshProvider == nil {
 		return contracts.NewRetryableError("virsh provider not initialized", nil)
 	}

--- a/internal/providers/libvirt/provider_virsh.go
+++ b/internal/providers/libvirt/provider_virsh.go
@@ -763,6 +763,10 @@ func (p *Provider) extractMemoryKB(domainInfo map[string]string) (int64, error) 
 
 // Describe returns comprehensive VM information using virsh (enhanced monitoring like vSphere)
 func (p *Provider) Describe(ctx context.Context, id string) (contracts.DescribeResponse, error) {
+	if p.nativeTransport != nil {
+		return p.nativeTransport.Describe(ctx, id)
+	}
+
 	log.Printf("INFO Describing VM with comprehensive monitoring: %s", id)
 
 	if p.virshProvider == nil {

--- a/internal/providers/libvirt/transport.go
+++ b/internal/providers/libvirt/transport.go
@@ -1,0 +1,77 @@
+package libvirt
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+)
+
+// controlTransport is the libvirt control-plane surface that can be served
+// either by the legacy virsh-over-ssh path or the native libvirt-go SDK. Only
+// the methods migrated so far are listed; the rest stay on virsh until moved.
+type controlTransport interface {
+	Validate(ctx context.Context) error
+	Describe(ctx context.Context, id string) (contracts.DescribeResponse, error)
+	Close()
+}
+
+// nativeDialer is registered (only) by the build-tagged native implementation's
+// init(). It stays nil in a build without `-tags libvirt_native`, so requesting
+// the native transport in such a binary is an explicit, loud error rather than
+// a silent no-op.
+var nativeDialer func(uri string, hostKey hostKeyPolicy) (controlTransport, error)
+
+// nativeTransportEnabled reports whether the operator selected the native
+// control transport via LIBVIRT_CONTROL_TRANSPORT=native (default: virsh).
+func nativeTransportEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("LIBVIRT_CONTROL_TRANSPORT")), "native")
+}
+
+// buildNativeTransport dials the native transport reusing the already-built
+// virsh connection URI and the one shared host-key policy. It converts the
+// qemu+ssh URI to qemu+libssh2 so host-key verification is enforced in-process
+// via URI params (known_hosts / known_hosts_verify) rather than depending on
+// the system ssh client picking up the provider's ~/.ssh/config — which is
+// environment-fragile (modern OpenSSH resolves the config from the passwd home,
+// not $HOME). This keeps ADR-0004 trust semantics: same known_hosts file, same
+// hard-fail gate (already run by dialNative), same single insecure opt-out.
+func buildNativeTransport(v *VirshProvider) (controlTransport, error) {
+	if nativeDialer == nil {
+		return nil, fmt.Errorf("LIBVIRT_CONTROL_TRANSPORT=native requested but this binary was not built with -tags libvirt_native")
+	}
+	nativeURI, err := toLibssh2URI(v.uri)
+	if err != nil {
+		return nil, err
+	}
+	return nativeDialer(nativeURI, v.hostKey)
+}
+
+// toLibssh2URI rewrites an ssh-based libvirt URI to qemu+libssh2 with the
+// host-key policy carried in URI params. The verifying path points libssh2 at
+// the credentials-mounted known_hosts with known_hosts_verify=normal; the
+// explicit insecure opt-out maps to known_hosts_verify=ignore. Auth params
+// already on the URI (keyfile/sshauth/no_tty) are preserved.
+func toLibssh2URI(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse libvirt URI %q: %w", raw, err)
+	}
+	if !strings.Contains(u.Scheme, "ssh") {
+		return "", fmt.Errorf("native transport needs an ssh-based endpoint, got scheme %q", u.Scheme)
+	}
+	u.Scheme = "qemu+libssh2"
+	q := u.Query()
+	q.Set("known_hosts", KnownHostsFile)
+	if resolveHostKeyPolicy().insecure {
+		q.Set("known_hosts_verify", "ignore")
+	} else {
+		q.Set("known_hosts_verify", "normal")
+	}
+	q.Del("no_verify") // libssh2 uses known_hosts_verify, not the ssh transport's no_verify
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/internal/providers/libvirt/transport_native.go
+++ b/internal/providers/libvirt/transport_native.go
@@ -1,0 +1,577 @@
+//go:build libvirt_native
+
+// Native libvirt control-plane transport — initial slice.
+//
+// First cut of the native connection the migration sketch targets
+// (docs/libvirt-go-sdk-migration-sketch.md). It deliberately reuses the
+// EXISTING host-key trust model rather than inventing a new one: the
+// qemu+ssh:// URI built by setupConnection, the ~/.ssh/config written by
+// createSSHConfig (StrictHostKeyChecking + UserKnownHostsFile=known_hosts),
+// and the verifyKnownHostsPresent hard-fail gate. The official binding's
+// qemu+ssh transport reads that same ssh config + known_hosts, so the ADR-0004
+// trust semantics carry over with zero new mechanism.
+//
+// Build-tagged: importing libvirt.org/go/libvirt turns the whole package into a
+// CGO build that needs libvirt-dev headers. Until the transport is wired into
+// Provider, keep it opt-in with `-tags libvirt_native` so the default
+// `go build`/`go test` on machines without libvirt headers is unaffected.
+package libvirt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/projectbeskar/virtrigaud/internal/providers/contracts"
+	libvirtgo "libvirt.org/go/libvirt"
+)
+
+// init registers the native dialer so buildNativeTransport (in the non-tagged
+// shim) can construct it. *nativeConn satisfies controlTransport.
+func init() {
+	nativeDialer = func(uri string, hostKey hostKeyPolicy) (controlTransport, error) {
+		return dialNative(uri, hostKey)
+	}
+}
+
+// guestAgentTimeoutSecs bounds every guest-agent round-trip. An absent agent
+// errors fast; a hung one is capped here so the rich path can never block a
+// caller for long (the CGO call does not honor ctx, so this is the real cap).
+const guestAgentTimeoutSecs = 3
+
+// Connection lifecycle (ADR-0007 §5): unlike the stateless virsh path (a fresh
+// subprocess per call, self-healing for free), the native transport is
+// stateful. Keepalive makes a dead peer close the socket — which flips IsAlive
+// for the next caller AND unblocks any CGO call stuck on the dead connection
+// (the closest substitute for ctx cancellation, which blocking CGO calls
+// cannot honor) — and conn() then redials with a rate limit.
+const (
+	keepAliveIntervalSecs = 5                // probe cadence on an idle connection
+	keepAliveCount        = 3                // unanswered probes before declared dead
+	redialBackoff         = 10 * time.Second // min gap between dial attempts
+)
+
+// nativeConn is a persistent native libvirt control-plane connection. One
+// long-lived connection replaces the per-call `virsh ... over ssh` fork that
+// the Validate-storm and Describe-timeout investigations identified as the
+// transport tax. Access the connection only through conn(), which owns
+// liveness checking and redial.
+type nativeConn struct {
+	uri     string // remembered for redial and deriving the console host
+	host    string // authority part, for the host-key pre-flight
+	hostKey hostKeyPolicy
+
+	mu       sync.Mutex
+	c        *libvirtgo.Connect
+	lastDial time.Time
+}
+
+// dialNative is THE single secured entry point for the native transport — the
+// chokepoint where the trust contract is enforced (initial dial and every
+// redial go through dialLocked).
+//
+// Precondition: setupConnection has run on the owning VirshProvider, so
+// ~/.ssh/config and the private key are on disk and `uri` already carries
+// no_tty/keyfile/no_verify.
+func dialNative(uri string, hostKey hostKeyPolicy) (*nativeConn, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("parse libvirt URI %q: %w", uri, err)
+	}
+	n := &nativeConn{uri: uri, host: u.Host, hostKey: hostKey}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if err := n.dialLocked(); err != nil {
+		return nil, err
+	}
+	return n, nil
+}
+
+// eventLoopOnce starts libvirt's default event loop once per process. The C
+// keepalive machinery is serviced by this loop — without it SetKeepAlive is
+// inert, so a failure here downgrades dead-peer detection, loudly.
+var eventLoopOnce sync.Once
+
+func startEventLoop() {
+	eventLoopOnce.Do(func() {
+		if err := libvirtgo.EventRegisterDefaultImpl(); err != nil {
+			log.Printf("WARN native libvirt: event loop unavailable, keepalive dead-peer detection disabled: %v", err)
+			return
+		}
+		go func() {
+			for {
+				if err := libvirtgo.EventRunDefaultImpl(); err != nil {
+					log.Printf("WARN native libvirt: event loop iteration failed: %v", err)
+					time.Sleep(time.Second)
+				}
+			}
+		}()
+	})
+}
+
+// dialLocked (re)opens the connection; the caller holds n.mu. It re-runs the
+// host-key hard-fail gate on EVERY dial — initial and redial — so the native
+// path independently fails closed if ever dialed without trust material
+// (ADR-0004: no TOFU, no silent downgrade), then arms keepalive.
+func (n *nativeConn) dialLocked() error {
+	if err := n.hostKey.verifyKnownHostsPresent(n.host); err != nil {
+		return fmt.Errorf("native libvirt host-key pre-flight failed: %w", err)
+	}
+	startEventLoop()
+	n.lastDial = time.Now()
+	c, err := libvirtgo.NewConnect(n.uri)
+	if err != nil {
+		return fmt.Errorf("native libvirt connect to %q failed: %w", n.uri, err)
+	}
+	if err := c.SetKeepAlive(keepAliveIntervalSecs, keepAliveCount); err != nil {
+		log.Printf("WARN native libvirt: SetKeepAlive failed, dead-peer detection degraded: %v", err)
+	}
+	n.c = c
+	return nil
+}
+
+// conn returns a live connection, redialing (rate-limited) if the current one
+// died. IsAlive is a local socket-state check, not an RPC round-trip, so
+// gating every call on it is cheap. This is what keeps the stateful native
+// transport as self-healing as the stateless virsh path it replaces: a
+// libvirtd restart or a dropped SSH session costs one redial, not a provider
+// pod restart.
+func (n *nativeConn) conn() (*libvirtgo.Connect, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.c != nil {
+		if alive, err := n.c.IsAlive(); err == nil && alive {
+			return n.c, nil
+		}
+		_, _ = n.c.Close()
+		n.c = nil
+		log.Printf("WARN native libvirt: connection to %q lost, redialing", n.host)
+	}
+	if since := time.Since(n.lastDial); since < redialBackoff {
+		return nil, fmt.Errorf("native libvirt connection to %q is down, redial backoff active (%s left)", n.host, (redialBackoff - since).Round(time.Second))
+	}
+	if err := n.dialLocked(); err != nil {
+		return nil, err
+	}
+	return n.c, nil
+}
+
+// Validate is the cheap liveness probe that replaces `virsh list --all --name`:
+// no domain enumeration, no subprocess, no ssh fork. conn() already embeds the
+// IsAlive check (and heals a dead connection), so a nil error IS liveness.
+// This is the Phase-1 win: many concurrent reconciles stop translating into a
+// fork storm.
+//
+// ponytail: ctx is accepted for a uniform transport signature but not threaded
+// — the CGO call is blocking; keepalive-driven socket close is the real bound
+// on a hung peer (see the lifecycle constants above).
+func (n *nativeConn) Validate(ctx context.Context) error {
+	if _, err := n.conn(); err != nil {
+		return fmt.Errorf("native libvirt liveness check failed: %w", err)
+	}
+	return nil
+}
+
+// DescribeBasic is the cheapest existence+power probe: two typed calls, no IP
+// discovery, no XML. Kept for callers/tests that only need liveness of a single
+// domain. Describe builds on the same lookup for the full controller response.
+func (n *nativeConn) DescribeBasic(ctx context.Context, name string) (exists bool, state string, err error) {
+	c, err := n.conn()
+	if err != nil {
+		return false, "", err
+	}
+	dom, err := c.LookupDomainByName(name)
+	if err != nil {
+		if isNoDomain(err) {
+			return false, "", nil
+		}
+		return false, "", fmt.Errorf("lookup domain %q: %w", name, err)
+	}
+	defer func() { _ = dom.Free() }()
+
+	st, _, err := dom.GetState()
+	if err != nil {
+		return true, "", fmt.Errorf("get state for %q: %w", name, err)
+	}
+	return true, domainStateString(st), nil
+}
+
+// Describe is the reconcile-safe path: it fills the full
+// contracts.DescribeResponse (existence, power state, best-effort IPs, console
+// URL, minimal provider-raw) using only cheap typed calls and deliberately
+// OMITS the heavy monitoring/guest-agent sweep. This is what the VM controller
+// calls on every reconcile.
+func (n *nativeConn) Describe(ctx context.Context, id string) (contracts.DescribeResponse, error) {
+	c, err := n.conn()
+	if err != nil {
+		// A transport failure must surface as an error, never as Exists:false.
+		return contracts.DescribeResponse{}, err
+	}
+	dom, err := c.LookupDomainByName(id)
+	if err != nil {
+		if isNoDomain(err) {
+			return contracts.DescribeResponse{Exists: false}, nil
+		}
+		return contracts.DescribeResponse{}, fmt.Errorf("lookup domain %q: %w", id, err)
+	}
+	defer func() { _ = dom.Free() }()
+	return n.describeCore(dom, id)
+}
+
+// DescribeRich returns the same response as Describe plus observability data in
+// ProviderRaw: host-side stats (memory/CPU/block) which are always cheap and
+// agent-free, and best-effort guest-agent enrichment (OS/hostname) which is
+// bounded by guestAgentTimeoutSecs and skipped entirely if the agent is absent.
+// It is NOT for the reconcile hot path — call it from a lower-frequency
+// monitoring path so a slow/missing guest agent can never stall reconcile.
+func (n *nativeConn) DescribeRich(ctx context.Context, id string) (contracts.DescribeResponse, error) {
+	c, err := n.conn()
+	if err != nil {
+		return contracts.DescribeResponse{}, err
+	}
+	dom, err := c.LookupDomainByName(id)
+	if err != nil {
+		if isNoDomain(err) {
+			return contracts.DescribeResponse{Exists: false}, nil
+		}
+		return contracts.DescribeResponse{}, fmt.Errorf("lookup domain %q: %w", id, err)
+	}
+	defer func() { _ = dom.Free() }()
+
+	resp, err := n.describeCore(dom, id)
+	if err != nil || !resp.Exists {
+		return resp, err
+	}
+
+	// Host-side: no guest agent, no fork — safe to collect inline.
+	enrichMemoryStats(dom, resp.ProviderRaw)
+	enrichCPUStats(dom, resp.ProviderRaw)
+	enrichBlockStats(dom, resp.ProviderRaw)
+
+	// Guest-side: only when running, best-effort and time-bounded.
+	if resp.PowerState == "On" {
+		enrichGuestAgent(dom, resp.ProviderRaw)
+	}
+	return resp, nil
+}
+
+// describeCore fills the five contract fields from cheap typed calls. Shared by
+// Describe and DescribeRich so the core is identical regardless of monitoring.
+func (n *nativeConn) describeCore(dom *libvirtgo.Domain, id string) (contracts.DescribeResponse, error) {
+	state, _, err := dom.GetState()
+	if err != nil {
+		return contracts.DescribeResponse{}, fmt.Errorf("get state for %q: %w", id, err)
+	}
+	power := powerStateOnOff(state)
+
+	raw := map[string]string{
+		"name":               id,
+		"state":              domainStateString(state),
+		"power_state_mapped": power,
+	}
+	if uuid, err := dom.GetUUIDString(); err == nil {
+		raw["uuid"] = uuid
+	}
+	if info, err := dom.GetInfo(); err == nil {
+		raw["vcpus"] = strconv.Itoa(int(info.NrVirtCpu))
+		raw["memory_kib"] = strconv.FormatUint(info.Memory, 10)
+		raw["max_memory_kib"] = strconv.FormatUint(info.MaxMem, 10)
+	}
+
+	ips := n.describeIPs(dom, state)
+	if len(ips) > 0 {
+		raw["primary_ip"] = ips[0]
+	}
+
+	consoleURL := ""
+	if state == libvirtgo.DOMAIN_RUNNING {
+		consoleURL = consoleURLFromXML(dom, n.consoleHost())
+	}
+
+	return contracts.DescribeResponse{
+		Exists:      true,
+		PowerState:  power,
+		IPs:         ips,
+		ConsoleURL:  consoleURL,
+		ProviderRaw: raw,
+	}, nil
+}
+
+// describeIPs collects best-effort IPv4/IPv6 addresses for a running domain.
+// It tries the dnsmasq lease DB first (no guest agent needed), then the guest
+// agent, deduping and dropping loopback/link-local. Every source is
+// best-effort: a missing lease DB or absent guest agent is not an error, it
+// just yields fewer IPs — the reconcile path must not fail because IP discovery
+// is incomplete.
+func (n *nativeConn) describeIPs(dom *libvirtgo.Domain, state libvirtgo.DomainState) []string {
+	if state != libvirtgo.DOMAIN_RUNNING {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, src := range []libvirtgo.DomainInterfaceAddressesSource{
+		libvirtgo.DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE,
+		libvirtgo.DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT,
+	} {
+		ifaces, err := dom.ListAllInterfaceAddresses(src)
+		if err != nil {
+			continue
+		}
+		for _, iface := range ifaces {
+			for _, a := range iface.Addrs {
+				ip := strings.TrimSpace(a.Addr)
+				if ip == "" || ip == "::1" || strings.HasPrefix(ip, "127.") || strings.HasPrefix(ip, "fe80:") || seen[ip] {
+					continue // drop empty, loopback, and link-local noise
+				}
+				seen[ip] = true
+				out = append(out, ip)
+			}
+		}
+	}
+	return out
+}
+
+// consoleHost derives the hypervisor host for a VNC URL from the connection URI.
+func (n *nativeConn) consoleHost() string {
+	if u, err := url.Parse(n.uri); err == nil && u.Hostname() != "" {
+		return u.Hostname()
+	}
+	return "localhost"
+}
+
+// Close releases the native connection. Safe to call on a nil-wrapped conn.
+func (n *nativeConn) Close() {
+	if n == nil {
+		return
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.c != nil {
+		_, _ = n.c.Close()
+		n.c = nil
+	}
+}
+
+// --- enrichment (DescribeRich only) ---------------------------------------
+
+// enrichMemoryStats adds balloon/guest memory stats. Host-side, no guest agent.
+func enrichMemoryStats(dom *libvirtgo.Domain, raw map[string]string) {
+	stats, err := dom.MemoryStats(uint32(libvirtgo.DOMAIN_MEMORY_STAT_NR), 0)
+	if err != nil {
+		return
+	}
+	for _, s := range stats {
+		if name := memStatName(s.Tag); name != "" {
+			raw["mem_"+name+"_kib"] = strconv.FormatUint(s.Val, 10)
+		}
+	}
+}
+
+// enrichCPUStats adds cumulative CPU time. Host-side, no guest agent.
+func enrichCPUStats(dom *libvirtgo.Domain, raw map[string]string) {
+	if info, err := dom.GetInfo(); err == nil {
+		raw["cpu_time_ns"] = strconv.FormatUint(info.CpuTime, 10)
+	}
+}
+
+// enrichBlockStats adds per-disk I/O counters. Host-side (qemu view), no agent.
+func enrichBlockStats(dom *libvirtgo.Domain, raw map[string]string) {
+	xml, err := dom.GetXMLDesc(0)
+	if err != nil {
+		return
+	}
+	for _, dev := range diskTargets(xml) {
+		bs, err := dom.BlockStats(dev)
+		if err != nil {
+			continue
+		}
+		if bs.RdBytesSet {
+			raw["blk_"+dev+"_rd_bytes"] = strconv.FormatInt(bs.RdBytes, 10)
+		}
+		if bs.WrBytesSet {
+			raw["blk_"+dev+"_wr_bytes"] = strconv.FormatInt(bs.WrBytes, 10)
+		}
+		if bs.RdReqSet {
+			raw["blk_"+dev+"_rd_req"] = strconv.FormatInt(bs.RdReq, 10)
+		}
+		if bs.WrReqSet {
+			raw["blk_"+dev+"_wr_req"] = strconv.FormatInt(bs.WrReq, 10)
+		}
+	}
+}
+
+// enrichGuestAgent adds in-guest data (OS, hostname) via the QEMU guest agent.
+// Best-effort and time-bounded: it pings first and, if the agent is absent or
+// unresponsive within guestAgentTimeoutSecs, records that and returns without
+// touching the rest — never an error, never a long block. Uses raw agent
+// commands (not virDomainGetGuestInfo) so it also works against old libvirtd
+// that lacks the higher-level guestinfo procedure.
+func enrichGuestAgent(dom *libvirtgo.Domain, raw map[string]string) {
+	const timeout = libvirtgo.DomainQemuAgentCommandTimeout(guestAgentTimeoutSecs)
+
+	if _, err := dom.QemuAgentCommand(`{"execute":"guest-ping"}`, timeout, 0); err != nil {
+		raw["guest_agent"] = "unavailable"
+		return
+	}
+	raw["guest_agent"] = "available"
+
+	if out, err := dom.QemuAgentCommand(`{"execute":"guest-get-osinfo"}`, timeout, 0); err == nil {
+		var r struct {
+			Return struct {
+				Name          string `json:"name"`
+				Version       string `json:"version"`
+				PrettyName    string `json:"pretty-name"`
+				KernelRelease string `json:"kernel-release"`
+				ID            string `json:"id"`
+			} `json:"return"`
+		}
+		if json.Unmarshal([]byte(out), &r) == nil {
+			setIf(raw, "guest_os", r.Return.Name)
+			setIf(raw, "guest_os_version", r.Return.Version)
+			setIf(raw, "guest_os_pretty", r.Return.PrettyName)
+			setIf(raw, "guest_kernel", r.Return.KernelRelease)
+		}
+	}
+
+	if out, err := dom.QemuAgentCommand(`{"execute":"guest-get-host-name"}`, timeout, 0); err == nil {
+		var r struct {
+			Return struct {
+				HostName string `json:"host-name"`
+			} `json:"return"`
+		}
+		if json.Unmarshal([]byte(out), &r) == nil {
+			setIf(raw, "guest_hostname", r.Return.HostName)
+		}
+	}
+}
+
+func setIf(raw map[string]string, k, v string) {
+	if v != "" {
+		raw[k] = v
+	}
+}
+
+// isNoDomain reports whether err is libvirt's "domain not found".
+func isNoDomain(err error) bool {
+	lverr, ok := err.(libvirtgo.Error)
+	return ok && lverr.Code == libvirtgo.ERR_NO_DOMAIN
+}
+
+// powerStateOnOff maps libvirt domain state to the contract's On/Off, matching
+// the existing virsh mapLibvirtPowerState (running -> On, everything else -> Off).
+func powerStateOnOff(s libvirtgo.DomainState) string {
+	if s == libvirtgo.DOMAIN_RUNNING {
+		return "On"
+	}
+	return "Off"
+}
+
+// memStatName maps the libvirt memory-stat tag to a short field name; "" for
+// tags we don't surface.
+func memStatName(tag int32) string {
+	switch libvirtgo.DomainMemoryStatTags(tag) {
+	case libvirtgo.DOMAIN_MEMORY_STAT_RSS:
+		return "rss"
+	case libvirtgo.DOMAIN_MEMORY_STAT_AVAILABLE:
+		return "available"
+	case libvirtgo.DOMAIN_MEMORY_STAT_UNUSED:
+		return "unused"
+	case libvirtgo.DOMAIN_MEMORY_STAT_USABLE:
+		return "usable"
+	case libvirtgo.DOMAIN_MEMORY_STAT_ACTUAL_BALLOON:
+		return "actual_balloon"
+	default:
+		return ""
+	}
+}
+
+// diskTargets extracts disk target dev names (vd*/sd*/hd*/xvd*) from domain XML,
+// skipping NIC and other <target> elements so BlockStats is only called on disks.
+func diskTargets(xml string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, line := range strings.Split(xml, "\n") {
+		if !strings.Contains(line, "<target ") {
+			continue
+		}
+		dev := xmlAttr(line, "dev")
+		if dev == "" || seen[dev] {
+			continue
+		}
+		if strings.HasPrefix(dev, "vd") || strings.HasPrefix(dev, "sd") ||
+			strings.HasPrefix(dev, "hd") || strings.HasPrefix(dev, "xvd") {
+			seen[dev] = true
+			out = append(out, dev)
+		}
+	}
+	return out
+}
+
+// consoleURLFromXML scans the domain XML for a graphics device (VNC or SPICE)
+// and returns a console URL like vnc://host:5901 or spice://host:5915, or ""
+// when there is no usable graphics port (autoport unresolved -> port='-1', or a
+// headless/serial-only guest). String-scan to avoid a full XML schema dep.
+func consoleURLFromXML(dom *libvirtgo.Domain, host string) string {
+	xml, err := dom.GetXMLDesc(0)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(xml, "\n") {
+		if !strings.Contains(line, "<graphics") {
+			continue
+		}
+		typ := xmlAttr(line, "type")
+		port := xmlAttr(line, "port")
+		if port == "" || port == "-1" {
+			continue
+		}
+		switch typ {
+		case "vnc", "spice":
+			return fmt.Sprintf("%s://%s:%s", typ, host, port)
+		}
+	}
+	return ""
+}
+
+// xmlAttr pulls the value of a single-quoted XML attribute (key='value') out of
+// one line; "" if absent.
+func xmlAttr(line, key string) string {
+	i := strings.Index(line, key+"='")
+	if i == -1 {
+		return ""
+	}
+	rest := line[i+len(key)+2:]
+	if j := strings.Index(rest, "'"); j != -1 {
+		return rest[:j]
+	}
+	return ""
+}
+
+// domainStateString maps the typed libvirt domain state to the lowercase
+// strings the rest of the provider already speaks (matching virsh `domstate`).
+func domainStateString(s libvirtgo.DomainState) string {
+	switch s {
+	case libvirtgo.DOMAIN_RUNNING:
+		return "running"
+	case libvirtgo.DOMAIN_BLOCKED:
+		return "blocked"
+	case libvirtgo.DOMAIN_PAUSED:
+		return "paused"
+	case libvirtgo.DOMAIN_SHUTDOWN:
+		return "shutdown"
+	case libvirtgo.DOMAIN_SHUTOFF:
+		return "shutoff"
+	case libvirtgo.DOMAIN_CRASHED:
+		return "crashed"
+	case libvirtgo.DOMAIN_PMSUSPENDED:
+		return "pmsuspended"
+	default:
+		return "nostate"
+	}
+}

--- a/internal/providers/libvirt/transport_native_test.go
+++ b/internal/providers/libvirt/transport_native_test.go
@@ -1,0 +1,203 @@
+//go:build libvirt_native
+
+package libvirt
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+)
+
+// These are opt-in LIVE integration tests for the native transport. They skip
+// unless the relevant env vars are set, and run with `-tags libvirt_native`
+// (which pulls in the CGO libvirt binding). Example:
+//
+//	LIBVIRT_NATIVE_URI='qemu+ssh://root@192.168.254.12/system?no_tty=1' \
+//	  go test -tags libvirt_native -run TestNative -v ./internal/providers/libvirt/
+
+// TestNativeSmoke drives the happy path against a live host: connect, probe
+// liveness, list domains, and run the cheap DescribeBasic against one real
+// domain plus a missing one. Read-only, no mutation.
+func TestNativeSmoke(t *testing.T) {
+	uri := os.Getenv("LIBVIRT_NATIVE_URI")
+	if uri == "" {
+		t.Skip("set LIBVIRT_NATIVE_URI to run the live native smoke test")
+	}
+
+	conn, err := dialNative(uri, resolveHostKeyPolicy())
+	if err != nil {
+		t.Fatalf("dialNative: %v", err)
+	}
+	defer conn.Close()
+
+	ctx := context.Background()
+
+	// 1. Cheap liveness probe (the Validate-storm fix): no fork, no ssh per call.
+	if err := conn.Validate(ctx); err != nil {
+		t.Fatalf("Validate (IsAlive): %v", err)
+	}
+	t.Log("Validate OK — connection alive")
+
+	// 2. Enumerate real domains via the persistent connection.
+	doms, err := conn.c.ListAllDomains(0)
+	if err != nil {
+		t.Fatalf("ListAllDomains: %v", err)
+	}
+	t.Logf("ListAllDomains OK — %d domains", len(doms))
+	if len(doms) == 0 {
+		return
+	}
+	name, err := doms[0].GetName()
+	for i := range doms {
+		_ = doms[i].Free()
+	}
+	if err != nil {
+		t.Fatalf("GetName: %v", err)
+	}
+
+	// 3. Cheap existence+power probe on a real domain.
+	exists, state, err := conn.DescribeBasic(ctx, name)
+	if err != nil {
+		t.Fatalf("DescribeBasic(%q): %v", name, err)
+	}
+	t.Logf("DescribeBasic(%q) OK — exists=%v state=%s", name, exists, state)
+
+	// 3b. Full controller-facing Describe (all DescribeResponse fields).
+	resp, err := conn.Describe(ctx, name)
+	if err != nil {
+		t.Fatalf("Describe(%q): %v", name, err)
+	}
+	if !resp.Exists {
+		t.Fatalf("Describe(%q) reported Exists=false for a listed domain", name)
+	}
+	t.Logf("Describe(%q) OK — power=%s ips=%v console=%q raw[vcpus]=%s",
+		name, resp.PowerState, resp.IPs, resp.ConsoleURL, resp.ProviderRaw["vcpus"])
+
+	// 3c. Rich Describe: host-side stats always, guest-agent best-effort.
+	rich, err := conn.DescribeRich(ctx, name)
+	if err != nil {
+		t.Fatalf("DescribeRich(%q): %v", name, err)
+	}
+	t.Logf("DescribeRich(%q) OK — %d raw keys; agent=%s os=%q rss=%s blk=%s",
+		name, len(rich.ProviderRaw), rich.ProviderRaw["guest_agent"],
+		rich.ProviderRaw["guest_os"], rich.ProviderRaw["mem_rss_kib"],
+		rich.ProviderRaw["blk_vda_rd_bytes"])
+
+	// 4. Negative path: a name that cannot exist must come back exists=false,
+	//    nil error (ERR_NO_DOMAIN swallowed), not a transport error.
+	exists, _, err = conn.DescribeBasic(ctx, "virtrigaud-nonexistent-"+name)
+	if err != nil {
+		t.Fatalf("DescribeBasic(missing) should not error: %v", err)
+	}
+	if exists {
+		t.Fatalf("DescribeBasic(missing) reported exists=true")
+	}
+	t.Log("DescribeBasic(missing) OK — exists=false, no error")
+}
+
+// TestNativeTrustStrict proves, against a live host, that the native transport
+// preserves the ADR-0004 trust contract — fail closed, no TOFU, one opt-out:
+//
+//  1. missing/empty known_hosts (verifying) -> pre-flight gate HARD-FAILS, no connect
+//  2. WRONG host key                         -> connection REJECTED, file NOT rewritten
+//     (no accept-new / no TOFU write-back)
+//  3. explicit insecure escape hatch         -> the ONE opt-out lets it connect
+//
+// The wrong-key case drives qemu+libssh2:// (in-process, known_hosts enforced via
+// URI params) rather than qemu+ssh://. Why: on OpenSSH 10.3 the ssh CLI resolves
+// ~/.ssh/config from the passwd home and ignores $HOME, so a test cannot reliably
+// force the provider's StrictHostKeyChecking config onto libvirt's ssh transport.
+// libssh2 verification is config-independent and deterministic — host-key checking
+// happens during KEX, before user auth, so it is unaffected by which key authn
+// uses. (qemu+ssh enforcement itself is sound; verified out-of-band:
+// `ssh -F <provider config>` with a wrong key returns "Host key verification failed".)
+//
+// Requires (set by the run wrapper):
+//
+//	LIBVIRT_NATIVE_URI   qemu+ssh://root@HOST/system?no_tty=1
+//	LIBVIRT_KH_WRONG     a valid-format but WRONG host-key line for HOST
+func TestNativeTrustStrict(t *testing.T) {
+	uri := os.Getenv("LIBVIRT_NATIVE_URI")
+	wrongKH := os.Getenv("LIBVIRT_KH_WRONG")
+	if uri == "" || wrongKH == "" {
+		t.Skip("set LIBVIRT_NATIVE_URI + LIBVIRT_KH_WRONG to run the strict trust test")
+	}
+	ctx := context.Background()
+
+	writeKH := func(t *testing.T, content string) {
+		t.Helper()
+		if err := os.WriteFile(KnownHostsFile, []byte(content), 0600); err != nil {
+			t.Fatalf("write known_hosts (need write access to %s): %v", KnownHostsFile, err)
+		}
+	}
+
+	t.Run("missing trust material hard-fails (no TOFU)", func(t *testing.T) {
+		writeKH(t, "")
+		_, err := dialNative(uri, resolveHostKeyPolicy())
+		if err == nil {
+			t.Fatal("expected hard-fail with empty known_hosts, got nil (silent accept!)")
+		}
+		if !strings.Contains(err.Error(), "known_hosts") {
+			t.Fatalf("error should name known_hosts, got: %v", err)
+		}
+		t.Logf("OK: empty known_hosts -> hard fail: %v", err)
+	})
+
+	t.Run("wrong host key rejected, no accept-new write-back", func(t *testing.T) {
+		writeKH(t, wrongKH+"\n")
+		_, err := dialNative(libssh2URI(t, uri), resolveHostKeyPolicy())
+		if err == nil {
+			t.Fatal("expected host-key rejection with wrong key, got nil (accepted unknown host!)")
+		}
+		if !strings.Contains(err.Error(), "HOST KEY VERIFICATION FAILED") {
+			t.Fatalf("expected an explicit host-key rejection, got: %v", err)
+		}
+		// no-TOFU proof: a failed verify must NOT have written the real key back.
+		after, readErr := os.ReadFile(KnownHostsFile)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if strings.TrimSpace(string(after)) != strings.TrimSpace(wrongKH) {
+			t.Fatalf("known_hosts mutated after a failed connect (accept-new/TOFU leak):\n%s", after)
+		}
+		t.Logf("OK: wrong host key -> rejected, file unchanged (no TOFU)")
+	})
+
+	t.Run("explicit insecure escape hatch connects", func(t *testing.T) {
+		t.Setenv(EnvInsecureSkipHostKeyVerification, "true")
+		writeKH(t, "") // no trust material at all
+		insecureURI := uri
+		if strings.Contains(insecureURI, "?") {
+			insecureURI += "&no_verify=1"
+		} else {
+			insecureURI += "?no_verify=1"
+		}
+		conn, err := dialNative(insecureURI, resolveHostKeyPolicy())
+		if err != nil {
+			t.Fatalf("insecure opt-out should connect with no known_hosts, got: %v", err)
+		}
+		defer conn.Close()
+		if err := conn.Validate(ctx); err != nil {
+			t.Fatalf("Validate (insecure): %v", err)
+		}
+		t.Log("OK: explicit insecure opt-out -> connected (the single, audit-flagged bypass)")
+	})
+}
+
+// libssh2URI rewrites a qemu+ssh:// URI to qemu+libssh2:// with the host-key
+// policy carried in URI params (config-independent enforcement).
+func libssh2URI(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u.Scheme = "qemu+libssh2"
+	q := u.Query()
+	q.Set("known_hosts", KnownHostsFile)
+	q.Set("known_hosts_verify", "normal")
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/internal/providers/libvirt/virsh.go
+++ b/internal/providers/libvirt/virsh.go
@@ -139,9 +139,17 @@ func (v *VirshProvider) Initialize(ctx context.Context) error {
 		return fmt.Errorf("failed to setup connection: %w", err)
 	}
 
-	// Test the connection
+	// Test the connection. When the native control transport is selected, the
+	// virsh-over-ssh probe must NOT gate startup: native owns the control-plane
+	// liveness check (over libssh2, independent of the system ssh client's
+	// config discovery), and virsh remains only for lazily-used data-plane work,
+	// which will surface its own errors if/when invoked.
 	if err := v.testConnection(ctx); err != nil {
-		return fmt.Errorf("failed to connect to libvirt: %w", err)
+		if nativeTransportEnabled() {
+			log.Printf("WARN virsh connectivity probe failed but LIBVIRT_CONTROL_TRANSPORT=native is set; continuing (native handles control plane, virsh data-plane surfaces errors lazily): %v", err)
+		} else {
+			return fmt.Errorf("failed to connect to libvirt: %w", err)
+		}
 	}
 
 	log.Printf("INFO Successfully initialized virsh provider with endpoint: %s", v.uri)


### PR DESCRIPTION
## Summary

Closes the libvirt `Describe` storm (#290) by moving the control plane off `virsh`-CLI-over-SSH
onto a **native libvirt SDK** transport, with `Describe` as the first feature on the SDK.

**Why a native SDK, directly.** The libvirt provider kept hitting the *same* SSH/subprocess wall
from different angles — `ListVMs` slowness, a post-adoption `Validate` fork storm, and then the
`Describe` 30s-deadline storm (#290). Each was patched tactically (one `dumpxml` per VM, drop the
duplicate validate, an exec semaphore), but the root cause — subprocess-per-call over SSH, plus a
host-key policy that the system `ssh` client cannot reliably receive in a read-only-rootfs pod —
never went away. Rather than keep patching the SSH path, this PR implements the native
libvirt-go-SDK transport and migrates the first hot path onto it.

Two ADRs capture the decision (no implementation status — that's here, in the PR):

- **ADR-0007** — migrate the control plane to a native SDK transport (control plane native, data
  plane stays SSH; the gate; the split `Describe`; phasing).
- **ADR-0008** — *which* binding/transport: the official CGO binding `libvirt.org/go/libvirt` over
  `qemu+libssh2` (host-key on the URI, config-independent — exactly the SSH-delivery problem that
  kept biting us).

## What's implemented (Phases 0–2)

- **Gate + seam**: `LIBVIRT_CONTROL_TRANSPORT=virsh|native` (default `virsh`). `transport.go` is a
  tag-free seam; the native CGO code is isolated behind `//go:build libvirt_native` and registers
  its dialer via `init()`, so the default non-CGO build/test is unaffected. Native-requested-but-
  uninitialisable fails closed (no silent downgrade).
- **`Validate`** → native `Connect.IsAlive`.
- **`Describe`** → cheap reconcile-safe path (existence/power/IPs/console/min raw) + opt-in
  `DescribeRich` (host-side mem/block stats + best-effort, time-bounded guest-agent).

`ListVMs`, `Reconfigure`, `Power`, `Snapshot*` stay on virsh for now (later phases).

## Validated end-to-end on a real fleet

Built the provider image from this branch (`-tags libvirt_native` + `libssh2-1` runtime) and ran
it on a kind manager against a **live host with 45 VMs**:

- Adoption ran the full path and **created all the VM CRs** — 45 `VirtualMachine` objects, with
  power state and real IPs populated by the native `Describe`.
- `Validate` ~30µs each; per-VM `Describe` served natively — **865 Describe RPCs all in
  milliseconds, 0 ≥ 1s, 0 `Failed to describe VM`** (vs. the prior 29–30s deadline storm). The
  `Describe` storm (#290) is gone.
- Strict host-key trust holds via `qemu+libssh2`: wrong key rejected with no accept-new write-back
  (no TOFU), empty `known_hosts` hard-fails, the single insecure opt-out still works.

> Caveat: in that run the still-virsh `ListVMs`/discovery path needed the insecure opt-out, because
> a read-only-rootfs pod cannot deliver host-key config to the system `ssh` client (ADR-0008
> §transport) — itself an argument for moving `ListVMs` to native (Phase 4).

## Branch / merge note

Rebased onto `main`: the three earlier libvirt fixes it was previously stacked on (`ListVMs` single-dumpxml, `<domain type=kvm>` #282, the `Validate` fork-storm cap #289) are now merged, so this branch is a **clean two-commit change** on top of `main` — `docs(adr)` (ADR-0007 + ADR-0008) then `feat(libvirt)` (native transport). Ready for review, no longer a draft.

## Forward-compatibility with #257 (libvirt multi-host cluster)

This is a deliberately minimal starting point, and it does not pre-judge #257. The single-host,
single-connection native client is a compatible building block under **all three** options in the
cluster RFC, and changes **no gRPC contract**, so it forecloses nothing:

- **Options 2 / 3 (host agents, one pod per host):** this *is* the host agent — single host, single
  connection — reused as-is.
- **Option 1 (monolithic / connection pool):** it is the per-host unit you pool (`map[host]→conn` +
  a router on top); the unit is reused, the routing is added above, not a rewrite.

Whatever #257 decides about packaging the cluster layer above it, this connection primitive stays
valid — which is exactly why it's kept single-host and minimal.

## Commits

- `docs(adr)`: ADR-0007 (migration) + ADR-0008 (binding/transport selection)
- `feat(libvirt)`: native transport + gate + routing, live smoke/trust tests, image build with
  `-tags libvirt_native` + `libssh2-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

